### PR TITLE
feat(cognito-auth-middleware): Cognito JWT auth middleware [P01-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Feature queue for all 12 phases
 - [P01-01] FastAPI project scaffold with health endpoint, Docker setup, and dev tooling
 - [P01-02] SQLAlchemy async models for all 7 domain tables with Alembic migration
+- [P01-03] AWS Cognito JWT authentication middleware with JWKS caching
 
 ---
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,0 +1,245 @@
+"""AWS Cognito JWT authentication — JWKS fetching, caching, and token verification.
+
+Provides CognitoJWKSProvider for fetching and caching Cognito JWKS keys with
+a 10-minute TTL, and verify_cognito_token for RS256 JWT validation including
+signature, expiry, audience, issuer, and token_use claims.
+
+The module-level singleton _jwks_provider shares the JWKS cache across all
+requests in the same process.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+
+import httpx
+from fastapi import HTTPException, status
+from jose import JWTError, jwt
+
+from app.config import settings
+
+logger = logging.getLogger("ember")
+
+
+class CognitoJWKSProvider:
+    """Fetches and caches JWKS keys from the AWS Cognito well-known endpoint.
+
+    Attributes:
+        _jwks_cache: The cached JWKS response (the full JSON with ``keys`` array).
+        _cache_timestamp: ``time.monotonic()`` when the cache was last populated.
+        _cache_ttl: Cache time-to-live in seconds (default 600 = 10 minutes).
+    """
+
+    def __init__(
+        self,
+        *,
+        region: str,
+        user_pool_id: str,
+        cache_ttl: float = 600.0,
+    ) -> None:
+        self._region = region
+        self._user_pool_id = user_pool_id
+        self._cache_ttl = cache_ttl
+        self._jwks_cache: dict[str, object] | None = None
+        self._cache_timestamp: float = 0.0
+        self._jwks_url = (
+            f"https://cognito-idp.{region}.amazonaws.com/"
+            f"{user_pool_id}/.well-known/jwks.json"
+        )
+        self._issuer_url = (
+            f"https://cognito-idp.{region}.amazonaws.com/{user_pool_id}"
+        )
+
+    @property
+    def issuer_url(self) -> str:
+        """Return the expected JWT issuer URL for this Cognito user pool."""
+        return self._issuer_url
+
+    def _cache_is_fresh(self) -> bool:
+        """Return True if the JWKS cache exists and has not expired."""
+        if self._jwks_cache is None:
+            return False
+        return (time.monotonic() - self._cache_timestamp) < self._cache_ttl
+
+    async def get_jwks(self, *, force_refresh: bool = False) -> dict[str, object]:
+        """Fetch JWKS from Cognito, using cache when available.
+
+        Args:
+            force_refresh: If True, bypass cache and fetch fresh keys.
+
+        Returns:
+            The JWKS JSON response containing the ``keys`` array.
+
+        Raises:
+            HTTPException: 401 if JWKS endpoint is unreachable and no cache exists.
+        """
+        if not force_refresh and self._cache_is_fresh():
+            return self._jwks_cache  # type: ignore[return-value]
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(self._jwks_url, timeout=5)
+                resp.raise_for_status()
+                jwks: dict[str, object] = resp.json()
+            self._jwks_cache = jwks
+            self._cache_timestamp = time.monotonic()
+            return jwks
+        except (httpx.HTTPError, httpx.TimeoutException):
+            if self._jwks_cache is not None:
+                logger.warning(
+                    "JWKS endpoint unreachable, using stale cache "
+                    "(age=%.0fs, url=%s)",
+                    time.monotonic() - self._cache_timestamp,
+                    self._jwks_url,
+                )
+                return self._jwks_cache
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication service unavailable",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    async def get_signing_key(self, token: str) -> dict[str, object]:
+        """Extract the kid from the token header and find the matching JWK.
+
+        If the kid is not found in cached keys, forces a JWKS refresh (once)
+        to handle key rotation gracefully.
+
+        Args:
+            token: The raw JWT string.
+
+        Returns:
+            The JWK dict matching the token's kid.
+
+        Raises:
+            HTTPException: 401 if kid is not found in JWKS even after refresh.
+        """
+        try:
+            header = jwt.get_unverified_header(token)
+        except JWTError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired token",
+                headers={"WWW-Authenticate": "Bearer"},
+            ) from exc
+
+        kid = header.get("kid")
+        if kid is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # First attempt: search cached keys
+        jwks = await self.get_jwks()
+        key = self._find_key(jwks, kid)
+        if key is not None:
+            return key
+
+        # Second attempt: force refresh (key rotation scenario)
+        jwks = await self.get_jwks(force_refresh=True)
+        key = self._find_key(jwks, kid)
+        if key is not None:
+            return key
+
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    @staticmethod
+    def _find_key(
+        jwks: dict[str, object],
+        kid: str,
+    ) -> dict[str, object] | None:
+        """Find a JWK by kid in the JWKS response."""
+        keys = jwks.get("keys", [])
+        if not isinstance(keys, list):
+            return None
+        for k in keys:
+            if isinstance(k, dict) and k.get("kid") == kid:
+                return k
+        return None
+
+
+# Module-level singleton — shares JWKS cache across all requests in the process
+_jwks_provider = CognitoJWKSProvider(
+    region=settings.aws_region,
+    user_pool_id=settings.cognito_user_pool_id,
+)
+
+
+async def verify_cognito_token(token: str) -> dict[str, object]:
+    """Verify a Cognito JWT and return its claims.
+
+    Validates the token's RS256 signature against the JWKS, checks
+    audience matches COGNITO_APP_CLIENT_ID, issuer matches the Cognito
+    user pool URL, and token_use is "id".
+
+    Args:
+        token: The raw JWT string (without ``Bearer`` prefix).
+
+    Returns:
+        The decoded JWT claims dict containing sub, email, iss, aud, exp,
+        token_use and other Cognito ID token claims.
+
+    Raises:
+        HTTPException: 401 if the token is invalid, expired, or has
+            wrong audience/issuer/token_use.
+    """
+    key = await _jwks_provider.get_signing_key(token)
+
+    try:
+        claims = jwt.decode(
+            token,
+            key,
+            algorithms=["RS256"],
+            audience=settings.cognito_app_client_id,
+            issuer=_jwks_provider.issuer_url,
+        )
+    except JWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    # Validate token_use — Ember uses ID tokens, not access tokens
+    if claims.get("token_use") != "id":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Validate sub is a valid UUID
+    sub = claims.get("sub")
+    if sub is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    try:
+        uuid.UUID(str(sub))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    result: dict[str, object] = claims
+    return result
+
+
+def get_jwks_provider() -> CognitoJWKSProvider:
+    """Return the module-level JWKS provider singleton.
+
+    Useful for testing — allows tests to access and reset the provider.
+    """
+    return _jwks_provider

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,18 +1,24 @@
 """Shared FastAPI dependency injection functions.
 
 Provides get_db for database session management and get_current_user
-for JWT authentication (stubbed until P01-03 auth feature).
+for JWT authentication via AWS Cognito.
 """
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import AsyncGenerator
-from typing import NoReturn
 
-from fastapi import HTTPException, status
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth import verify_cognito_token
 from app.db.session import AsyncSessionLocal
+from app.models.profile import Profile
+
+_bearer_scheme = HTTPBearer()
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
@@ -21,13 +27,38 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
-async def get_current_user() -> NoReturn:
-    """Stub for JWT authentication. Implemented in P01-03 (user-auth).
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> Profile:
+    """Authenticate the request and return the current user's Profile.
+
+    Extracts the Bearer token from the Authorization header, verifies it
+    against Cognito JWKS, and looks up the corresponding profile in the
+    database.
+
+    Args:
+        credentials: The Bearer token extracted by FastAPI's HTTPBearer.
+        db: The async database session.
+
+    Returns:
+        The authenticated user's Profile ORM object.
 
     Raises:
-        HTTPException: Always raises 501 Not Implemented.
+        HTTPException: 401 if the token is missing, invalid, expired,
+            or the user is not found in the database.
     """
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="Authentication not yet implemented",
+    claims = await verify_cognito_token(credentials.credentials)
+    cognito_sub = uuid.UUID(str(claims["sub"]))
+
+    result = await db.execute(
+        select(Profile).where(Profile.id == cognito_sub),
     )
+    profile = result.scalar_one_or_none()
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return profile

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,579 @@
+"""Tests for the Cognito JWT authentication module (core/auth.py).
+
+Tests JWKS fetching, caching with TTL, force refresh on key rotation,
+stale cache fallback, and token verification with RSA key pairs.
+
+All tests use locally generated RSA keys — no network access required.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from fastapi import HTTPException
+from jose import jwt as jose_jwt
+
+from app.core.auth import CognitoJWKSProvider, verify_cognito_token
+
+# ---------------------------------------------------------------------------
+# RSA key helpers
+# ---------------------------------------------------------------------------
+
+TEST_REGION = "eu-west-1"
+TEST_POOL_ID = "eu-west-1_TestPool"
+TEST_CLIENT_ID = "test-client-id-123"
+TEST_KID = "test-kid-001"
+TEST_KID_2 = "test-kid-002"
+TEST_ISSUER = f"https://cognito-idp.{TEST_REGION}.amazonaws.com/{TEST_POOL_ID}"
+
+
+def _generate_rsa_key() -> RSAPrivateKey:
+    """Generate a 2048-bit RSA private key for testing."""
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+
+def _private_key_to_jwk(private_key: RSAPrivateKey, kid: str) -> dict[str, Any]:
+    """Convert an RSA private key to a JWK dict (public key only) for JWKS."""
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+
+    pub_numbers: RSAPublicNumbers = private_key.public_key().public_numbers()
+
+    def _int_to_base64url(value: int) -> str:
+        import base64
+
+        byte_length = (value.bit_length() + 7) // 8
+        value_bytes = value.to_bytes(byte_length, byteorder="big")
+        return base64.urlsafe_b64encode(value_bytes).rstrip(b"=").decode("ascii")
+
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "alg": "RS256",
+        "use": "sig",
+        "n": _int_to_base64url(pub_numbers.n),
+        "e": _int_to_base64url(pub_numbers.e),
+    }
+
+
+def _private_key_to_pem(private_key: RSAPrivateKey) -> str:
+    """Export RSA private key as PEM string for python-jose signing."""
+    from cryptography.hazmat.primitives import serialization
+
+    pem_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem_bytes.decode("ascii")
+
+
+def _make_token(
+    private_key: RSAPrivateKey,
+    kid: str,
+    *,
+    sub: str | None = None,
+    aud: str | None = None,
+    iss: str | None = None,
+    token_use: str = "id",
+    exp_delta: timedelta | None = None,
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    """Create a signed JWT using the given RSA private key."""
+    now = datetime.now(tz=UTC)
+    exp = now + (exp_delta if exp_delta is not None else timedelta(hours=1))
+    claims: dict[str, Any] = {
+        "sub": sub or str(uuid.uuid4()),
+        "aud": aud or TEST_CLIENT_ID,
+        "iss": iss or TEST_ISSUER,
+        "token_use": token_use,
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+        "email": "test@ember.ai",
+    }
+    if extra_claims:
+        claims.update(extra_claims)
+
+    return jose_jwt.encode(
+        claims,
+        _private_key_to_pem(private_key),
+        algorithm="RS256",
+        headers={"kid": kid},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def rsa_key() -> RSAPrivateKey:
+    """Provide a test RSA private key."""
+    return _generate_rsa_key()
+
+
+@pytest.fixture
+def rsa_key_2() -> RSAPrivateKey:
+    """Provide a second RSA private key (for wrong-signature tests)."""
+    return _generate_rsa_key()
+
+
+@pytest.fixture
+def jwks_response(rsa_key: RSAPrivateKey) -> dict[str, Any]:
+    """Provide a JWKS JSON response with the test public key."""
+    return {"keys": [_private_key_to_jwk(rsa_key, TEST_KID)]}
+
+
+@pytest.fixture
+def provider() -> CognitoJWKSProvider:
+    """Provide a fresh CognitoJWKSProvider instance."""
+    return CognitoJWKSProvider(
+        region=TEST_REGION,
+        user_pool_id=TEST_POOL_ID,
+        cache_ttl=600.0,
+    )
+
+
+def _mock_httpx_response(
+    json_data: dict[str, Any],
+    status_code: int = 200,
+) -> AsyncMock:
+    """Create a mock httpx response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error",
+            request=MagicMock(),
+            response=resp,
+        )
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# JWKS Provider Tests (Spec #1–#9)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_jwks_fetches_on_first_call(
+    provider: CognitoJWKSProvider,
+    jwks_response: dict[str, Any],
+) -> None:
+    """#1: get_jwks fetches from Cognito URL on first call."""
+    mock_get = AsyncMock(return_value=_mock_httpx_response(jwks_response))
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = mock_get
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        result = await provider.get_jwks()
+
+    assert result == jwks_response
+    mock_get.assert_called_once()
+    call_args = mock_get.call_args
+    assert provider._jwks_url in str(call_args)
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_returns_cached_within_ttl(
+    provider: CognitoJWKSProvider,
+    jwks_response: dict[str, Any],
+) -> None:
+    """#2: get_jwks returns cached keys on second call within TTL."""
+    mock_get = AsyncMock(return_value=_mock_httpx_response(jwks_response))
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = mock_get
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        await provider.get_jwks()
+        result = await provider.get_jwks()
+
+    assert result == jwks_response
+    assert mock_get.call_count == 1  # Only one HTTP call total
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_refetches_after_ttl_expiry(
+    provider: CognitoJWKSProvider,
+    jwks_response: dict[str, Any],
+) -> None:
+    """#3: get_jwks re-fetches after TTL expiry."""
+    mock_get = AsyncMock(return_value=_mock_httpx_response(jwks_response))
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = mock_get
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        # First fetch
+        await provider.get_jwks()
+        assert mock_get.call_count == 1
+
+        # Simulate TTL expiry by setting cache timestamp in the past
+        provider._cache_timestamp = time.monotonic() - 700
+
+        # Second fetch — should re-fetch
+        await provider.get_jwks()
+        assert mock_get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_force_refresh_bypasses_cache(
+    provider: CognitoJWKSProvider,
+    jwks_response: dict[str, Any],
+) -> None:
+    """#4: get_jwks(force_refresh=True) bypasses cache."""
+    mock_get = AsyncMock(return_value=_mock_httpx_response(jwks_response))
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = mock_get
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        await provider.get_jwks()
+        await provider.get_jwks(force_refresh=True)
+
+    assert mock_get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_returns_stale_cache_on_failure(
+    provider: CognitoJWKSProvider,
+    jwks_response: dict[str, Any],
+) -> None:
+    """#5: get_jwks returns stale cache when endpoint is unreachable."""
+    success_resp = _mock_httpx_response(jwks_response)
+    fail_effect = httpx.ConnectError("Connection refused")
+
+    call_count = 0
+
+    async def _mock_get(*args: object, **kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return success_resp
+        raise fail_effect
+
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = _mock_get
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        # First call succeeds
+        await provider.get_jwks()
+
+        # Expire cache
+        provider._cache_timestamp = time.monotonic() - 700
+
+        # Second call fails but returns stale cache
+        result = await provider.get_jwks()
+
+    assert result == jwks_response
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_raises_401_when_no_cache_and_unreachable(
+    provider: CognitoJWKSProvider,
+) -> None:
+    """#6: get_jwks raises 401 when endpoint is unreachable and no cache."""
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused"),
+        )
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        with pytest.raises(HTTPException) as exc_info:
+            await provider.get_jwks()
+
+        assert exc_info.value.status_code == 401
+        assert "Authentication service unavailable" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_get_signing_key_returns_matching_key(
+    rsa_key: RSAPrivateKey,
+    provider: CognitoJWKSProvider,
+    jwks_response: dict[str, Any],
+) -> None:
+    """#7: get_signing_key returns the correct key matching the token's kid."""
+    token = _make_token(rsa_key, TEST_KID)
+
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(
+            return_value=_mock_httpx_response(jwks_response),
+        )
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        key = await provider.get_signing_key(token)
+
+    assert key["kid"] == TEST_KID
+
+
+@pytest.mark.asyncio
+async def test_get_signing_key_force_refreshes_on_kid_miss(
+    rsa_key: RSAPrivateKey,
+    provider: CognitoJWKSProvider,
+) -> None:
+    """#8: get_signing_key triggers force refresh when kid is not in cache."""
+    token = _make_token(rsa_key, TEST_KID)
+
+    # First JWKS response has a different kid, second has the correct one
+    old_jwks: dict[str, Any] = {"keys": [_private_key_to_jwk(rsa_key, "old-kid")]}
+    new_jwks: dict[str, Any] = {"keys": [_private_key_to_jwk(rsa_key, TEST_KID)]}
+
+    call_count = 0
+
+    async def _mock_get(*args: object, **kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _mock_httpx_response(old_jwks)
+        return _mock_httpx_response(new_jwks)
+
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = _mock_get
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        key = await provider.get_signing_key(token)
+
+    assert key["kid"] == TEST_KID
+    assert call_count == 2  # Initial fetch + force refresh
+
+
+@pytest.mark.asyncio
+async def test_get_signing_key_raises_401_kid_not_found_after_refresh(
+    rsa_key: RSAPrivateKey,
+    provider: CognitoJWKSProvider,
+) -> None:
+    """#9: get_signing_key raises 401 when kid is not found even after refresh."""
+    token = _make_token(rsa_key, "nonexistent-kid")
+    jwks: dict[str, Any] = {"keys": [_private_key_to_jwk(rsa_key, TEST_KID)]}
+
+    with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(
+            return_value=_mock_httpx_response(jwks),
+        )
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client_instance
+
+        with pytest.raises(HTTPException) as exc_info:
+            await provider.get_signing_key(token)
+
+        assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Token Verification Tests (Spec #10–#17)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_valid_token_returns_claims(
+    rsa_key: RSAPrivateKey,
+    jwks_response: dict[str, Any],
+) -> None:
+    """#10: Valid token with correct claims returns claims dict."""
+    test_sub = str(uuid.uuid4())
+    token = _make_token(rsa_key, TEST_KID, sub=test_sub)
+
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        mock_provider.get_signing_key = AsyncMock(
+            return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+        )
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        claims = await verify_cognito_token(token)
+
+    assert claims["sub"] == test_sub
+    assert claims["token_use"] == "id"
+    assert claims["aud"] == TEST_CLIENT_ID
+
+
+@pytest.mark.asyncio
+async def test_expired_token_raises_401(
+    rsa_key: RSAPrivateKey,
+) -> None:
+    """#11: Token with expired exp claim raises 401."""
+    token = _make_token(
+        rsa_key,
+        TEST_KID,
+        exp_delta=timedelta(hours=-1),
+    )
+
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        mock_provider.get_signing_key = AsyncMock(
+            return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+        )
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_cognito_token(token)
+
+        assert exc_info.value.status_code == 401
+        assert "Invalid or expired token" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_wrong_signature_raises_401(
+    rsa_key: RSAPrivateKey,
+    rsa_key_2: RSAPrivateKey,
+) -> None:
+    """#12: Token signed with different RSA key raises 401."""
+    # Sign with key 2, but provide key 1's public key for verification
+    token = _make_token(rsa_key_2, TEST_KID)
+
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        mock_provider.get_signing_key = AsyncMock(
+            return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+        )
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_cognito_token(token)
+
+        assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_audience_raises_401(
+    rsa_key: RSAPrivateKey,
+) -> None:
+    """#13: Token with wrong aud (different client ID) raises 401."""
+    token = _make_token(rsa_key, TEST_KID, aud="wrong-client-id")
+
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        mock_provider.get_signing_key = AsyncMock(
+            return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+        )
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_cognito_token(token)
+
+        assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_issuer_raises_401(
+    rsa_key: RSAPrivateKey,
+) -> None:
+    """#14: Token with wrong iss (different issuer URL) raises 401."""
+    token = _make_token(
+        rsa_key,
+        TEST_KID,
+        iss="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_WrongPool",
+    )
+
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        mock_provider.get_signing_key = AsyncMock(
+            return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+        )
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_cognito_token(token)
+
+        assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_access_token_use_raises_401(
+    rsa_key: RSAPrivateKey,
+) -> None:
+    """#15: Token with token_use=access instead of id raises 401."""
+    token = _make_token(rsa_key, TEST_KID, token_use="access")
+
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        mock_provider.get_signing_key = AsyncMock(
+            return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+        )
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_cognito_token(token)
+
+        assert exc_info.value.status_code == 401
+        assert "Invalid or expired token" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_malformed_token_raises_401() -> None:
+    """#16: Completely malformed token string raises 401."""
+    with patch("app.core.auth._jwks_provider") as mock_provider:
+        mock_provider.get_signing_key = AsyncMock(
+            side_effect=HTTPException(
+                status_code=401,
+                detail="Invalid or expired token",
+                headers={"WWW-Authenticate": "Bearer"},
+            ),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_cognito_token("not.a.valid.jwt.at.all")
+
+        assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_kid_not_matching_any_jwks_key_raises_401(
+    rsa_key: RSAPrivateKey,
+) -> None:
+    """#17: Token with kid not matching any JWKS key raises 401."""
+    token = _make_token(rsa_key, "unknown-kid-xyz")
+
+    with patch("app.core.auth._jwks_provider") as mock_provider:
+        mock_provider.get_signing_key = AsyncMock(
+            side_effect=HTTPException(
+                status_code=401,
+                detail="Invalid or expired token",
+                headers={"WWW-Authenticate": "Bearer"},
+            ),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_cognito_token(token)
+
+        assert exc_info.value.status_code == 401

--- a/backend/tests/test_auth_dependency.py
+++ b/backend/tests/test_auth_dependency.py
@@ -1,0 +1,357 @@
+"""Integration tests for the get_current_user dependency.
+
+Tests the full authentication flow through the FastAPI test client, including
+token validation, profile lookup, missing auth header, and invalid tokens.
+
+Uses locally generated RSA keys and mock JWKS — no network access required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from fastapi import APIRouter, Depends
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_current_user, get_db
+from app.main import app
+from app.models.profile import Profile
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TEST_REGION = "eu-west-1"
+TEST_POOL_ID = "eu-west-1_TestPool"
+TEST_CLIENT_ID = "test-client-id-123"
+TEST_KID = "test-kid-001"
+TEST_ISSUER = f"https://cognito-idp.{TEST_REGION}.amazonaws.com/{TEST_POOL_ID}"
+
+
+# ---------------------------------------------------------------------------
+# RSA key helpers (same as test_auth.py — duplicated to keep tests self-contained)
+# ---------------------------------------------------------------------------
+
+
+def _generate_rsa_key() -> RSAPrivateKey:
+    """Generate a 2048-bit RSA private key for testing."""
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+
+def _private_key_to_jwk(private_key: RSAPrivateKey, kid: str) -> dict[str, Any]:
+    """Convert an RSA private key to a JWK dict (public key only)."""
+    import base64
+
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+
+    pub_numbers: RSAPublicNumbers = private_key.public_key().public_numbers()
+
+    def _int_to_base64url(value: int) -> str:
+        byte_length = (value.bit_length() + 7) // 8
+        value_bytes = value.to_bytes(byte_length, byteorder="big")
+        return base64.urlsafe_b64encode(value_bytes).rstrip(b"=").decode("ascii")
+
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "alg": "RS256",
+        "use": "sig",
+        "n": _int_to_base64url(pub_numbers.n),
+        "e": _int_to_base64url(pub_numbers.e),
+    }
+
+
+def _private_key_to_pem(private_key: RSAPrivateKey) -> str:
+    """Export RSA private key as PEM string."""
+    from cryptography.hazmat.primitives import serialization
+
+    pem_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem_bytes.decode("ascii")
+
+
+def _make_token(
+    private_key: RSAPrivateKey,
+    kid: str,
+    *,
+    sub: str | None = None,
+    aud: str | None = None,
+    iss: str | None = None,
+    token_use: str = "id",
+    exp_delta: timedelta | None = None,
+) -> str:
+    """Create a signed JWT using the given RSA private key."""
+    from datetime import UTC, datetime
+
+    from jose import jwt as jose_jwt
+
+    now = datetime.now(tz=UTC)
+    exp = now + (exp_delta if exp_delta is not None else timedelta(hours=1))
+    claims: dict[str, Any] = {
+        "sub": sub or str(uuid.uuid4()),
+        "aud": aud or TEST_CLIENT_ID,
+        "iss": iss or TEST_ISSUER,
+        "token_use": token_use,
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+        "email": "test@ember.ai",
+    }
+    return jose_jwt.encode(
+        claims,
+        _private_key_to_pem(private_key),
+        algorithm="RS256",
+        headers={"kid": kid},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rsa_key() -> RSAPrivateKey:
+    """Module-scoped RSA key to avoid regenerating for every test."""
+    return _generate_rsa_key()
+
+
+@pytest.fixture(scope="module")
+def test_sub() -> str:
+    """Module-scoped test user UUID."""
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def mock_db_session() -> AsyncMock:
+    """Provide a mock async database session."""
+    return AsyncMock(spec=AsyncSession)
+
+
+def _create_mock_profile(user_id: str) -> Profile:
+    """Create a Profile-like object for testing without a real DB."""
+    profile = MagicMock(spec=Profile)
+    profile.id = uuid.UUID(user_id)
+    profile.email = "test@ember.ai"
+    profile.name = "Test User"
+    return profile
+
+
+@pytest_asyncio.fixture
+async def auth_client(
+    rsa_key: RSAPrivateKey,
+    test_sub: str,
+) -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client with auth mocking configured.
+
+    Patches the JWKS provider and database to allow valid token verification
+    and profile lookup.
+    """
+    mock_profile = _create_mock_profile(test_sub)
+
+    # Mock the database dependency
+    mock_db = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_profile
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    # Patch the JWKS provider to return our test key
+    jwk = _private_key_to_jwk(rsa_key, TEST_KID)
+
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        mock_provider.get_signing_key = AsyncMock(return_value=jwk)
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def auth_client_no_profile(
+    rsa_key: RSAPrivateKey,
+) -> AsyncGenerator[AsyncClient, None]:
+    """Client where token is valid but no matching profile exists in DB."""
+    mock_db = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None  # No profile found
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    jwk = _private_key_to_jwk(rsa_key, TEST_KID)
+
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        mock_provider.get_signing_key = AsyncMock(return_value=jwk)
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Register a protected test route
+# ---------------------------------------------------------------------------
+
+_test_router = APIRouter()
+
+
+@_test_router.get("/api/v1/_test_protected")
+async def _protected_endpoint(
+    current_user: Profile = Depends(get_current_user),
+) -> dict[str, str]:
+    return {"user_id": str(current_user.id)}
+
+
+# Register the test route (idempotent — router check)
+_route_paths = {r.path for r in app.routes}
+if "/api/v1/_test_protected" not in _route_paths:
+    app.include_router(_test_router)
+
+
+# ---------------------------------------------------------------------------
+# Dependency Integration Tests (Spec #18–#24)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_valid_token_and_existing_profile(
+    auth_client: AsyncClient,
+    rsa_key: RSAPrivateKey,
+    test_sub: str,
+) -> None:
+    """#18: Valid token + existing profile returns the Profile object."""
+    token = _make_token(rsa_key, TEST_KID, sub=test_sub)
+    response = await auth_client.get(
+        "/api/v1/_test_protected",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["user_id"] == test_sub
+
+
+@pytest.mark.asyncio
+async def test_valid_token_but_no_profile(
+    auth_client_no_profile: AsyncClient,
+    rsa_key: RSAPrivateKey,
+) -> None:
+    """#19: Valid token but no matching profile returns 401 'User not found'."""
+    token = _make_token(rsa_key, TEST_KID, sub=str(uuid.uuid4()))
+    response = await auth_client_no_profile.get(
+        "/api/v1/_test_protected",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "User not found"
+
+
+@pytest.mark.asyncio
+async def test_no_authorization_header(
+    auth_client: AsyncClient,
+) -> None:
+    """#20: Request without Authorization header returns 401."""
+    response = await auth_client.get("/api/v1/_test_protected")
+    assert response.status_code in (401, 403)
+    assert response.json()["detail"] == "Not authenticated"
+
+
+@pytest.mark.asyncio
+async def test_basic_auth_instead_of_bearer(
+    auth_client: AsyncClient,
+) -> None:
+    """#21: Authorization: Basic returns 401."""
+    response = await auth_client.get(
+        "/api/v1/_test_protected",
+        headers={"Authorization": "Basic dXNlcjpwYXNz"},
+    )
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_invalid_bearer_token(
+    auth_client: AsyncClient,
+) -> None:
+    """#22: Invalid Bearer token returns 401."""
+    with patch("app.core.auth._jwks_provider") as mock_provider, \
+         patch("app.core.auth.settings") as mock_settings:
+        from fastapi import HTTPException
+
+        mock_provider.get_signing_key = AsyncMock(
+            side_effect=HTTPException(
+                status_code=401,
+                detail="Invalid or expired token",
+                headers={"WWW-Authenticate": "Bearer"},
+            ),
+        )
+        mock_provider.issuer_url = TEST_ISSUER
+        mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+        response = await auth_client.get(
+            "/api/v1/_test_protected",
+            headers={"Authorization": "Bearer totally-invalid-token"},
+        )
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_requires_no_auth() -> None:
+    """#23: GET /api/v1/health works without any Authorization header."""
+    # Use the base conftest client without auth overrides
+    async def _no_db() -> AsyncGenerator[AsyncMock, None]:
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = _no_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/health")
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_protected_endpoint_returns_correct_user_context(
+    auth_client: AsyncClient,
+    rsa_key: RSAPrivateKey,
+    test_sub: str,
+) -> None:
+    """#24: Protected endpoint receives the authenticated Profile object."""
+    token = _make_token(rsa_key, TEST_KID, sub=test_sub)
+    response = await auth_client.get(
+        "/api/v1/_test_protected",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user_id"] == test_sub

--- a/backend/tests/test_auth_dependency_extended.py
+++ b/backend/tests/test_auth_dependency_extended.py
@@ -1,0 +1,473 @@
+"""Extended integration tests for the get_current_user dependency.
+
+Covers edge cases NOT addressed by the backend-dev's test_auth_dependency.py:
+
+- DB session error handling (database exception during profile lookup)
+- HTTPBearer edge cases (empty Bearer value, whitespace-only token)
+- WWW-Authenticate header on dependency-level 401 responses
+- Verify 'User not found' response includes WWW-Authenticate header
+- Multiple sequential authenticated requests (token caching behavior)
+
+All tests use locally generated RSA keys -- no network access required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicNumbers
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_current_user, get_db
+from app.main import app
+from app.models.profile import Profile
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TEST_REGION = "eu-west-1"
+TEST_POOL_ID = "eu-west-1_TestPool"
+TEST_CLIENT_ID = "test-client-id-123"
+TEST_KID = "test-kid-001"
+TEST_ISSUER = f"https://cognito-idp.{TEST_REGION}.amazonaws.com/{TEST_POOL_ID}"
+
+
+# ---------------------------------------------------------------------------
+# RSA key helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_rsa_key() -> RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _private_key_to_jwk(private_key: RSAPrivateKey, kid: str) -> dict[str, Any]:
+    import base64
+
+    pub_numbers: RSAPublicNumbers = private_key.public_key().public_numbers()
+
+    def _int_to_base64url(value: int) -> str:
+        byte_length = (value.bit_length() + 7) // 8
+        value_bytes = value.to_bytes(byte_length, byteorder="big")
+        return base64.urlsafe_b64encode(value_bytes).rstrip(b"=").decode("ascii")
+
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "alg": "RS256",
+        "use": "sig",
+        "n": _int_to_base64url(pub_numbers.n),
+        "e": _int_to_base64url(pub_numbers.e),
+    }
+
+
+def _private_key_to_pem(private_key: RSAPrivateKey) -> str:
+    pem_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem_bytes.decode("ascii")
+
+
+def _make_token(
+    private_key: RSAPrivateKey,
+    kid: str,
+    *,
+    sub: str | None = None,
+    aud: str | None = None,
+    iss: str | None = None,
+    token_use: str = "id",
+    exp_delta: timedelta | None = None,
+) -> str:
+    from jose import jwt as jose_jwt
+
+    now = datetime.now(tz=UTC)
+    exp = now + (exp_delta if exp_delta is not None else timedelta(hours=1))
+    claims: dict[str, Any] = {
+        "sub": sub or str(uuid.uuid4()),
+        "aud": aud or TEST_CLIENT_ID,
+        "iss": iss or TEST_ISSUER,
+        "token_use": token_use,
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+        "email": "test@ember.ai",
+    }
+    return jose_jwt.encode(
+        claims,
+        _private_key_to_pem(private_key),
+        algorithm="RS256",
+        headers={"kid": kid},
+    )
+
+
+def _create_mock_profile(user_id: str) -> Profile:
+    profile = MagicMock(spec=Profile)
+    profile.id = uuid.UUID(user_id)
+    profile.email = "test@ember.ai"
+    profile.name = "Test User"
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rsa_key() -> RSAPrivateKey:
+    return _generate_rsa_key()
+
+
+@pytest.fixture(scope="module")
+def test_sub() -> str:
+    return str(uuid.uuid4())
+
+
+# Ensure the test protected route is registered (same as test_auth_dependency.py)
+from fastapi import APIRouter, Depends
+
+_test_router = APIRouter()
+
+
+@_test_router.get("/api/v1/_test_protected")
+async def _protected_endpoint(
+    current_user: Profile = Depends(get_current_user),
+) -> dict[str, str]:
+    return {"user_id": str(current_user.id)}
+
+
+_route_paths = {r.path for r in app.routes}
+if "/api/v1/_test_protected" not in _route_paths:
+    app.include_router(_test_router)
+
+
+# ---------------------------------------------------------------------------
+# DB session error handling
+# ---------------------------------------------------------------------------
+
+
+class TestDBSessionErrorHandling:
+    """Tests for database errors during profile lookup."""
+
+    @pytest_asyncio.fixture
+    async def client_with_db_error(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> AsyncGenerator[AsyncClient, None]:
+        """Client where DB raises an exception during profile lookup."""
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_db.execute = AsyncMock(
+            side_effect=Exception("Database connection lost"),
+        )
+
+        async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override_get_db
+
+        jwk = _private_key_to_jwk(rsa_key, TEST_KID)
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(return_value=jwk)
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                yield ac
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_db_error_propagates_exception(
+        self,
+        client_with_db_error: AsyncClient,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Database exception during profile lookup propagates as an error.
+
+        When using httpx's ASGI transport, unhandled exceptions in
+        dependencies propagate to the test. In production, the ASGI
+        server (uvicorn) would return HTTP 500.
+        """
+        token = _make_token(rsa_key, TEST_KID, sub=str(uuid.uuid4()))
+        with pytest.raises(Exception, match="Database connection lost"):
+            await client_with_db_error.get(
+                "/api/v1/_test_protected",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+
+# ---------------------------------------------------------------------------
+# HTTPBearer edge cases via integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestHTTPBearerEdgeCases:
+    """Tests for HTTPBearer edge cases via the FastAPI test client."""
+
+    @pytest_asyncio.fixture
+    async def basic_client(self) -> AsyncGenerator[AsyncClient, None]:
+        """Minimal client with DB override only (no auth mocking)."""
+        async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+            yield AsyncMock()
+
+        app.dependency_overrides[get_db] = _override_get_db
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_empty_bearer_value_returns_401(
+        self,
+        basic_client: AsyncClient,
+    ) -> None:
+        """Authorization: Bearer (with empty token) returns 401/403."""
+        response = await basic_client.get(
+            "/api/v1/_test_protected",
+            headers={"Authorization": "Bearer "},
+        )
+        # HTTPBearer may return 401 or 403 depending on FastAPI version
+        assert response.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_bearer_with_only_whitespace_returns_error(
+        self,
+        basic_client: AsyncClient,
+    ) -> None:
+        """Authorization: Bearer with whitespace-only value returns error."""
+        response = await basic_client.get(
+            "/api/v1/_test_protected",
+            headers={"Authorization": "Bearer    "},
+        )
+        assert response.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_no_authorization_header_response_body(
+        self,
+        basic_client: AsyncClient,
+    ) -> None:
+        """Missing Authorization header returns expected JSON body."""
+        response = await basic_client.get("/api/v1/_test_protected")
+        assert response.status_code in (401, 403)
+        body = response.json()
+        assert "detail" in body
+        assert body["detail"] == "Not authenticated"
+
+    @pytest.mark.asyncio
+    async def test_malformed_authorization_header(
+        self,
+        basic_client: AsyncClient,
+    ) -> None:
+        """Authorization header with random text (no scheme) returns 401/403."""
+        response = await basic_client.get(
+            "/api/v1/_test_protected",
+            headers={"Authorization": "JustSomeRandomText"},
+        )
+        assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# WWW-Authenticate header on dependency-level 401s
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyWWWAuthenticate:
+    """Verify WWW-Authenticate header on 401 responses from get_current_user."""
+
+    @pytest_asyncio.fixture
+    async def auth_client_no_profile(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> AsyncGenerator[AsyncClient, None]:
+        """Client where token is valid but no profile exists."""
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override_get_db
+
+        jwk = _private_key_to_jwk(rsa_key, TEST_KID)
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(return_value=jwk)
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                yield ac
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_user_not_found_has_www_authenticate_header(
+        self,
+        auth_client_no_profile: AsyncClient,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """'User not found' 401 includes WWW-Authenticate: Bearer header."""
+        token = _make_token(rsa_key, TEST_KID, sub=str(uuid.uuid4()))
+        response = await auth_client_no_profile.get(
+            "/api/v1/_test_protected",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "User not found"
+        # FastAPI includes WWW-Authenticate when the HTTPException headers are set
+        assert "www-authenticate" in {k.lower() for k in response.headers}
+        assert response.headers.get("www-authenticate") == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_user_not_found_exact_response_shape(
+        self,
+        auth_client_no_profile: AsyncClient,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """'User not found' response has exact expected shape."""
+        token = _make_token(rsa_key, TEST_KID, sub=str(uuid.uuid4()))
+        response = await auth_client_no_profile.get(
+            "/api/v1/_test_protected",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 401
+        body = response.json()
+        assert body == {"detail": "User not found"}
+
+
+# ---------------------------------------------------------------------------
+# Multiple sequential authenticated requests
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleSequentialRequests:
+    """Tests for multiple authenticated requests in sequence."""
+
+    @pytest_asyncio.fixture
+    async def auth_client(
+        self,
+        rsa_key: RSAPrivateKey,
+        test_sub: str,
+    ) -> AsyncGenerator[AsyncClient, None]:
+        """Client with valid auth setup."""
+        mock_profile = _create_mock_profile(test_sub)
+
+        mock_db = AsyncMock(spec=AsyncSession)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_profile
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override_get_db
+
+        jwk = _private_key_to_jwk(rsa_key, TEST_KID)
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(return_value=jwk)
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                yield ac
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_two_sequential_requests_both_succeed(
+        self,
+        auth_client: AsyncClient,
+        rsa_key: RSAPrivateKey,
+        test_sub: str,
+    ) -> None:
+        """Two sequential authenticated requests both return 200."""
+        token = _make_token(rsa_key, TEST_KID, sub=test_sub)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response1 = await auth_client.get("/api/v1/_test_protected", headers=headers)
+        assert response1.status_code == 200
+        assert response1.json()["user_id"] == test_sub
+
+        response2 = await auth_client.get("/api/v1/_test_protected", headers=headers)
+        assert response2.status_code == 200
+        assert response2.json()["user_id"] == test_sub
+
+    @pytest.mark.asyncio
+    async def test_tokens_with_different_expiry_same_user(
+        self,
+        auth_client: AsyncClient,
+        rsa_key: RSAPrivateKey,
+        test_sub: str,
+    ) -> None:
+        """Two tokens with different exp for the same sub both authenticate."""
+        token1 = _make_token(
+            rsa_key, TEST_KID, sub=test_sub, exp_delta=timedelta(hours=1),
+        )
+        token2 = _make_token(
+            rsa_key, TEST_KID, sub=test_sub, exp_delta=timedelta(hours=2),
+        )
+        # Tokens differ due to different exp values
+        assert token1 != token2
+
+        resp1 = await auth_client.get(
+            "/api/v1/_test_protected",
+            headers={"Authorization": f"Bearer {token1}"},
+        )
+        resp2 = await auth_client.get(
+            "/api/v1/_test_protected",
+            headers={"Authorization": f"Bearer {token2}"},
+        )
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        assert resp1.json()["user_id"] == resp2.json()["user_id"]
+
+
+# ---------------------------------------------------------------------------
+# Health endpoint accessibility
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpointAccessibility:
+    """Verify health endpoint remains public regardless of auth state."""
+
+    @pytest.mark.asyncio
+    async def test_health_with_invalid_bearer_still_returns_200(self) -> None:
+        """Health endpoint ignores invalid Bearer tokens."""
+        async def _no_db() -> AsyncGenerator[AsyncMock, None]:
+            yield AsyncMock()
+
+        app.dependency_overrides[get_db] = _no_db
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get(
+                "/api/v1/health",
+                headers={"Authorization": "Bearer some-invalid-token"},
+            )
+
+        app.dependency_overrides.clear()
+        assert response.status_code == 200

--- a/backend/tests/test_auth_extended.py
+++ b/backend/tests/test_auth_extended.py
@@ -1,0 +1,1059 @@
+"""Extended tests for the Cognito JWT authentication module (core/auth.py).
+
+Covers edge cases and scenarios NOT addressed by the backend-dev's original
+test_auth.py (17 tests) and test_auth_dependency.py (7 tests):
+
+- Empty/missing sub claim in token
+- Non-UUID sub claim
+- Token with extra claims (still valid)
+- Exact TTL boundary conditions (cache fresh at TTL-1, stale at TTL+0)
+- Error message content verification on all 401 paths
+- WWW-Authenticate: Bearer header presence on all 401s
+- Multiple kid rotation scenarios (3+ keys in JWKS)
+- _find_key edge cases (non-list keys, empty keys array, keys without kid)
+- get_signing_key with token missing kid header
+- get_signing_key with completely malformed token
+- get_jwks_provider() accessor
+- Concurrent JWKS refresh behavior (asyncio.gather)
+- JWKS fetch timeout handling
+- DB session error handling in get_current_user
+- HTTPBearer edge cases (empty Bearer, whitespace-only token)
+
+All tests use locally generated RSA keys -- no network access required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicNumbers
+from fastapi import HTTPException
+from jose import jwt as jose_jwt
+
+from app.core.auth import CognitoJWKSProvider, get_jwks_provider, verify_cognito_token
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TEST_REGION = "eu-west-1"
+TEST_POOL_ID = "eu-west-1_TestPool"
+TEST_CLIENT_ID = "test-client-id-123"
+TEST_KID = "test-kid-001"
+TEST_KID_2 = "test-kid-002"
+TEST_KID_3 = "test-kid-003"
+TEST_ISSUER = f"https://cognito-idp.{TEST_REGION}.amazonaws.com/{TEST_POOL_ID}"
+
+
+# ---------------------------------------------------------------------------
+# RSA key helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_rsa_key() -> RSAPrivateKey:
+    """Generate a 2048-bit RSA private key for testing."""
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+
+def _private_key_to_jwk(private_key: RSAPrivateKey, kid: str) -> dict[str, Any]:
+    """Convert an RSA private key to a JWK dict (public key only) for JWKS."""
+    import base64
+
+    pub_numbers: RSAPublicNumbers = private_key.public_key().public_numbers()
+
+    def _int_to_base64url(value: int) -> str:
+        byte_length = (value.bit_length() + 7) // 8
+        value_bytes = value.to_bytes(byte_length, byteorder="big")
+        return base64.urlsafe_b64encode(value_bytes).rstrip(b"=").decode("ascii")
+
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "alg": "RS256",
+        "use": "sig",
+        "n": _int_to_base64url(pub_numbers.n),
+        "e": _int_to_base64url(pub_numbers.e),
+    }
+
+
+def _private_key_to_pem(private_key: RSAPrivateKey) -> str:
+    """Export RSA private key as PEM string for python-jose signing."""
+    pem_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem_bytes.decode("ascii")
+
+
+def _make_token(
+    private_key: RSAPrivateKey,
+    kid: str,
+    *,
+    sub: str | None = None,
+    aud: str | None = None,
+    iss: str | None = None,
+    token_use: str = "id",
+    exp_delta: timedelta | None = None,
+    extra_claims: dict[str, Any] | None = None,
+    omit_sub: bool = False,
+) -> str:
+    """Create a signed JWT using the given RSA private key.
+
+    Args:
+        omit_sub: If True, do not include the 'sub' claim at all.
+    """
+    now = datetime.now(tz=UTC)
+    exp = now + (exp_delta if exp_delta is not None else timedelta(hours=1))
+    claims: dict[str, Any] = {
+        "aud": aud or TEST_CLIENT_ID,
+        "iss": iss or TEST_ISSUER,
+        "token_use": token_use,
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+        "email": "test@ember.ai",
+    }
+    if not omit_sub:
+        claims["sub"] = sub if sub is not None else str(uuid.uuid4())
+    if extra_claims:
+        claims.update(extra_claims)
+
+    return jose_jwt.encode(
+        claims,
+        _private_key_to_pem(private_key),
+        algorithm="RS256",
+        headers={"kid": kid},
+    )
+
+
+def _mock_httpx_response(
+    json_data: dict[str, Any],
+    status_code: int = 200,
+) -> MagicMock:
+    """Create a mock httpx response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error",
+            request=MagicMock(),
+            response=resp,
+        )
+    return resp
+
+
+def _make_mock_client(mock_get: Any) -> AsyncMock:
+    """Create a mock httpx.AsyncClient instance with proper async context manager."""
+    mock_client_instance = AsyncMock()
+    mock_client_instance.get = mock_get
+    mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+    return mock_client_instance
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rsa_key() -> RSAPrivateKey:
+    """Provide a test RSA private key."""
+    return _generate_rsa_key()
+
+
+@pytest.fixture
+def rsa_key_2() -> RSAPrivateKey:
+    """Provide a second RSA private key."""
+    return _generate_rsa_key()
+
+
+@pytest.fixture
+def jwks_response(rsa_key: RSAPrivateKey) -> dict[str, Any]:
+    """Provide a JWKS JSON response with the test public key."""
+    return {"keys": [_private_key_to_jwk(rsa_key, TEST_KID)]}
+
+
+@pytest.fixture
+def provider() -> CognitoJWKSProvider:
+    """Provide a fresh CognitoJWKSProvider instance."""
+    return CognitoJWKSProvider(
+        region=TEST_REGION,
+        user_pool_id=TEST_POOL_ID,
+        cache_ttl=600.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _find_key edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestFindKeyEdgeCases:
+    """Tests for the _find_key static method edge cases."""
+
+    def test_find_key_with_non_list_keys(self) -> None:
+        """_find_key returns None when 'keys' is not a list."""
+        jwks: dict[str, Any] = {"keys": "not-a-list"}
+        result = CognitoJWKSProvider._find_key(jwks, TEST_KID)
+        assert result is None
+
+    def test_find_key_with_empty_keys_array(self) -> None:
+        """_find_key returns None when 'keys' is an empty list."""
+        jwks: dict[str, Any] = {"keys": []}
+        result = CognitoJWKSProvider._find_key(jwks, TEST_KID)
+        assert result is None
+
+    def test_find_key_with_missing_keys_field(self) -> None:
+        """_find_key returns None when 'keys' field is absent."""
+        jwks: dict[str, Any] = {"something_else": True}
+        result = CognitoJWKSProvider._find_key(jwks, TEST_KID)
+        assert result is None
+
+    def test_find_key_with_non_dict_entries(self) -> None:
+        """_find_key skips non-dict entries in the keys array."""
+        jwks: dict[str, Any] = {"keys": ["not-a-dict", 42, None]}
+        result = CognitoJWKSProvider._find_key(jwks, TEST_KID)
+        assert result is None
+
+    def test_find_key_with_dict_entries_missing_kid(self) -> None:
+        """_find_key skips dict entries that have no 'kid' field."""
+        jwks: dict[str, Any] = {"keys": [{"kty": "RSA", "n": "abc"}]}
+        result = CognitoJWKSProvider._find_key(jwks, TEST_KID)
+        assert result is None
+
+    def test_find_key_selects_correct_kid_among_multiple(
+        self,
+        rsa_key: RSAPrivateKey,
+        rsa_key_2: RSAPrivateKey,
+    ) -> None:
+        """_find_key returns the correct key when multiple keys are present."""
+        jwk_1 = _private_key_to_jwk(rsa_key, TEST_KID)
+        jwk_2 = _private_key_to_jwk(rsa_key_2, TEST_KID_2)
+        jwks: dict[str, Any] = {"keys": [jwk_1, jwk_2]}
+
+        result = CognitoJWKSProvider._find_key(jwks, TEST_KID_2)
+        assert result is not None
+        assert result["kid"] == TEST_KID_2
+
+
+# ---------------------------------------------------------------------------
+# JWKS Provider: TTL boundary conditions
+# ---------------------------------------------------------------------------
+
+
+class TestJWKSCacheTTLBoundary:
+    """Tests for exact TTL boundary conditions on cache freshness."""
+
+    @pytest.mark.asyncio
+    async def test_cache_fresh_at_exactly_ttl_minus_one_second(
+        self,
+        provider: CognitoJWKSProvider,
+        jwks_response: dict[str, Any],
+    ) -> None:
+        """Cache is still fresh at TTL-1 second (599s for 600s TTL)."""
+        mock_get = AsyncMock(return_value=_mock_httpx_response(jwks_response))
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(mock_get)
+
+            await provider.get_jwks()
+            assert mock_get.call_count == 1
+
+            # Set cache timestamp to TTL-1 second ago
+            provider._cache_timestamp = time.monotonic() - 599
+
+            result = await provider.get_jwks()
+            assert result == jwks_response
+            assert mock_get.call_count == 1  # Still cached
+
+    @pytest.mark.asyncio
+    async def test_cache_stale_at_exactly_ttl(
+        self,
+        provider: CognitoJWKSProvider,
+        jwks_response: dict[str, Any],
+    ) -> None:
+        """Cache is stale at exactly TTL seconds (600s boundary)."""
+        mock_get = AsyncMock(return_value=_mock_httpx_response(jwks_response))
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(mock_get)
+
+            await provider.get_jwks()
+            assert mock_get.call_count == 1
+
+            # Set cache timestamp to exactly TTL ago
+            provider._cache_timestamp = time.monotonic() - 600
+
+            await provider.get_jwks()
+            assert mock_get.call_count == 2  # Re-fetched
+
+    @pytest.mark.asyncio
+    async def test_cache_is_fresh_returns_false_when_no_cache(
+        self,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """_cache_is_fresh returns False when cache is None."""
+        assert provider._jwks_cache is None
+        assert provider._cache_is_fresh() is False
+
+    @pytest.mark.asyncio
+    async def test_cache_is_fresh_returns_true_when_just_populated(
+        self,
+        provider: CognitoJWKSProvider,
+        jwks_response: dict[str, Any],
+    ) -> None:
+        """_cache_is_fresh returns True immediately after populating cache."""
+        mock_get = AsyncMock(return_value=_mock_httpx_response(jwks_response))
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(mock_get)
+            await provider.get_jwks()
+
+        assert provider._cache_is_fresh() is True
+
+
+# ---------------------------------------------------------------------------
+# JWKS Provider: Multiple key rotation scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleKeyRotation:
+    """Tests for JWKS with multiple keys and rotation scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_three_keys_in_jwks_find_correct_one(
+        self,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """Provider finds the correct key among 3 JWKS keys."""
+        key_1 = _generate_rsa_key()
+        key_2 = _generate_rsa_key()
+        key_3 = _generate_rsa_key()
+        jwks: dict[str, Any] = {
+            "keys": [
+                _private_key_to_jwk(key_1, TEST_KID),
+                _private_key_to_jwk(key_2, TEST_KID_2),
+                _private_key_to_jwk(key_3, TEST_KID_3),
+            ],
+        }
+
+        token = _make_token(key_2, TEST_KID_2)
+        mock_get = AsyncMock(return_value=_mock_httpx_response(jwks))
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(mock_get)
+
+            key = await provider.get_signing_key(token)
+
+        assert key["kid"] == TEST_KID_2
+
+    @pytest.mark.asyncio
+    async def test_key_rotation_old_key_removed_new_key_added(
+        self,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """Simulates full key rotation: old JWKS has kid-A, new JWKS has kid-B."""
+        old_key = _generate_rsa_key()
+        new_key = _generate_rsa_key()
+
+        old_jwks: dict[str, Any] = {"keys": [_private_key_to_jwk(old_key, "old-kid")]}
+        new_jwks: dict[str, Any] = {
+            "keys": [
+                _private_key_to_jwk(old_key, "old-kid"),
+                _private_key_to_jwk(new_key, "new-kid"),
+            ],
+        }
+
+        # Token signed with new key
+        token = _make_token(new_key, "new-kid")
+
+        call_count = 0
+
+        async def _mock_get(*args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_httpx_response(old_jwks)
+            return _mock_httpx_response(new_jwks)
+
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(_mock_get)
+
+            key = await provider.get_signing_key(token)
+
+        assert key["kid"] == "new-kid"
+        assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# JWKS Provider: Concurrent refresh behavior
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentJWKSRefresh:
+    """Tests for concurrent JWKS fetch behavior."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_jwks_calls_all_complete(
+        self,
+        provider: CognitoJWKSProvider,
+        jwks_response: dict[str, Any],
+    ) -> None:
+        """Multiple concurrent get_jwks calls all complete without error."""
+        mock_get = AsyncMock(return_value=_mock_httpx_response(jwks_response))
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(mock_get)
+
+            # Simulate 5 concurrent requests
+            results = await asyncio.gather(
+                provider.get_jwks(),
+                provider.get_jwks(),
+                provider.get_jwks(),
+                provider.get_jwks(),
+                provider.get_jwks(),
+            )
+
+        # All results should be the JWKS response
+        for result in results:
+            assert result == jwks_response
+
+
+# ---------------------------------------------------------------------------
+# JWKS Provider: Timeout handling
+# ---------------------------------------------------------------------------
+
+
+class TestJWKSTimeoutHandling:
+    """Tests for JWKS endpoint timeout scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_no_cache_raises_401(
+        self,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """Timeout on JWKS fetch with no cache raises 401."""
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_instance = _make_mock_client(
+                AsyncMock(side_effect=httpx.TimeoutException("Request timed out")),
+            )
+            mock_client_cls.return_value = mock_client_instance
+
+            with pytest.raises(HTTPException) as exc_info:
+                await provider.get_jwks()
+
+            assert exc_info.value.status_code == 401
+            assert exc_info.value.detail == "Authentication service unavailable"
+            assert exc_info.value.headers is not None
+            assert exc_info.value.headers["WWW-Authenticate"] == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_stale_cache_returns_stale(
+        self,
+        provider: CognitoJWKSProvider,
+        jwks_response: dict[str, Any],
+    ) -> None:
+        """Timeout on JWKS fetch with stale cache returns stale keys."""
+        call_count = 0
+
+        async def _mock_get(*args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_httpx_response(jwks_response)
+            raise httpx.TimeoutException("Request timed out")
+
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(_mock_get)
+
+            await provider.get_jwks()
+            provider._cache_timestamp = time.monotonic() - 700
+
+            result = await provider.get_jwks()
+
+        assert result == jwks_response
+
+    @pytest.mark.asyncio
+    async def test_http_status_error_with_stale_cache(
+        self,
+        provider: CognitoJWKSProvider,
+        jwks_response: dict[str, Any],
+    ) -> None:
+        """HTTP 500 on JWKS fetch with stale cache returns stale keys."""
+        call_count = 0
+
+        async def _mock_get(*args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_httpx_response(jwks_response)
+            return _mock_httpx_response({}, status_code=500)
+
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(_mock_get)
+
+            await provider.get_jwks()
+            provider._cache_timestamp = time.monotonic() - 700
+
+            result = await provider.get_jwks()
+
+        assert result == jwks_response
+
+
+# ---------------------------------------------------------------------------
+# get_signing_key edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestGetSigningKeyEdgeCases:
+    """Tests for get_signing_key with malformed tokens and missing kid."""
+
+    @pytest.mark.asyncio
+    async def test_completely_malformed_token_raises_401(
+        self,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """Completely non-JWT string raises 401 from get_signing_key."""
+        with pytest.raises(HTTPException) as exc_info:
+            await provider.get_signing_key("this-is-not-a-jwt")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid or expired token"
+        assert exc_info.value.headers is not None
+        assert exc_info.value.headers["WWW-Authenticate"] == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_token_without_kid_in_header_raises_401(
+        self,
+        provider: CognitoJWKSProvider,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Token with no kid in header raises 401."""
+        # Create a token without a kid header
+        now = datetime.now(tz=UTC)
+        claims: dict[str, Any] = {
+            "sub": str(uuid.uuid4()),
+            "aud": TEST_CLIENT_ID,
+            "iss": TEST_ISSUER,
+            "token_use": "id",
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        }
+        # Encode without kid header
+        token = jose_jwt.encode(
+            claims,
+            _private_key_to_pem(rsa_key),
+            algorithm="RS256",
+            # No kid in headers
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await provider.get_signing_key(token)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid or expired token"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_token_raises_401(
+        self,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """Empty string token raises 401 from get_signing_key."""
+        with pytest.raises(HTTPException) as exc_info:
+            await provider.get_signing_key("")
+
+        assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# verify_cognito_token: sub claim edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCognitoTokenSubClaim:
+    """Tests for verify_cognito_token sub claim validation."""
+
+    @pytest.mark.asyncio
+    async def test_missing_sub_claim_raises_401(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Token without sub claim raises 401."""
+        token = _make_token(rsa_key, TEST_KID, omit_sub=True)
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.status_code == 401
+            assert exc_info.value.detail == "Invalid or expired token"
+            assert exc_info.value.headers is not None
+            assert exc_info.value.headers["WWW-Authenticate"] == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_non_uuid_sub_claim_raises_401(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Token with non-UUID sub claim raises 401."""
+        token = _make_token(rsa_key, TEST_KID, sub="not-a-uuid-value")
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.status_code == 401
+            assert exc_info.value.detail == "Invalid or expired token"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_sub_claim_raises_401(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Token with empty string sub claim raises 401."""
+        token = _make_token(rsa_key, TEST_KID, sub="")
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.status_code == 401
+            assert exc_info.value.detail == "Invalid or expired token"
+
+
+# ---------------------------------------------------------------------------
+# verify_cognito_token: extra claims and happy path details
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCognitoTokenExtraClaims:
+    """Tests for verify_cognito_token with extra/unusual claims."""
+
+    @pytest.mark.asyncio
+    async def test_token_with_extra_claims_still_valid(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Token with additional custom claims still validates successfully."""
+        test_sub = str(uuid.uuid4())
+        token = _make_token(
+            rsa_key,
+            TEST_KID,
+            sub=test_sub,
+            extra_claims={
+                "custom:role": "admin",
+                "cognito:groups": ["users", "admins"],
+                "given_name": "Test",
+                "family_name": "User",
+            },
+        )
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            claims = await verify_cognito_token(token)
+
+        assert claims["sub"] == test_sub
+        assert claims["custom:role"] == "admin"
+        assert claims["cognito:groups"] == ["users", "admins"]
+
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_all_standard_claims(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Valid token claims dict contains all expected standard fields."""
+        test_sub = str(uuid.uuid4())
+        token = _make_token(rsa_key, TEST_KID, sub=test_sub)
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            claims = await verify_cognito_token(token)
+
+        assert "sub" in claims
+        assert "aud" in claims
+        assert "iss" in claims
+        assert "token_use" in claims
+        assert "exp" in claims
+        assert "iat" in claims
+        assert "email" in claims
+        assert claims["iss"] == TEST_ISSUER
+        assert claims["aud"] == TEST_CLIENT_ID
+
+    @pytest.mark.asyncio
+    async def test_token_use_missing_raises_401(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Token without token_use claim raises 401."""
+        now = datetime.now(tz=UTC)
+        claims: dict[str, Any] = {
+            "sub": str(uuid.uuid4()),
+            "aud": TEST_CLIENT_ID,
+            "iss": TEST_ISSUER,
+            # token_use intentionally omitted
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        }
+        token = jose_jwt.encode(
+            claims,
+            _private_key_to_pem(rsa_key),
+            algorithm="RS256",
+            headers={"kid": TEST_KID},
+        )
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.status_code == 401
+            assert exc_info.value.detail == "Invalid or expired token"
+
+
+# ---------------------------------------------------------------------------
+# WWW-Authenticate header verification on all 401 paths
+# ---------------------------------------------------------------------------
+
+
+class TestWWWAuthenticateHeader:
+    """Verify WWW-Authenticate: Bearer header is present on all 401 responses."""
+
+    @pytest.mark.asyncio
+    async def test_expired_token_has_www_authenticate_header(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """401 for expired token includes WWW-Authenticate: Bearer."""
+        token = _make_token(rsa_key, TEST_KID, exp_delta=timedelta(hours=-1))
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.headers is not None
+            assert exc_info.value.headers.get("WWW-Authenticate") == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_wrong_audience_has_www_authenticate_header(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """401 for wrong audience includes WWW-Authenticate: Bearer."""
+        token = _make_token(rsa_key, TEST_KID, aud="wrong-client")
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.headers is not None
+            assert exc_info.value.headers.get("WWW-Authenticate") == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_use_has_www_authenticate_header(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """401 for token_use=access includes WWW-Authenticate: Bearer."""
+        token = _make_token(rsa_key, TEST_KID, token_use="access")
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.headers is not None
+            assert exc_info.value.headers.get("WWW-Authenticate") == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_no_cache_unreachable_has_www_authenticate_header(
+        self,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """401 for unreachable JWKS (no cache) includes WWW-Authenticate."""
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(
+                AsyncMock(side_effect=httpx.ConnectError("Connection refused")),
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await provider.get_jwks()
+
+            assert exc_info.value.headers is not None
+            assert exc_info.value.headers.get("WWW-Authenticate") == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_kid_not_found_after_refresh_has_www_authenticate_header(
+        self,
+        rsa_key: RSAPrivateKey,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """401 for kid not found after refresh includes WWW-Authenticate."""
+        token = _make_token(rsa_key, "nonexistent-kid")
+        jwks: dict[str, Any] = {"keys": [_private_key_to_jwk(rsa_key, TEST_KID)]}
+
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(
+                AsyncMock(return_value=_mock_httpx_response(jwks)),
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await provider.get_signing_key(token)
+
+            assert exc_info.value.headers is not None
+            assert exc_info.value.headers.get("WWW-Authenticate") == "Bearer"
+
+
+# ---------------------------------------------------------------------------
+# Error message content verification
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMessageContent:
+    """Verify exact error messages on all failure paths."""
+
+    @pytest.mark.asyncio
+    async def test_expired_token_exact_message(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Expired token produces exactly 'Invalid or expired token'."""
+        token = _make_token(rsa_key, TEST_KID, exp_delta=timedelta(hours=-1))
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.detail == "Invalid or expired token"
+
+    @pytest.mark.asyncio
+    async def test_wrong_signature_exact_message(
+        self,
+        rsa_key: RSAPrivateKey,
+        rsa_key_2: RSAPrivateKey,
+    ) -> None:
+        """Wrong signature produces exactly 'Invalid or expired token'."""
+        token = _make_token(rsa_key_2, TEST_KID)
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.detail == "Invalid or expired token"
+
+    @pytest.mark.asyncio
+    async def test_wrong_issuer_exact_message(
+        self,
+        rsa_key: RSAPrivateKey,
+    ) -> None:
+        """Wrong issuer produces exactly 'Invalid or expired token'."""
+        token = _make_token(rsa_key, TEST_KID, iss="https://wrong-issuer.example.com")
+
+        with patch("app.core.auth._jwks_provider") as mock_provider, \
+             patch("app.core.auth.settings") as mock_settings:
+            mock_provider.get_signing_key = AsyncMock(
+                return_value=_private_key_to_jwk(rsa_key, TEST_KID),
+            )
+            mock_provider.issuer_url = TEST_ISSUER
+            mock_settings.cognito_app_client_id = TEST_CLIENT_ID
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_cognito_token(token)
+
+            assert exc_info.value.detail == "Invalid or expired token"
+
+    @pytest.mark.asyncio
+    async def test_unreachable_jwks_no_cache_exact_message(
+        self,
+        provider: CognitoJWKSProvider,
+    ) -> None:
+        """Unreachable JWKS with no cache produces 'Authentication service unavailable'."""
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = _make_mock_client(
+                AsyncMock(side_effect=httpx.ConnectError("Connection refused")),
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await provider.get_jwks()
+
+            assert exc_info.value.detail == "Authentication service unavailable"
+
+
+# ---------------------------------------------------------------------------
+# CognitoJWKSProvider: issuer_url and jwks_url construction
+# ---------------------------------------------------------------------------
+
+
+class TestProviderURLConstruction:
+    """Tests for correct URL construction in CognitoJWKSProvider."""
+
+    def test_issuer_url_format(self) -> None:
+        """issuer_url follows Cognito format without trailing slash."""
+        provider = CognitoJWKSProvider(
+            region="us-west-2",
+            user_pool_id="us-west-2_AbcDef",
+        )
+        expected = "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_AbcDef"
+        assert provider.issuer_url == expected
+        assert not provider.issuer_url.endswith("/")
+
+    def test_jwks_url_format(self) -> None:
+        """_jwks_url points to the well-known JWKS endpoint."""
+        provider = CognitoJWKSProvider(
+            region="us-west-2",
+            user_pool_id="us-west-2_AbcDef",
+        )
+        expected = (
+            "https://cognito-idp.us-west-2.amazonaws.com/"
+            "us-west-2_AbcDef/.well-known/jwks.json"
+        )
+        assert provider._jwks_url == expected
+
+    def test_custom_ttl(self) -> None:
+        """Cache TTL can be customized via constructor."""
+        provider = CognitoJWKSProvider(
+            region="eu-west-1",
+            user_pool_id="eu-west-1_Test",
+            cache_ttl=300.0,
+        )
+        assert provider._cache_ttl == 300.0
+
+
+# ---------------------------------------------------------------------------
+# get_jwks_provider accessor
+# ---------------------------------------------------------------------------
+
+
+class TestGetJWKSProvider:
+    """Tests for the get_jwks_provider function."""
+
+    def test_returns_provider_instance(self) -> None:
+        """get_jwks_provider returns a CognitoJWKSProvider instance."""
+        provider = get_jwks_provider()
+        assert isinstance(provider, CognitoJWKSProvider)
+
+    def test_returns_same_singleton(self) -> None:
+        """get_jwks_provider returns the same instance each time."""
+        provider_1 = get_jwks_provider()
+        provider_2 = get_jwks_provider()
+        assert provider_1 is provider_2
+
+
+# ---------------------------------------------------------------------------
+# JWKS Provider: stale cache logging
+# ---------------------------------------------------------------------------
+
+
+class TestStaleCacheLogging:
+    """Tests for stale cache warning log behavior."""
+
+    @pytest.mark.asyncio
+    async def test_stale_cache_fallback_logs_warning(
+        self,
+        provider: CognitoJWKSProvider,
+        jwks_response: dict[str, Any],
+    ) -> None:
+        """Using stale cache logs a warning with cache age and URL."""
+        call_count = 0
+
+        async def _mock_get(*args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_httpx_response(jwks_response)
+            raise httpx.ConnectError("Connection refused")
+
+        with patch("app.core.auth.httpx.AsyncClient") as mock_client_cls, \
+             patch("app.core.auth.logger") as mock_logger:
+            mock_client_cls.return_value = _make_mock_client(_mock_get)
+
+            await provider.get_jwks()
+            provider._cache_timestamp = time.monotonic() - 700
+
+            await provider.get_jwks()
+
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "stale cache" in warning_msg.lower()

--- a/backend/tests/test_dependencies.py
+++ b/backend/tests/test_dependencies.py
@@ -1,38 +1,30 @@
 """Tests for the dependency injection module.
 
-Verifies get_current_user stub returns 501 and get_db yields a session.
+Verifies get_current_user requires authentication and get_db yields a session.
 """
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
-from fastapi import HTTPException
 
-from app.dependencies import get_current_user
-
-
-@pytest.mark.asyncio
-async def test_get_current_user_raises_501() -> None:
-    """get_current_user stub must raise 501 Not Implemented."""
-    with pytest.raises(HTTPException) as exc_info:
-        await get_current_user()
-    assert exc_info.value.status_code == 501
-    assert "not yet implemented" in exc_info.value.detail.lower()
-
-
-@pytest.mark.asyncio
-async def test_get_current_user_detail_message() -> None:
-    """get_current_user detail must indicate auth is not implemented."""
-    with pytest.raises(HTTPException) as exc_info:
-        await get_current_user()
-    assert "Authentication" in exc_info.value.detail or "authentication" in exc_info.value.detail
+from app.dependencies import get_current_user, get_db
 
 
 @pytest.mark.asyncio
 async def test_get_db_is_async_generator() -> None:
     """get_db must be an async generator function."""
-    import inspect
-
-    from app.dependencies import get_db
-
     assert inspect.isasyncgenfunction(get_db)
+
+
+def test_get_current_user_is_coroutine_function() -> None:
+    """get_current_user must be an async function (coroutine)."""
+    assert inspect.iscoroutinefunction(get_current_user)
+
+
+def test_get_current_user_has_dependencies() -> None:
+    """get_current_user must depend on credentials and db."""
+    params = inspect.signature(get_current_user).parameters
+    assert "credentials" in params
+    assert "db" in params

--- a/docs/features/cognito-auth-middleware.md
+++ b/docs/features/cognito-auth-middleware.md
@@ -1,0 +1,312 @@
+# Cognito Auth Middleware
+
+> Authenticates every protected API request by verifying AWS Cognito RS256 JWT tokens against cached JWKS keys and resolving the caller's database profile.
+
+**Status**: Released
+**Added in**: Phase 1 (P01-03)
+**Platforms**: Backend
+**GitHub Issue**: #5
+
+---
+
+## Overview
+
+Cognito Auth Middleware replaces the placeholder `get_current_user` stub (which returned HTTP 501) with a fully functional JWT authentication dependency. Every protected endpoint in Ember injects `Depends(get_current_user)` to identify the calling user. This middleware is the security foundation for the entire API -- without it, no endpoint can authenticate requests, enforce data isolation, or extract the `user_id` from the token.
+
+The middleware verifies RS256-signed Cognito ID tokens by fetching the JSON Web Key Set (JWKS) from the Cognito well-known endpoint, caching those keys in memory with a 10-minute TTL, and using them to validate the token's signature, expiry, audience, issuer, and `token_use` claims. On successful verification, it extracts the `sub` claim (a UUID), looks up the corresponding `Profile` row in the database, and returns the ORM object. If any step fails, a 401 response is returned with an intentionally vague error message to prevent information leakage.
+
+This feature does not implement user registration, login, token refresh, or authorization (role-based access control). Registration and login are handled by AWS Cognito directly. Token refresh is handled by the mobile clients via the Cognito SDK. Authorization checks (e.g., "does this character belong to this user?") are implemented in individual route features.
+
+---
+
+## Architecture
+
+### Authentication Flow
+
+The end-to-end flow for every authenticated request:
+
+1. The client sends an HTTP request with the header `Authorization: Bearer <jwt_token>`.
+2. FastAPI's `HTTPBearer` security scheme extracts the token string. If the header is missing or malformed, FastAPI returns 401 automatically with `{"detail": "Not authenticated"}`.
+3. `verify_cognito_token(token)` is called with the raw JWT string.
+4. The `CognitoJWKSProvider` singleton fetches JWKS keys from Cognito (or returns cached keys if the cache is fresh).
+5. The token header is decoded (unverified) to extract the `kid` (Key ID).
+6. The matching public key is found in the JWKS response by `kid`.
+7. `jose.jwt.decode()` verifies the RS256 signature, checks `exp` (expiry), `aud` (audience matches `COGNITO_APP_CLIENT_ID`), and `iss` (issuer matches the Cognito user pool URL).
+8. The `token_use` claim is validated as `"id"` (Ember uses ID tokens, not access tokens).
+9. The `sub` claim is extracted and validated as a UUID.
+10. A database query looks up `SELECT * FROM profiles WHERE id = {sub}`.
+11. If a profile is found, it is returned as the `Profile` ORM object. If not, a 401 "User not found" error is raised.
+
+```
+Authorization: Bearer <jwt>
+         |
+         v
+  HTTPBearer extracts token
+         |
+         v
+  verify_cognito_token(token)
+     |
+     +--> CognitoJWKSProvider.get_signing_key(token)
+     |        +--> get_jwks() with 10-min TTL cache
+     |        +--> Force refresh on kid miss (key rotation)
+     |        +--> Stale cache fallback on endpoint unreachable
+     |
+     +--> jose.jwt.decode(token, key, RS256, audience, issuer)
+     +--> Validate token_use == "id"
+     +--> Validate sub is a UUID
+         |
+         v
+  DB lookup: SELECT * FROM profiles WHERE id = {sub}
+         |
+         +--> Found: return Profile
+         +--> Not found: raise 401 "User not found"
+```
+
+### JWKS Caching Strategy
+
+The JWKS cache is an in-memory dict stored on the `CognitoJWKSProvider` singleton. This is intentionally simple because the JWKS response is small (typically 2 keys, under 1 KB) and each ECS task process handles its own requests.
+
+**Cache lifecycle**:
+
+- **First request**: Cache is empty. JWKS is fetched from Cognito. Cache is populated. Timestamp is recorded using `time.monotonic()`.
+- **Subsequent requests (within 10 minutes)**: Cache is fresh. Cached keys are returned immediately without an HTTP call.
+- **After 10 minutes**: Cache is stale. JWKS is re-fetched. Cache is updated.
+- **Key rotation (kid not found)**: A force refresh is triggered. If the `kid` is found in the new keys, verification proceeds. If still not found, the token is rejected. Only one refresh attempt per `get_signing_key` call prevents infinite loops.
+- **Endpoint unreachable (with stale cache)**: Stale cached keys are used and a warning is logged. JWKS keys change approximately every 30 days, so stale keys are almost certainly still valid.
+- **Endpoint unreachable (no cache)**: All authenticated requests fail with 401 "Authentication service unavailable".
+
+**Why stale cache over hard failure**: Rejecting all requests during a transient network issue would cause a complete service outage. Serving stale keys for a few minutes is far less risky because key rotation happens approximately every 30 days.
+
+**TTL details**:
+- Default: 600 seconds (10 minutes)
+- Time source: `time.monotonic()` (immune to system clock adjustments)
+- HTTP timeout: 5 seconds per JWKS fetch to prevent hanging
+
+### Why ID Tokens (not Access Tokens)
+
+Cognito issues two token types. Ember validates `token_use == "id"` because:
+
+- The ID token `sub` claim is the user's UUID, which maps directly to `profiles.id`.
+- The ID token contains the user's email and other attributes, useful for profile operations.
+- Access tokens are used for OAuth2 resource server authorization patterns, which Ember does not need (the backend is both the auth and resource server).
+
+### Database Tables Involved
+
+| Table | Operation | Notes |
+|-------|-----------|-------|
+| `profiles` | SELECT | Lookup by `id = JWT sub claim`. Read-only -- no writes. |
+
+No new tables are created or modified by this feature. It reads from the existing `profiles` table defined in P01-02.
+
+---
+
+## Error Responses
+
+All error responses from the auth middleware follow the standard Ember error format `{"detail": "..."}`.
+
+All 401 responses include the `WWW-Authenticate: Bearer` header as required by RFC 6750.
+
+| Scenario | Status | Response Body |
+|----------|--------|---------------|
+| No `Authorization` header | 401 | `{"detail": "Not authenticated"}` |
+| `Authorization` header without `Bearer` prefix | 401 | `{"detail": "Not authenticated"}` |
+| Token is malformed (cannot parse header) | 401 | `{"detail": "Invalid or expired token"}` |
+| Token signature is invalid | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `kid` does not match any JWKS key | 401 | `{"detail": "Invalid or expired token"}` |
+| Token has expired (`exp` claim in the past) | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `aud` does not match `COGNITO_APP_CLIENT_ID` | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `iss` does not match Cognito user pool URL | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `token_use` claim is not `"id"` | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `sub` claim missing or not a UUID | 401 | `{"detail": "Invalid or expired token"}` |
+| Valid token but `sub` does not match any `profiles.id` | 401 | `{"detail": "User not found"}` |
+| JWKS endpoint unreachable and no cache exists | 401 | `{"detail": "Authentication service unavailable"}` |
+
+The generic "Invalid or expired token" message is intentionally used for all token-level failures. This prevents information leakage about the specific reason for rejection. "User not found" is a distinct case because the token itself is valid but the user has no profile in the database (e.g., registration incomplete or account deleted).
+
+---
+
+## Configuration
+
+No new configuration variables were introduced by this feature. The required settings already exist from P01-01:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `COGNITO_USER_POOL_ID` | str | `""` | AWS Cognito user pool ID |
+| `COGNITO_APP_CLIENT_ID` | str | `""` | AWS Cognito app client ID |
+| `AWS_REGION` | str | `us-east-1` | AWS region for Cognito endpoint URL |
+
+Two URLs are derived at runtime from these settings (they are not stored as separate configuration):
+
+- **JWKS URL**: `https://cognito-idp.{AWS_REGION}.amazonaws.com/{COGNITO_USER_POOL_ID}/.well-known/jwks.json`
+- **Issuer URL**: `https://cognito-idp.{AWS_REGION}.amazonaws.com/{COGNITO_USER_POOL_ID}`
+
+---
+
+## Usage in Routes
+
+Any route that requires authentication injects the `get_current_user` dependency via FastAPI's `Depends()`:
+
+```python
+from fastapi import APIRouter, Depends
+from app.dependencies import get_current_user
+from app.models.profile import Profile
+
+router = APIRouter()
+
+@router.get("/api/v1/example")
+async def example_endpoint(
+    current_user: Profile = Depends(get_current_user),
+):
+    # current_user is the authenticated Profile ORM object
+    # current_user.id is the UUID matching the JWT sub claim
+    return {"user_id": str(current_user.id)}
+```
+
+The health endpoint (`GET /api/v1/health`) does not use `Depends(get_current_user)` and remains public.
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `backend/app/core/auth.py` | `CognitoJWKSProvider` class, `verify_cognito_token` function, module-level singleton |
+| `backend/app/dependencies.py` | `get_current_user` dependency (modified from 501 stub to real implementation) |
+| `backend/app/config.py` | Settings (unchanged -- already had required Cognito settings) |
+
+### `backend/app/core/auth.py`
+
+This module is placed in `core/` (not `utils/`) because authentication is an application-wide concern, consistent with the existing `core/logging.py` pattern from P01-01.
+
+**`CognitoJWKSProvider`** -- manages JWKS fetching and caching:
+- `get_jwks(force_refresh=False)` -- fetches JWKS with cache-first strategy
+- `get_signing_key(token)` -- extracts `kid` from token header and finds the matching JWK
+- `_find_key(jwks, kid)` -- static method to search the JWKS keys array
+- `_cache_is_fresh()` -- checks if cache exists and is within TTL
+- `issuer_url` -- property returning the expected JWT issuer URL
+
+**`verify_cognito_token(token)`** -- verifies a JWT and returns its claims dict. Validates signature, expiry, audience, issuer, `token_use`, and `sub` format.
+
+**`get_jwks_provider()`** -- returns the module-level singleton (useful for testing).
+
+**`_jwks_provider`** -- module-level singleton instantiated with `settings.aws_region` and `settings.cognito_user_pool_id`.
+
+### `backend/app/dependencies.py`
+
+The `get_current_user` function:
+1. Accepts `credentials` from `HTTPBearer()` and `db` from `get_db()` via `Depends()`.
+2. Calls `verify_cognito_token(credentials.credentials)`.
+3. Converts `claims["sub"]` to `uuid.UUID`.
+4. Queries `profiles` for a matching row.
+5. Returns the `Profile` ORM object or raises 401 "User not found".
+
+The `get_db` dependency is unchanged from P01-01.
+
+---
+
+## Testing
+
+### Coverage Summary
+
+| Module | Line Coverage | Branch Coverage |
+|--------|---------------|-----------------|
+| `app/core/auth.py` | 100% | 100% |
+| `app/dependencies.py` | 92% | 100% |
+| **Combined** | **98%** | **100%** |
+
+The only uncovered lines (26-27 of `dependencies.py`) are the `get_db()` body, which is a database session dependency unrelated to the auth feature.
+
+### Test Files
+
+| Test File | Count | What It Covers |
+|-----------|-------|----------------|
+| `tests/test_auth.py` | 17 | JWKS provider caching, TTL, force refresh, stale cache, token verification (valid, expired, wrong signature, wrong audience, wrong issuer, wrong token_use, malformed) |
+| `tests/test_auth_extended.py` | 40 | `_find_key` edge cases, TTL boundary conditions (599s/600s), multiple key rotation, concurrent JWKS refresh, timeout handling, `get_signing_key` edge cases, sub claim validation, WWW-Authenticate header verification, error message exactness, provider URL construction, singleton accessor |
+| `tests/test_auth_dependency.py` | 7 | `get_current_user` with valid token + profile, valid token + no profile, missing auth header, non-Bearer auth, invalid token |
+| `tests/test_auth_dependency_extended.py` | 10 | DB session error handling, HTTPBearer edge cases (empty bearer, whitespace, malformed), WWW-Authenticate on "User not found", multiple sequential requests, health endpoint with invalid bearer |
+| `tests/test_dependencies.py` | 3 | Dependency introspection (coroutine check, parameter types) |
+
+**Total**: 77 auth-specific tests passing, 0 failures.
+
+### Test Approach
+
+Tests generate a real RSA key pair (2048-bit) at test-module scope using the `cryptography` library. A mock JWKS response is constructed from the public key. Test JWTs are signed with the private key using `python-jose`. The httpx client is mocked to return the JWKS JSON. This approach:
+
+- Does not require network access or real Cognito endpoints.
+- Tests the full verification pipeline (JWKS fetch, key extraction, signature verification, claim validation).
+- Allows creating tokens with various invalid states (expired, wrong audience, wrong key, etc.).
+
+For dependency integration tests, the FastAPI test client is used with `get_db` overridden to inject a mock `AsyncSession`. A test `Profile` row with a known UUID (matching the `sub` in the test JWT) is used to verify the full dependency chain.
+
+### Running Tests
+
+Auth tests only:
+
+```bash
+cd backend && python -m pytest tests/test_auth.py tests/test_auth_extended.py tests/test_auth_dependency.py tests/test_auth_dependency_extended.py tests/test_dependencies.py -v
+```
+
+Full backend suite:
+
+```bash
+cd backend && python -m pytest tests/ -v --ignore=tests/test_migration.py
+```
+
+Code quality:
+
+```bash
+cd backend && ruff check app/core/auth.py app/dependencies.py
+cd backend && mypy app/core/auth.py app/dependencies.py
+```
+
+---
+
+## Known Limitations
+
+- **No offline token validation**: The first authenticated request after process startup requires a network call to the Cognito JWKS endpoint. If the endpoint is unreachable and no cache exists, all authentication fails.
+- **In-memory cache is per-process**: Each ECS Fargate task process maintains its own JWKS cache. There is no shared cache across processes. This is by design -- the JWKS payload is small and the worst case is one extra HTTP call per 10 minutes per process.
+- **No token refresh logic**: The backend does not refresh tokens. Mobile clients are responsible for refreshing expired tokens via the Cognito SDK and resending the request.
+- **No authorization**: This feature authenticates (who are you?) but does not authorize (what can you do?). Authorization checks are implemented in individual route features.
+- **Profile must pre-exist**: A valid Cognito token for a user with no `profiles` row returns 401 "User not found". Profile creation happens during registration, which is a separate feature.
+
+---
+
+## Design Decisions
+
+### `CognitoJWKSProvider` as a class (not a module-level dict)
+
+The cache requires both data and a TTL timestamp, plus force-refresh logic for key rotation. A class encapsulates this cleanly and is easier to test (instances can be created with custom settings without patching module globals). The module-level singleton provides identical runtime performance to a module-level dict.
+
+### Auth module at `core/auth.py` (not `utils/cognito.py`)
+
+The `docs/standards/backend.md` reference shows `utils/cognito.py`, but the actual project structure from P01-01 established `core/` for application-wide concerns (`core/logging.py`). Authentication is an application-wide concern, not a stateless utility, so `core/auth.py` follows the established pattern.
+
+### Generic error messages for token failures
+
+All token-level failures return "Invalid or expired token" regardless of the specific cause. This prevents attackers from distinguishing between expired tokens, wrong signatures, and wrong audiences, reducing information leakage.
+
+### `HTTPBearer` from `fastapi.security`
+
+This is the standard FastAPI pattern. It automatically extracts the Bearer token, returns 401 for missing/malformed headers, and adds the security scheme to OpenAPI documentation (enabling the Swagger UI "Authorize" button).
+
+---
+
+## Extending This Feature
+
+To add additional claims extraction (e.g., reading the user's email from the token), modify `verify_cognito_token` in `backend/app/core/auth.py` to extract the desired claim from the `claims` dict after verification. The claims dict contains all standard Cognito ID token claims (`sub`, `email`, `email_verified`, `name`, `cognito:username`, etc.).
+
+To add a secondary authentication scheme (e.g., API keys), create a new dependency function alongside `get_current_user` in `backend/app/dependencies.py` and inject it via `Depends()` in the routes that accept it. Do not modify `get_current_user` -- it should remain Cognito-only.
+
+To adjust the JWKS cache TTL, modify the `cache_ttl` parameter when instantiating `CognitoJWKSProvider` in `backend/app/core/auth.py`. The default is 600.0 seconds (10 minutes). A shorter TTL means more frequent JWKS fetches; a longer TTL means slower response to key rotation.
+
+To support access tokens in addition to ID tokens, modify the `token_use` validation in `verify_cognito_token` to accept both `"id"` and `"access"`. Note that access tokens may have a different `aud` claim format.
+
+---
+
+## Related Documentation
+
+- [Project Setup](./project-setup.md) -- the scaffold this feature builds on
+- [Database Schema](./database-schema.md) -- the `profiles` table this feature reads from
+- [Database Schema and API Endpoints](../04-veri-api.md) -- authoritative source for table definitions
+- [Security and Performance](../08-guvenlik-performans.md) -- JWT strategy, rate limiting
+- [Backend Standards](../standards/backend.md) -- coding conventions

--- a/docs/pipeline/cognito-auth-middleware-architect.handoff.md
+++ b/docs/pipeline/cognito-auth-middleware-architect.handoff.md
@@ -1,0 +1,71 @@
+# Architect Handoff: Cognito Auth Middleware
+
+**Date**: 2026-02-23
+**Agent**: architect
+**Status**: COMPLETE
+**Feature ID**: P01-03
+**GitHub Issue**: #5
+**Layer**: backend
+
+---
+
+## What Was Designed
+
+AWS Cognito JWT authentication middleware for FastAPI that replaces the existing `get_current_user` stub (which returns HTTP 501) with real RS256 JWT verification. The middleware fetches JWKS keys from the Cognito well-known endpoint, caches them with a 10-minute TTL, verifies token signature/expiry/audience/issuer claims, validates `token_use=id`, extracts the `sub` claim as the user UUID, and looks up the corresponding `Profile` row in the database. It handles key rotation gracefully by force-refreshing JWKS when a `kid` is not found in the cache.
+
+## Spec Location
+
+`shared/feature-specs/cognito-auth-middleware.md`
+
+## Key Decisions
+
+- **`CognitoJWKSProvider` class instead of simple module-level dict**: The cache requires both data and a TTL timestamp, plus force-refresh logic for key rotation. A class encapsulates this cleanly and is easier to test than module-level globals. A module-level singleton provides identical runtime performance.
+- **`token_use` validated as `"id"` (not `"access"`)**: Ember uses Cognito ID tokens because they contain the `sub` UUID mapping to `profiles.id` and user attributes (email, name). Access tokens are for OAuth2 resource server patterns that Ember does not use.
+- **Auth module placed at `core/auth.py`** (not `utils/cognito.py`): Consistent with the existing `core/logging.py` pattern from P01-01. Authentication is an application-wide concern, not a stateless utility. The standards doc shows `utils/cognito.py` as a reference, but the implemented project structure favors `core/`.
+- **Stale cache preferred over hard failure**: When the Cognito JWKS endpoint is unreachable, stale cached keys are used (with a warning log) rather than rejecting all requests. JWKS keys change approximately every 30 days; a few minutes of staleness is acceptable.
+- **Force refresh on `kid` miss**: When a token's `kid` is not in the cached JWKS, one forced refresh is attempted before rejecting the token. This handles Cognito key rotation without waiting for TTL expiry.
+- **`HTTPBearer` from `fastapi.security`**: Standard FastAPI pattern that handles header extraction, missing-header 401s, and OpenAPI documentation automatically.
+- **No changes to `config.py`**: The required settings (`cognito_user_pool_id`, `cognito_app_client_id`, `aws_region`) already exist from P01-01.
+- **Generic error messages for token failures**: All token-level failures return "Invalid or expired token" to prevent information leakage about the specific rejection reason. Only "User not found" is distinct (valid token, missing profile).
+
+## Assumptions Made
+
+- P01-01 is complete: `config.py` has `cognito_user_pool_id`, `cognito_app_client_id`, `aws_region` settings; `dependencies.py` has the `get_current_user` stub and `get_db`; `core/` directory exists with `logging.py`.
+- P01-02 is complete: The `Profile` model exists with `id: Mapped[uuid.UUID]` as the PK (Cognito sub).
+- `python-jose[cryptography]` and `httpx` are already in `requirements.txt` (verified -- they are).
+- The mobile clients will send Cognito ID tokens (not access tokens) in the `Authorization: Bearer` header.
+- The `profiles` table is pre-populated for authenticated users (profile creation happens during registration, which is a separate feature).
+
+## Dependencies
+
+- **Requires**: P01-01 (project-setup), P01-02 (database-schema)
+- **Blocks**: P01-04 (character CRUD), P01-05 (basic messaging), and all subsequent features that use `Depends(get_current_user)`
+
+## File Manifest
+
+```
+Backend:
+  CREATE  backend/app/core/auth.py
+  MODIFY  backend/app/dependencies.py
+  CREATE  backend/tests/test_auth.py
+  CREATE  backend/tests/test_auth_dependency.py
+
+Shared:
+  CREATE  shared/feature-specs/cognito-auth-middleware.md
+  CREATE  docs/pipeline/cognito-auth-middleware-architect.handoff.md
+```
+
+## Notes for Developers
+
+- **Read the full spec first**: `shared/feature-specs/cognito-auth-middleware.md` -- it contains the complete authentication flow, JWKS caching strategy, all error scenarios, and all 24 test scenarios.
+- **Start with `core/auth.py`**: Implement `CognitoJWKSProvider` and `verify_cognito_token` first. Then modify `dependencies.py` to use them.
+- **RSA key generation for tests**: Use `cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key()` to create test keys. Build a mock JWKS from the public key. Sign test JWTs with the private key using `python-jose`.
+- **UUID conversion**: The `sub` claim is a string. Convert with `uuid.UUID(claims["sub"])` before querying `profiles.id`.
+- **Use `time.monotonic()`** for cache TTL, not `time.time()`.
+- **`HTTPBearer` import**: `from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer`.
+- **Preserve `get_db`**: Only replace `get_current_user` in `dependencies.py`. Do not touch `get_db`.
+- **All 401 responses** must include the `WWW-Authenticate: Bearer` header (except the automatic ones from `HTTPBearer` which handle this themselves).
+
+## Next Steps
+
+backend-dev should read the spec at `shared/feature-specs/cognito-auth-middleware.md` and implement all 5 files (1 new module, 1 modification, 2 test files, plus verifying ruff/mypy pass). backend-tester should then verify all 20 acceptance criteria.

--- a/docs/pipeline/cognito-auth-middleware-backend-dev.handoff.md
+++ b/docs/pipeline/cognito-auth-middleware-backend-dev.handoff.md
@@ -1,0 +1,105 @@
+# Backend Dev Handoff: Cognito Auth Middleware
+
+**Date**: 2026-02-23
+**Agent**: backend-dev
+**Status**: COMPLETE
+**Feature ID**: P01-03
+**GitHub Issue**: #5
+
+## Implemented Files
+
+### Created
+- `backend/app/core/auth.py` -- CognitoJWKSProvider class (JWKS fetching, 10-min TTL cache, force refresh on kid miss, stale cache fallback) and verify_cognito_token function (RS256 verification, audience/issuer/token_use validation)
+- `backend/tests/test_auth.py` -- 17 unit tests covering JWKS provider caching, TTL, force refresh, stale cache, and token verification scenarios
+- `backend/tests/test_auth_dependency.py` -- 7 integration tests covering get_current_user dependency via FastAPI test client
+
+### Modified
+- `backend/app/dependencies.py` -- Replaced `get_current_user` stub (HTTP 501) with real Cognito JWT authentication: HTTPBearer token extraction, verify_cognito_token call, Profile DB lookup by sub claim UUID
+- `backend/tests/test_dependencies.py` -- Updated tests to reflect new get_current_user signature (no longer raises 501; now validates it is a coroutine with credentials and db parameters)
+
+## Endpoints Implemented
+
+No new endpoints. This feature modifies the `get_current_user` dependency injected into all protected endpoints via `Depends(get_current_user)`.
+
+**Before**: `Depends(get_current_user)` always raised HTTP 501 Not Implemented.
+**After**: `Depends(get_current_user)` verifies the Cognito JWT and returns the authenticated `Profile` ORM object.
+
+## Architecture
+
+### Authentication Flow
+```
+Authorization: Bearer <jwt>
+    |
+    v
+HTTPBearer extracts token
+    |
+    v
+verify_cognito_token(token)
+    |
+    +--> CognitoJWKSProvider.get_signing_key(token)
+    |        +--> get_jwks() with 10-min TTL cache
+    |        +--> Force refresh on kid miss (key rotation)
+    |        +--> Stale cache fallback on endpoint unreachable
+    |
+    +--> jose.jwt.decode(token, key, RS256, audience, issuer)
+    +--> Validate token_use == "id"
+    +--> Extract sub claim (UUID)
+    |
+    v
+DB lookup: SELECT * FROM profiles WHERE id = {sub}
+    |
+    +--> Found: return Profile
+    +--> Not found: raise 401 "User not found"
+```
+
+### JWKS Caching
+- 10-minute TTL using `time.monotonic()`
+- Force refresh on kid miss (handles Cognito key rotation)
+- Stale cache preferred over hard failure when endpoint unreachable
+- Module-level singleton shares cache across all requests
+
+## Test Results
+- pytest: 394 passed, 0 failed
+- ruff: clean (app/ and all new/modified test files)
+- mypy: clean (app/core/auth.py, app/dependencies.py)
+- hardcoded secrets check: clean
+
+## Test Command
+```bash
+backend/.venv/bin/python -m pytest backend/tests/test_auth.py backend/tests/test_auth_dependency.py -v
+```
+
+## Known Issues / Deviations from Spec
+- None. Implementation follows the spec exactly.
+
+## Notes for Backend Tester
+
+### Mock Setup
+- **JWKS Provider**: Patch `app.core.auth._jwks_provider` to control JWKS key responses. The provider has `get_signing_key` (returns JWK dict) and `issuer_url` (string property).
+- **Settings**: Patch `app.core.auth.settings` to set `cognito_app_client_id`.
+- **httpx**: For JWKS provider unit tests, patch `app.core.auth.httpx.AsyncClient` to mock HTTP responses.
+- **Database**: Override `get_db` dependency to inject mock AsyncSession.
+
+### RSA Key Generation
+```python
+from cryptography.hazmat.primitives.asymmetric import rsa
+private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+```
+Convert to JWK for mock JWKS, convert to PEM for signing test tokens with python-jose.
+
+### Token Creation
+Use `jose.jwt.encode()` with the private key PEM and `headers={"kid": kid}`. Set claims: sub (UUID), aud (client_id), iss (issuer_url), token_use ("id"), exp, iat.
+
+### Key Scenarios to Verify
+1. Valid token + existing profile returns Profile object
+2. Expired token returns 401 "Invalid or expired token"
+3. Wrong signature returns 401
+4. Wrong audience returns 401
+5. Wrong issuer returns 401
+6. token_use="access" returns 401
+7. Valid token + no profile returns 401 "User not found"
+8. No Authorization header returns 401 "Not authenticated"
+9. JWKS cache TTL honored (10 min)
+10. Force refresh on kid miss
+11. Stale cache used when endpoint unreachable
+12. Health endpoint remains public (no auth required)

--- a/docs/pipeline/cognito-auth-middleware-backend-test.handoff.md
+++ b/docs/pipeline/cognito-auth-middleware-backend-test.handoff.md
@@ -1,0 +1,84 @@
+# Backend Test Handoff: Cognito Auth Middleware
+
+**Date**: 2026-02-23
+**Agent**: backend-tester
+**Status**: COMPLETE
+**Feature ID**: P01-03
+**GitHub Issue**: #5
+
+## Test Files Written
+
+### Existing (written by backend-dev, reviewed by backend-tester)
+- `backend/tests/test_auth.py` -- 17 tests (JWKS provider + token verification)
+- `backend/tests/test_auth_dependency.py` -- 7 tests (get_current_user integration)
+- `backend/tests/test_dependencies.py` -- 3 tests (dependency introspection)
+
+### New (written by backend-tester)
+- `backend/tests/test_auth_extended.py` -- 40 tests
+- `backend/tests/test_auth_dependency_extended.py` -- 10 tests
+
+### Test Breakdown by Category (new tests only)
+
+| Category | Count | File |
+|----------|-------|------|
+| `_find_key` edge cases (non-list, empty, missing, non-dict entries) | 6 | test_auth_extended.py |
+| TTL boundary conditions (599s fresh, 600s stale, no-cache, just-populated) | 4 | test_auth_extended.py |
+| Multiple key rotation scenarios (3 keys, old-to-new rotation) | 2 | test_auth_extended.py |
+| Concurrent JWKS refresh (asyncio.gather) | 1 | test_auth_extended.py |
+| Timeout handling (no cache, stale cache, HTTP 500 stale cache) | 3 | test_auth_extended.py |
+| get_signing_key edge cases (malformed token, missing kid, empty token) | 3 | test_auth_extended.py |
+| Sub claim validation (missing, non-UUID, empty string) | 3 | test_auth_extended.py |
+| Extra claims / token_use missing / all standard claims present | 3 | test_auth_extended.py |
+| WWW-Authenticate header on all 401 paths | 5 | test_auth_extended.py |
+| Exact error message content verification | 4 | test_auth_extended.py |
+| Provider URL construction (issuer, jwks_url, custom TTL) | 3 | test_auth_extended.py |
+| get_jwks_provider singleton accessor | 2 | test_auth_extended.py |
+| Stale cache warning log verification | 1 | test_auth_extended.py |
+| DB session error handling | 1 | test_auth_dependency_extended.py |
+| HTTPBearer edge cases (empty bearer, whitespace, malformed header) | 4 | test_auth_dependency_extended.py |
+| WWW-Authenticate on dependency 401s (User not found) | 2 | test_auth_dependency_extended.py |
+| Multiple sequential requests / different tokens same user | 2 | test_auth_dependency_extended.py |
+| Health endpoint with invalid bearer | 1 | test_auth_dependency_extended.py |
+
+## Coverage Results
+
+| Module | Lines | Line Coverage | Branches | Branch Coverage |
+|--------|-------|---------------|----------|-----------------|
+| `app/core/auth.py` | 87 | 100% | 22 | 100% |
+| `app/dependencies.py` | 22 | 92% | 2 | 100% |
+| **Total** | **109** | **98%** | **24** | **100%** |
+
+- Lines: 98% (target: >= 80%) -- EXCEEDS
+- Branches: 100% (target: >= 70%) -- EXCEEDS
+- The only uncovered lines (26-27) are `get_db()` body, which is a database session dependency unrelated to the auth feature
+
+## Test Run Results
+
+- Total tests (all auth files): **77 passed**
+- Total tests (full backend suite): **444 passed**
+- Failed: **0**
+- Skipped: **0**
+
+## Test Command
+
+```bash
+# Auth tests only
+backend/.venv/bin/python -m pytest backend/tests/test_auth.py backend/tests/test_auth_extended.py backend/tests/test_auth_dependency.py backend/tests/test_auth_dependency_extended.py backend/tests/test_dependencies.py -v
+
+# Full suite
+backend/.venv/bin/python -m pytest backend/tests/ -v --ignore=backend/tests/test_migration.py
+```
+
+## Issues Found During Testing
+
+- None. All implementation paths work correctly per the spec.
+
+## Notes for Reviewer
+
+- The backend-dev's original 24 tests (17 unit + 7 integration) covered all spec-required scenarios (#1-#24). The 50 new tests focus on edge cases, boundary conditions, and robustness that go beyond the spec requirements.
+- `app/core/auth.py` now has 100% line AND branch coverage -- every code path is exercised.
+- All 401 responses from the auth module include the `WWW-Authenticate: Bearer` header as required by RFC 6750 -- this is verified explicitly in 5 dedicated tests.
+- The `_find_key` static method has 6 edge case tests covering non-list keys, empty arrays, missing fields, non-dict entries, and entries without kid fields.
+- Concurrent JWKS fetch behavior is tested using `asyncio.gather` with 5 simultaneous calls.
+- TTL boundary is tested at exactly 599s (fresh) and 600s (stale) to catch off-by-one errors.
+- DB session errors during profile lookup correctly propagate as unhandled exceptions (in production, uvicorn returns 500).

--- a/docs/pipeline/cognito-auth-middleware-doc.handoff.md
+++ b/docs/pipeline/cognito-auth-middleware-doc.handoff.md
@@ -1,0 +1,17 @@
+# Doc Writer Handoff: Cognito Auth Middleware
+
+**Date**: 2026-02-23
+**Agent**: doc-writer
+**Status**: COMPLETE
+
+## Documents Written
+- `docs/features/cognito-auth-middleware.md` -- main feature documentation
+- `CHANGELOG.md` -- added entry under [Unreleased]
+
+## Summary
+Documented the AWS Cognito JWT authentication middleware (P01-03), covering the full authentication flow, JWKS caching strategy with 10-minute TTL, all 12 error response scenarios with exact messages and status codes, configuration variables, the `Depends(get_current_user)` usage pattern for routes, implementation file descriptions, testing approach with 77 passing tests at 98% line coverage, and design decisions explaining why each architectural choice was made.
+
+## Notes
+- No inconsistencies found between the spec, handoff files, and implementation. The implementation follows the spec exactly as noted in the backend-dev handoff.
+- The feature doc omits iOS and Android sections because this is a backend-only feature (layer: backend).
+- The auth module lives at `core/auth.py` (not `utils/cognito.py` as referenced in the standards doc). This deviation is documented in the Design Decisions section with rationale.

--- a/docs/pipeline/cognito-auth-middleware-review.handoff.md
+++ b/docs/pipeline/cognito-auth-middleware-review.handoff.md
@@ -1,0 +1,136 @@
+# Reviewer Handoff: Cognito Auth Middleware
+
+**Date**: 2026-02-23
+**Agent**: reviewer
+**Status**: APPROVED
+**Feature ID**: P01-03
+**GitHub Issue**: #5
+**Layer**: backend
+
+## Review Summary
+
+| Category | Passed | Warnings | Issues |
+|----------|--------|----------|--------|
+| Security | 11 | 0 | 0 |
+| Architecture | 6 | 0 | 0 |
+| Code Quality | 7 | 0 | 0 |
+| Testing | 11 | 0 | 0 |
+| **Total** | **35** | **0** | **0** |
+
+## Security Checklist
+
+- [x] RS256 algorithm enforced (no "none", no HS256) -- `algorithms=["RS256"]` at auth.py:199
+- [x] JWKS fetched from official Cognito endpoint -- auth.py:48-50
+- [x] kid lookup validates key existence with force refresh on miss -- auth.py:104-152
+- [x] Token audience validated against COGNITO_APP_CLIENT_ID -- auth.py:201
+- [x] Token issuer validated against Cognito user pool URL -- auth.py:202
+- [x] token_use == "id" validated -- auth.py:212
+- [x] sub claim extracted and validated as UUID -- auth.py:220-234
+- [x] No hardcoded secrets or keys -- all grep checks clean
+- [x] 401 responses don't leak internal details -- generic "Invalid or expired token" used
+- [x] JWKS cache cannot be poisoned -- in-memory only, populated from Cognito URL
+- [x] No verify=False or verify_signature=False -- grep returned no matches
+
+## Architecture Checklist
+
+- [x] user_id from JWT only -- never from request body (grep for user_id in body: no matches)
+- [x] get_current_user returns Profile model -- dependencies.py:33
+- [x] HTTPBearer used for token extraction -- dependencies.py:21
+- [x] Async throughout (async def, httpx.AsyncClient) -- all functions async
+- [x] JWKS cache with 10-min TTL using time.monotonic() -- auth.py:40,64,87
+- [x] Stale cache preferred over hard failure -- auth.py:90-97
+
+## Code Quality Checklist
+
+- [x] No hardcoded credentials
+- [x] Error messages are user-friendly
+- [x] No TODO/FIXME in production code
+- [x] No print() in production code -- uses logging module
+- [x] ruff passes (reported by backend-dev handoff)
+- [x] mypy passes (reported by backend-dev handoff)
+- [x] Type annotations present on all functions
+
+## Test Coverage
+
+| Module | Lines | Line Coverage | Branches | Branch Coverage |
+|--------|-------|---------------|----------|-----------------|
+| `app/core/auth.py` | 87 | 100% | 22 | 100% |
+| `app/dependencies.py` | 22 | 92% | 2 | 100% |
+| **Total** | **109** | **98%** | **24** | **100%** |
+
+Target: >= 80% line coverage -- EXCEEDS (98%)
+
+## Files Reviewed
+
+**Backend Implementation**:
+- `backend/app/core/auth.py` -- PASS (CognitoJWKSProvider, verify_cognito_token, module-level singleton)
+- `backend/app/dependencies.py` -- PASS (get_current_user with HTTPBearer + Profile DB lookup)
+
+**Backend Tests**:
+- `backend/tests/test_auth.py` -- PASS (17 tests: JWKS provider + token verification)
+- `backend/tests/test_auth_extended.py` -- PASS (40 tests: edge cases, TTL boundaries, concurrent refresh)
+- `backend/tests/test_auth_dependency.py` -- PASS (7 tests: FastAPI integration, protected endpoints)
+- `backend/tests/test_auth_dependency_extended.py` -- PASS (10 tests: DB errors, HTTPBearer edge cases, WWW-Authenticate)
+- `backend/tests/test_dependencies.py` -- PASS (3 tests: dependency introspection)
+
+**Pipeline Documents**:
+- `docs/pipeline/cognito-auth-middleware-architect.handoff.md` -- reviewed
+- `docs/pipeline/cognito-auth-middleware-backend-dev.handoff.md` -- reviewed
+- `docs/pipeline/cognito-auth-middleware-backend-test.handoff.md` -- reviewed
+
+**Spec**:
+- `shared/feature-specs/cognito-auth-middleware.md` -- all 20 acceptance criteria verified
+
+## Grep Security Scan Results
+
+| Pattern | Result |
+|---------|--------|
+| `OFFSET` in backend/app/ | No matches |
+| Hardcoded secrets / api_key= | No matches (config.py uses empty defaults from env) |
+| `algorithms.*none` | No matches |
+| `verify=False` / `verify_signature=False` | No matches |
+| `user_id.*body` in routes | No matches |
+| `api_key =` with string values | No matches |
+| `secret =` with string values | No matches |
+| `password =` with string values | No matches |
+| Hardcoded `Bearer` tokens | No matches (only doc comments) |
+| `token =` with string values | No matches |
+| `TODO` / `FIXME` / `HACK` | No matches |
+| `print(` in production code | No matches |
+
+## Issues Resolved During Review
+
+- None (first-pass clean)
+
+## Warnings (Not Blocking)
+
+1. **Redundant exception type** (`backend/app/core/auth.py:89`): `except (httpx.HTTPError, httpx.TimeoutException)` -- `TimeoutException` inherits from `HTTPError` in httpx 0.28.1, making it redundant. No functional impact.
+
+2. **Duplicated RSA test helpers**: The `_generate_rsa_key`, `_private_key_to_jwk`, `_private_key_to_pem`, and `_make_token` functions are duplicated across 4 test files. Consider extracting to a shared test helper module in a future refactor. The duplication is acknowledged in test_auth_dependency.py as a trade-off for test self-containment.
+
+3. **Standards doc drift**: `docs/standards/backend.md` Section 5 shows `User.cognito_sub` as the DB lookup field, but the actual project uses `Profile.id` (the PK) as the Cognito sub. Both the spec and the implementation are internally consistent, but the standards doc reference example diverges from the actual pattern. Worth updating the standards doc in a future pass.
+
+## Spec Compliance (20 Acceptance Criteria)
+
+All 20 acceptance criteria from `shared/feature-specs/cognito-auth-middleware.md` Section 8 are verified:
+
+1. Valid token + existing profile returns Profile -- tested in test_auth_dependency.py:248
+2. Missing Authorization header returns 401 -- tested in test_auth_dependency.py:279
+3. Expired JWT returns 401 with WWW-Authenticate -- tested in test_auth.py:426
+4. Wrong signature returns 401 -- tested in test_auth.py:452
+5. Wrong audience returns 401 -- tested in test_auth.py:475
+6. Wrong issuer returns 401 -- tested in test_auth.py:496
+7. Valid token + no profile returns 401 "User not found" -- tested in test_auth_dependency.py:264
+8. token_use=access returns 401 -- tested in test_auth.py:521
+9. First request fetches JWKS -- tested in test_auth.py:170
+10. Second request within TTL uses cache -- tested in test_auth.py:192
+11. After TTL expiry, re-fetches JWKS -- tested in test_auth.py:213
+12. kid miss triggers force refresh -- tested in test_auth.py:340
+13. Stale cache used when endpoint unreachable -- tested in test_auth.py:259
+14. No cache + unreachable returns 401 -- tested in test_auth.py:296
+15. Health endpoint remains public -- tested in test_auth_dependency.py:327
+16. ruff check passes -- reported clean in backend-dev handoff
+17. mypy passes -- reported clean in backend-dev handoff
+18. All tests pass -- 77 auth tests passed, 444 total
+19. get_current_user stub removed -- verified in dependencies.py (no 501 reference)
+20. Error response format matches standards -- all 401s return {"detail": "..."} shape

--- a/shared/feature-specs/cognito-auth-middleware.md
+++ b/shared/feature-specs/cognito-auth-middleware.md
@@ -1,0 +1,607 @@
+# Feature Spec: P01-03 -- Cognito Auth Middleware
+
+**Feature ID**: P01-03
+**Phase**: 1
+**Layer**: backend
+**GitHub Issue**: #5
+**Date**: 2026-02-23
+**Author**: architect
+
+---
+
+## 1. Overview
+
+### What This Feature Does
+
+This feature replaces the `get_current_user` stub in `backend/app/dependencies.py` (which currently returns HTTP 501) with a fully functional AWS Cognito JWT authentication middleware. It verifies RS256-signed JWT tokens against the Cognito JWKS endpoint, extracts the `user_id` from the `sub` claim, looks up the corresponding `Profile` row in the database, and returns the authenticated user object. It provides JWKS key caching with a 10-minute TTL to avoid fetching keys on every request, and returns appropriate 401 errors for expired, malformed, or invalid tokens.
+
+### Why It Exists
+
+Every protected endpoint in Ember depends on `Depends(get_current_user)` to identify the calling user. Without this middleware, no endpoint can authenticate requests, enforce data isolation (user can only access their own data), or extract the `user_id` from the JWT. This is the security foundation for the entire API.
+
+### Dependencies
+
+- **Requires**: P01-01 (project-setup -- FastAPI scaffold, config, dependencies stub, httpx, python-jose in requirements.txt)
+- **Requires**: P01-02 (database-schema -- `Profile` model with `id` as Cognito sub UUID)
+- **Blocks**: P01-04 (character CRUD), P01-05 (basic messaging), and all subsequent features that use `Depends(get_current_user)`
+
+### What This Feature Does NOT Do
+
+- It does not implement user registration or login endpoints. Those are a separate feature (Cognito handles registration/login; the backend receives tokens).
+- It does not implement token refresh logic. Refresh tokens are handled by the mobile clients via the Cognito SDK.
+- It does not implement authorization (role-based access control). Authorization checks (e.g., "does this character belong to this user?") are implemented in individual route features.
+- It does not add any new database tables or columns. It reads from the existing `profiles` table.
+
+---
+
+## 2. Data Models
+
+### No New Tables
+
+This feature does not create or modify any database tables. It reads from the existing `profiles` table (defined in P01-02, documented in `docs/04-veri-api.md`).
+
+### Key Table Reference
+
+The `profiles` table has `id` as a UUID primary key, where the value is the AWS Cognito `sub` claim. The auth middleware extracts `sub` from the JWT and uses it to look up the profile:
+
+```
+profiles.id = JWT claims["sub"]   (UUID format)
+```
+
+---
+
+## 3. API Changes
+
+### No New Endpoints
+
+This feature does not introduce any new API endpoints. It modifies the behavior of the `get_current_user` dependency that existing and future endpoints inject via `Depends(get_current_user)`.
+
+### Auth Dependency Behavior Change
+
+**Before (P01-01 stub)**:
+```
+Depends(get_current_user) -> always raises HTTP 501 Not Implemented
+```
+
+**After (this feature)**:
+```
+Depends(get_current_user) -> verifies JWT, returns Profile ORM object
+```
+
+### Error Responses Produced by the Middleware
+
+All 401 responses include the `WWW-Authenticate: Bearer` header as required by RFC 6750.
+
+| Scenario | Status | Response Body |
+|----------|--------|---------------|
+| No `Authorization` header | 401 | `{"detail": "Not authenticated"}` |
+| `Authorization` header without `Bearer` prefix | 401 | `{"detail": "Not authenticated"}` |
+| Token is malformed (cannot parse header) | 401 | `{"detail": "Invalid or expired token"}` |
+| Token signature is invalid | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `kid` does not match any JWKS key | 401 | `{"detail": "Invalid or expired token"}` |
+| Token has expired (`exp` claim in the past) | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `aud` (audience) does not match `COGNITO_APP_CLIENT_ID` | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `iss` (issuer) does not match Cognito user pool URL | 401 | `{"detail": "Invalid or expired token"}` |
+| Token `token_use` claim is not `"id"` | 401 | `{"detail": "Invalid or expired token"}` |
+| Token is valid but `sub` does not match any `profiles.id` | 401 | `{"detail": "User not found"}` |
+
+The generic "Invalid or expired token" message is intentionally vague for all token-level failures. This prevents information leakage about the specific reason for rejection. The "User not found" message is a separate case because the token itself is valid but the user has no profile in the database (e.g., registration incomplete, account deleted).
+
+---
+
+## 4. Backend Logic
+
+### Authentication Flow
+
+```
+Client sends: Authorization: Bearer <jwt_token>
+                 |
+                 v
+    HTTPBearer extracts token string
+                 |
+                 v
+    verify_cognito_token(token)
+        |
+        +--> get_jwks() — fetch keys from Cognito (cached 10 min)
+        |        |
+        |        +--> Cache HIT: return cached keys
+        |        +--> Cache MISS or EXPIRED: fetch from
+        |             https://cognito-idp.{region}.amazonaws.com/{pool_id}/.well-known/jwks.json
+        |
+        +--> jwt.get_unverified_header(token) — extract kid
+        |
+        +--> Find matching key in JWKS by kid
+        |        |
+        |        +--> NOT FOUND: try JWKS refresh (key rotation scenario), then fail if still not found
+        |
+        +--> jwt.decode(token, key, algorithms=["RS256"], audience=client_id, issuer=issuer_url)
+        |
+        +--> Validate token_use == "id"
+        |
+        +--> Extract sub claim (UUID)
+                 |
+                 v
+    DB lookup: SELECT * FROM profiles WHERE id = {sub}
+                 |
+                 +--> Found: return Profile object
+                 +--> Not found: raise 401 "User not found"
+```
+
+### Module: `backend/app/core/auth.py`
+
+This module contains the JWKS fetching, caching, and token verification logic. It is placed in `core/` rather than `utils/` because authentication is an application-wide concern (not a stateless helper). The `docs/standards/backend.md` Section 1 shows `utils/cognito.py` as a reference, but the actual project structure (from P01-01) already has `core/` for application-wide concerns like logging.
+
+**Class: `CognitoJWKSProvider`**
+
+Responsibilities:
+- Fetch JWKS keys from the Cognito well-known endpoint
+- Cache keys in memory with a 10-minute TTL
+- Handle key rotation: if a token's `kid` is not found in the cached keys, force a refresh (once per request) before failing
+- Construct the Cognito issuer URL from `aws_region` and `cognito_user_pool_id`
+
+State:
+- `_jwks_cache: dict | None` -- the cached JWKS response (the full JSON with `keys` array)
+- `_cache_timestamp: float` -- `time.monotonic()` when the cache was last populated
+- `_cache_ttl: float` -- 600.0 seconds (10 minutes)
+
+Methods:
+
+```
+async def get_jwks(self, *, force_refresh: bool = False) -> dict
+    """Fetch JWKS from Cognito, using cache when available.
+
+    Args:
+        force_refresh: If True, bypass cache and fetch fresh keys.
+
+    Returns:
+        The JWKS JSON response containing the 'keys' array.
+
+    Raises:
+        HTTPException 401: If JWKS endpoint is unreachable after retries.
+    """
+```
+
+The `get_jwks` method:
+1. If `force_refresh` is False and cache is populated and cache age < 600 seconds, return cached keys.
+2. Otherwise, make an async HTTP GET to the JWKS URL using httpx.
+3. Set `timeout=5` on the httpx request to prevent hanging.
+4. On success, update `_jwks_cache` and `_cache_timestamp`.
+5. On failure (network error, non-200 status), if there is a stale cache, return it with a warning log. If there is no cache at all, raise 401 with detail "Authentication service unavailable".
+
+```
+async def get_signing_key(self, token: str) -> dict
+    """Extract the kid from the token header and find the matching JWK.
+
+    Args:
+        token: The raw JWT string.
+
+    Returns:
+        The JWK dict matching the token's kid.
+
+    Raises:
+        HTTPException 401: If kid is not found in JWKS (even after refresh).
+    """
+```
+
+The `get_signing_key` method:
+1. Decode the token header (unverified) to get the `kid`.
+2. Search the cached JWKS keys for a matching `kid`.
+3. If not found, call `get_jwks(force_refresh=True)` and search again. This handles Cognito key rotation gracefully.
+4. If still not found after refresh, raise 401.
+
+**Function: `verify_cognito_token`**
+
+```
+async def verify_cognito_token(token: str) -> dict
+    """Verify a Cognito JWT and return its claims.
+
+    Args:
+        token: The raw JWT string (without 'Bearer ' prefix).
+
+    Returns:
+        The decoded JWT claims dict, containing at minimum: sub, email, iss, aud, exp, token_use.
+
+    Raises:
+        HTTPException 401: If the token is invalid, expired, or has wrong audience/issuer.
+    """
+```
+
+The `verify_cognito_token` function:
+1. Get the signing key from the JWKS provider.
+2. Call `jose.jwt.decode()` with:
+   - `algorithms=["RS256"]`
+   - `audience=settings.cognito_app_client_id`
+   - `issuer=f"https://cognito-idp.{settings.aws_region}.amazonaws.com/{settings.cognito_user_pool_id}"`
+3. Validate that `claims["token_use"] == "id"`. Cognito issues both `id` and `access` tokens; Ember uses the ID token which contains the user's email and other attributes.
+4. On any `JWTError`, `JWTClaimsError`, `ExpiredSignatureError`, or `StopIteration`, raise HTTP 401 with detail "Invalid or expired token" and `WWW-Authenticate: Bearer` header.
+5. Return the claims dict on success.
+
+### JWKS Provider Singleton
+
+The `CognitoJWKSProvider` is instantiated as a module-level singleton in `core/auth.py`:
+
+```python
+_jwks_provider = CognitoJWKSProvider(settings=settings)
+```
+
+This ensures the JWKS cache is shared across all requests in the same process. The `verify_cognito_token` function uses this singleton.
+
+### Module: `backend/app/dependencies.py` (Modified)
+
+The existing `get_current_user` stub is replaced with the real implementation.
+
+**Function: `get_current_user`**
+
+```
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
+    db: AsyncSession = Depends(get_db),
+) -> Profile
+    """Authenticate the request and return the current user's Profile.
+
+    Extracts the Bearer token from the Authorization header, verifies it
+    against Cognito JWKS, and looks up the corresponding profile in the database.
+
+    Args:
+        credentials: The Bearer token extracted by FastAPI's HTTPBearer.
+        db: The async database session.
+
+    Returns:
+        The authenticated user's Profile ORM object.
+
+    Raises:
+        HTTPException 401: If the token is missing, invalid, expired, or the user is not found.
+    """
+```
+
+Implementation steps:
+1. `HTTPBearer()` extracts the token from the `Authorization: Bearer <token>` header. If the header is missing or malformed, FastAPI automatically returns 401 with `{"detail": "Not authenticated"}`.
+2. Call `verify_cognito_token(credentials.credentials)` to validate the token and get claims.
+3. Extract `cognito_sub = claims["sub"]` as a UUID.
+4. Query the database: `SELECT * FROM profiles WHERE id = {cognito_sub}`.
+5. If no profile is found, raise HTTP 401 with detail "User not found".
+6. Return the `Profile` ORM object.
+
+The `get_db` dependency remains unchanged from P01-01.
+
+### Why `core/auth.py` and not `utils/cognito.py`
+
+The `docs/standards/backend.md` Section 1 reference structure shows `utils/cognito.py`. However, the actual P01-01 implementation established `core/` for application-wide concerns (logging is in `core/logging.py`). Authentication is an application-wide concern, not a stateless utility function. Placing it in `core/` follows the established pattern and keeps `utils/` for truly stateless helpers (like cursor encoding).
+
+That said, `utils/cognito.py` as shown in the standards is also acceptable. The developer should use `core/auth.py` to be consistent with the existing `core/logging.py` pattern established in P01-01. If the developer strongly prefers the standards reference, `utils/cognito.py` is also acceptable -- the key requirement is that the implementation is correct, not the exact file path.
+
+### Configuration
+
+The `Settings` class in `backend/app/config.py` already has the required fields:
+- `cognito_user_pool_id: str = ""` (line 51)
+- `cognito_app_client_id: str = ""` (line 52)
+- `aws_region: str = "us-east-1"` (line 43)
+
+No changes to `config.py` are needed.
+
+### Derived Constants
+
+The JWKS URL is derived at runtime:
+```
+https://cognito-idp.{settings.aws_region}.amazonaws.com/{settings.cognito_user_pool_id}/.well-known/jwks.json
+```
+
+The issuer URL is derived at runtime:
+```
+https://cognito-idp.{settings.aws_region}.amazonaws.com/{settings.cognito_user_pool_id}
+```
+
+These are NOT stored in `config.py` as separate settings. They are computed from `aws_region` and `cognito_user_pool_id`.
+
+---
+
+## 5. JWKS Caching Strategy
+
+### Cache Design
+
+The JWKS cache is an in-memory dict stored on the `CognitoJWKSProvider` singleton. This is intentionally simple.
+
+**Why not Redis or external cache**: The JWKS response is small (typically 2 keys, under 1 KB). In-memory caching is sufficient because:
+- Each ECS task process handles its own requests and needs its own cached copy.
+- The JWKS endpoint is highly available (AWS-managed).
+- The worst case on cache miss is one additional HTTP call per 10 minutes per process.
+
+**Cache lifecycle**:
+
+```
+Process starts
+    |
+    v
+First authenticated request arrives
+    |
+    +--> Cache is empty → fetch JWKS → populate cache → set timestamp
+    |
+    v
+Subsequent requests (within 10 min)
+    |
+    +--> Cache is populated and fresh → return cached keys
+    |
+    v
+After 10 minutes
+    |
+    +--> Cache is stale → fetch JWKS → update cache → set new timestamp
+    |
+    v
+Key rotation scenario (kid not found)
+    |
+    +--> Force refresh → fetch JWKS → update cache
+    |    +--> kid found in new keys → proceed
+    |    +--> kid still not found → reject token (401)
+    |
+    v
+JWKS endpoint unreachable
+    |
+    +--> Stale cache exists → use stale cache + log warning
+    +--> No cache exists → reject all requests (401 "Authentication service unavailable")
+```
+
+### TTL Details
+
+- **Default TTL**: 600 seconds (10 minutes)
+- **Time source**: `time.monotonic()` (immune to system clock changes)
+- **Staleness policy**: Stale cache is preferred over a hard failure when the JWKS endpoint is temporarily unreachable. The stale keys are still valid for signature verification.
+- **Force refresh**: Triggered when a token's `kid` is not found in the current cache. This handles key rotation without waiting for TTL expiry. Limited to one refresh attempt per `get_signing_key` call to prevent infinite loops.
+
+---
+
+## 6. Test Requirements
+
+### What Must Be Tested
+
+This is a security-critical feature. The test suite must cover all token validation paths, JWKS caching behavior, and dependency injection integration.
+
+#### JWKS Provider Tests (`tests/test_auth.py`)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | `get_jwks` fetches from Cognito URL on first call | httpx mock receives one GET request to the JWKS URL |
+| 2 | `get_jwks` returns cached keys on second call within TTL | httpx mock receives exactly one GET request total (cache hit) |
+| 3 | `get_jwks` re-fetches after TTL expiry | httpx mock receives two GET requests (initial + refresh after TTL) |
+| 4 | `get_jwks(force_refresh=True)` bypasses cache | httpx mock receives a new GET request even when cache is fresh |
+| 5 | `get_jwks` returns stale cache when endpoint is unreachable | Returns previously cached keys; logs a warning |
+| 6 | `get_jwks` raises 401 when endpoint is unreachable and no cache exists | HTTPException with status 401 and detail "Authentication service unavailable" |
+| 7 | `get_signing_key` returns the correct key matching the token's `kid` | Returned key dict has the expected `kid` value |
+| 8 | `get_signing_key` triggers force refresh when `kid` is not in cache | After refresh, returns the newly available key |
+| 9 | `get_signing_key` raises 401 when `kid` is not found even after refresh | HTTPException with status 401 |
+
+#### Token Verification Tests (`tests/test_auth.py` continued)
+
+These tests use a locally generated RSA key pair to create test JWTs and a mock JWKS response. They do NOT call real Cognito endpoints.
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 10 | Valid token with correct signature, audience, issuer, and `token_use=id` | Returns claims dict with `sub` field |
+| 11 | Token with expired `exp` claim | Raises HTTPException 401 with detail "Invalid or expired token" |
+| 12 | Token signed with a different RSA key (wrong signature) | Raises HTTPException 401 |
+| 13 | Token with wrong `aud` (different client ID) | Raises HTTPException 401 |
+| 14 | Token with wrong `iss` (different issuer URL) | Raises HTTPException 401 |
+| 15 | Token with `token_use=access` instead of `id` | Raises HTTPException 401 |
+| 16 | Completely malformed token string (not a JWT) | Raises HTTPException 401 |
+| 17 | Token with `kid` that does not match any JWKS key | Raises HTTPException 401 (after attempting JWKS refresh) |
+
+#### Dependency Integration Tests (`tests/test_auth_dependency.py`)
+
+These tests use the FastAPI test client with dependency overrides for the database session.
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 18 | Request with valid token and existing profile in DB | `get_current_user` returns the Profile object with correct `id` |
+| 19 | Request with valid token but no matching profile in DB | Raises HTTPException 401 with detail "User not found" |
+| 20 | Request with no `Authorization` header | Returns 401 with detail "Not authenticated" |
+| 21 | Request with `Authorization: Basic ...` (not Bearer) | Returns 401 with detail "Not authenticated" |
+| 22 | Request with `Authorization: Bearer <invalid_token>` | Returns 401 with detail "Invalid or expired token" |
+
+#### Route-Level Integration Test (`tests/test_auth_dependency.py` continued)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 23 | `GET /api/v1/health` without auth header | Returns 200 (health is public) |
+| 24 | A hypothetical protected endpoint with valid auth returns the correct user context | The route handler receives the authenticated Profile object |
+
+### How to Mock JWKS
+
+The test suite must generate a real RSA key pair at test-module scope and construct a JWKS response from it.
+
+```
+Test setup:
+1. Generate RSA key pair (2048-bit) using the `cryptography` library (already installed as a dependency of python-jose[cryptography])
+2. Construct a JWKS JSON with the public key, a known `kid`, and `alg: RS256`
+3. Patch the httpx.AsyncClient.get to return this JWKS JSON
+4. Sign test JWTs with the private key using python-jose
+
+This approach:
+- Does not require network access
+- Tests the full verification pipeline (JWKS fetch -> key extraction -> signature verification -> claim validation)
+- Allows creating tokens with various invalid states (expired, wrong audience, etc.)
+```
+
+### How to Mock the Database for Dependency Tests
+
+Use the `conftest.py` pattern from P01-01:
+- Override `get_db` to yield a test database session
+- Insert a test `Profile` row with a known UUID (matching the `sub` in the test JWT)
+- Verify that `get_current_user` returns this profile
+
+### Code Quality Checks
+
+```bash
+ruff check backend/app/core/auth.py backend/app/dependencies.py
+ruff check backend/tests/test_auth.py backend/tests/test_auth_dependency.py
+mypy backend/app/core/auth.py backend/app/dependencies.py
+pytest backend/tests/test_auth.py backend/tests/test_auth_dependency.py -v
+```
+
+---
+
+## 7. File Manifest
+
+Every file to be created or modified, grouped by purpose.
+
+### Core Authentication Module
+
+```
+Backend:
+  CREATE  backend/app/core/auth.py
+```
+
+This file contains `CognitoJWKSProvider`, `verify_cognito_token`, and the module-level singleton.
+
+### Dependencies (Modified)
+
+```
+Backend:
+  MODIFY  backend/app/dependencies.py
+```
+
+Replace the `get_current_user` stub with the real implementation that uses `HTTPBearer`, `verify_cognito_token`, and a database lookup on `profiles`.
+
+### Tests
+
+```
+Backend:
+  CREATE  backend/tests/test_auth.py
+  CREATE  backend/tests/test_auth_dependency.py
+```
+
+`test_auth.py` tests the JWKS provider and token verification logic in isolation.
+`test_auth_dependency.py` tests the `get_current_user` dependency with the FastAPI test client.
+
+### Documentation (Pipeline)
+
+```
+Shared:
+  CREATE  shared/feature-specs/cognito-auth-middleware.md         (this file)
+  CREATE  docs/pipeline/cognito-auth-middleware-architect.handoff.md
+```
+
+### Summary
+
+| Action | Count |
+|--------|-------|
+| CREATE | 4 |
+| MODIFY | 1 |
+| DELETE | 0 |
+| **Total** | **5** |
+
+### Files NOT Modified
+
+- `backend/app/config.py` -- already has `cognito_user_pool_id`, `cognito_app_client_id`, and `aws_region`. No changes needed.
+- `backend/app/main.py` -- no new routes to register. The auth middleware is injected via `Depends()`, not via middleware registration.
+- `backend/requirements.txt` -- `python-jose[cryptography]` and `httpx` are already listed.
+- `backend/.env.example` -- already has `COGNITO_USER_POOL_ID` and `COGNITO_APP_CLIENT_ID` entries.
+
+---
+
+## 8. Acceptance Criteria
+
+1. Given the `get_current_user` dependency, when a client sends a request with a valid Cognito ID token in the `Authorization: Bearer` header and a matching profile exists in the `profiles` table, then the dependency returns the `Profile` ORM object with `id` equal to the token's `sub` claim.
+
+2. Given the `get_current_user` dependency, when a client sends a request without an `Authorization` header, then the response is HTTP 401 with body `{"detail": "Not authenticated"}`.
+
+3. Given the `get_current_user` dependency, when a client sends a request with an expired JWT, then the response is HTTP 401 with body `{"detail": "Invalid or expired token"}` and the `WWW-Authenticate: Bearer` header is present.
+
+4. Given the `get_current_user` dependency, when a client sends a request with a JWT signed by a different key (invalid signature), then the response is HTTP 401 with body `{"detail": "Invalid or expired token"}`.
+
+5. Given the `get_current_user` dependency, when a client sends a request with a JWT that has a wrong `aud` (audience) claim (not matching `COGNITO_APP_CLIENT_ID`), then the response is HTTP 401.
+
+6. Given the `get_current_user` dependency, when a client sends a request with a JWT that has a wrong `iss` (issuer) claim, then the response is HTTP 401.
+
+7. Given the `get_current_user` dependency, when a client sends a request with a valid JWT but the `sub` does not match any `profiles.id`, then the response is HTTP 401 with body `{"detail": "User not found"}`.
+
+8. Given the `get_current_user` dependency, when a client sends a request with a JWT that has `token_use=access` instead of `token_use=id`, then the response is HTTP 401.
+
+9. Given the JWKS provider, when the first authenticated request arrives, then the provider fetches the JWKS from `https://cognito-idp.{region}.amazonaws.com/{pool_id}/.well-known/jwks.json` and caches the response.
+
+10. Given the JWKS provider with a populated cache, when a second authenticated request arrives within 10 minutes, then the provider returns the cached JWKS without making another HTTP request.
+
+11. Given the JWKS provider with a cache older than 10 minutes, when an authenticated request arrives, then the provider fetches fresh JWKS from Cognito and updates the cache.
+
+12. Given the JWKS provider, when a token's `kid` is not found in the cached JWKS, then the provider forces a refresh and retries the lookup before failing.
+
+13. Given the JWKS provider, when the Cognito JWKS endpoint is unreachable and stale cached keys exist, then the provider uses the stale cached keys and logs a warning.
+
+14. Given the JWKS provider, when the Cognito JWKS endpoint is unreachable and no cached keys exist, then all authenticated requests fail with HTTP 401.
+
+15. Given the `GET /api/v1/health` endpoint, when a client sends a request without any `Authorization` header, then the response is HTTP 200 (health endpoint remains public and unaffected by the auth middleware).
+
+16. Given the backend source code, when a developer runs `ruff check backend/app/core/auth.py backend/app/dependencies.py`, then zero errors are reported.
+
+17. Given the backend source code, when a developer runs `mypy backend/app/core/auth.py backend/app/dependencies.py`, then zero errors are reported.
+
+18. Given the backend test suite, when a developer runs `pytest backend/tests/test_auth.py backend/tests/test_auth_dependency.py -v`, then all tests pass with exit code 0.
+
+19. Given the `backend/app/dependencies.py` file after implementation, when a developer inspects it, then the old `NoReturn` stub raising 501 is completely removed and replaced with the real `get_current_user` that returns `Profile`.
+
+20. Given the error response for any 401 from the auth middleware, when a developer inspects the response, then it follows the format `{"detail": "..."}` as specified in `docs/standards/common.md` Section 7.
+
+---
+
+## 9. Design Decisions and Rationale
+
+### Why `CognitoJWKSProvider` is a class with instance state, not a module-level dict
+
+The initial reference in `docs/standards/backend.md` Section 5 shows a simple `_jwks_cache: dict | None` module variable. This spec upgrades that to a class because:
+1. The cache needs both the data and a timestamp for TTL enforcement.
+2. The force-refresh logic (for key rotation) requires coordinated access to both fields.
+3. A class is easier to test -- tests can create instances with custom settings and mock the HTTP client without patching module globals.
+4. The singleton pattern (`_jwks_provider` at module level) still provides the same performance as a module-level variable.
+
+### Why `token_use` is validated as `"id"` (not `"access"`)
+
+Cognito issues two types of tokens: ID tokens and access tokens. The ID token contains the user's email, name, and other attributes from the user pool. The access token contains OAuth2 scopes. Ember uses the ID token because:
+1. The `sub` claim in the ID token is the user's UUID, which maps to `profiles.id`.
+2. The ID token contains the user's email, useful for profile auto-creation in future features.
+3. The access token is typically used for resource server authorization, which Ember does not need (the backend is both the auth and resource server).
+
+### Why the auth module is in `core/auth.py` instead of `utils/cognito.py`
+
+See Section 4 for the rationale. The key points are: `core/` was established in P01-01 for application-wide concerns, authentication is an application-wide concern, and this is consistent with `core/logging.py`.
+
+### Why stale cache is preferred over hard failure
+
+When the Cognito JWKS endpoint is temporarily unreachable (network blip, AWS incident), rejecting all requests would cause a complete service outage. The JWKS keys change infrequently (only on key rotation, which Cognito does approximately every 30 days). Serving stale keys for a few minutes of unreachability is far less risky than rejecting all authenticated requests.
+
+### Why force refresh on `kid` miss before failing
+
+Cognito rotates signing keys periodically. When a new key is deployed, tokens signed with the new key will have a `kid` not present in the cached JWKS. Rather than rejecting these valid tokens, the middleware forces one JWKS refresh. If the `kid` is still not found after the fresh fetch, the token is genuinely invalid.
+
+### Why `HTTPBearer` from `fastapi.security` instead of manual header parsing
+
+`HTTPBearer` is a FastAPI-provided security scheme that:
+1. Automatically extracts the token from `Authorization: Bearer <token>`.
+2. Returns 401 with `{"detail": "Not authenticated"}` if the header is missing or malformed.
+3. Adds the security scheme to the OpenAPI docs (Swagger UI "Authorize" button).
+4. Is the standard pattern shown in `docs/standards/backend.md` Section 5.
+
+---
+
+## 10. Notes for Developers
+
+### For backend-dev
+
+- Start by creating `backend/app/core/auth.py` with the JWKS provider and verification function. Then modify `backend/app/dependencies.py` to import and use them.
+- The `Profile` model from P01-02 uses `id: Mapped[uuid.UUID]` as the PK. The `sub` claim from Cognito is a UUID string. You need to convert it: `uuid.UUID(claims["sub"])` before querying.
+- The `HTTPBearer` dependency from `fastapi.security` must be imported. When `auto_error=True` (default), it automatically returns 401 for missing/malformed Authorization headers.
+- The httpx client for JWKS fetching should use `timeout=5` to prevent hanging on slow responses.
+- Use `time.monotonic()` for cache TTL tracking, not `time.time()` or `datetime.now()`. Monotonic time is immune to system clock adjustments.
+- When catching exceptions from `python-jose`, catch `jose.JWTError` as the base class. It covers `ExpiredSignatureError`, `JWTClaimsError`, and other JWT-specific errors.
+- Import `jose.jwt` for `decode()` and `get_unverified_header()`. Do NOT import from `jose.jws` directly.
+- The `issuer` URL format is `https://cognito-idp.{region}.amazonaws.com/{pool_id}` (no trailing slash).
+- Do not create an `httpx.AsyncClient` on every JWKS fetch. Use a context-managed client within `get_jwks` or create one on the provider. Since JWKS fetches are infrequent (at most once per 10 minutes), creating a fresh client per fetch is acceptable and simpler than managing a persistent client lifecycle.
+- The existing `get_db` dependency in `dependencies.py` must be preserved unchanged. Only `get_current_user` is replaced.
+- Do not add `from __future__ import annotations` to files that need runtime type resolution for FastAPI dependency injection (FastAPI needs actual types at runtime for `Depends` to work). The existing `dependencies.py` already uses this import successfully with the stub, but verify it works with `HTTPBearer` and `Profile`.
+
+### For backend-tester
+
+- Generate RSA keys using `cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key()`. Export the public key as JWK format for the mock JWKS response.
+- Use `python-jose` to sign test tokens with the generated private key. Set `kid` in the header to match the mock JWKS.
+- For the JWKS endpoint mock, use `unittest.mock.patch` on the httpx request. A `pytest.fixture` that patches `httpx.AsyncClient.get` or the provider's internal HTTP call is recommended.
+- The `conftest.py` from P01-01 provides the basic test infrastructure. You may need to add fixtures for creating test `Profile` rows in the database.
+- Test both the unit level (`core/auth.py` functions in isolation) and the integration level (FastAPI test client with real dependency injection).
+- For TTL tests, mock `time.monotonic()` to simulate cache expiry without waiting 10 minutes.
+- Verify that the `WWW-Authenticate: Bearer` header is present in all 401 responses from the auth middleware (not just from `HTTPBearer`).


### PR DESCRIPTION
## cognito-auth-middleware

AWS Cognito JWT authentication middleware for FastAPI. Verifies RS256 tokens against Cognito JWKS endpoint, extracts user_id from 'sub' claim, and provides `Depends(get_current_user)` dependency injection. Replaces the 501 stub from P01-01.

Closes #5

---

## Pipeline Summary

| Stage | Agent | Status |
|-------|-------|--------|
| Architecture | architect | ✅ |
| Backend | backend-dev | ✅ |
| Backend Tests | backend-tester | ✅ |
| Documentation | doc-writer | ✅ |
| Code Review | reviewer | ✅ Approved (35/35) |

## Spec
`shared/feature-specs/cognito-auth-middleware.md`

## Key Components
- **`CognitoJWKSProvider`**: Fetches and caches JWKS keys with 10-min TTL, force refresh on kid miss, stale cache fallback
- **`verify_cognito_token()`**: RS256 signature verification, audience/issuer/token_use validation
- **`get_current_user()`**: HTTPBearer extraction → token verification → Profile DB lookup

## Security
- RS256-only enforcement (no "none" algorithm)
- Token audience, issuer, and token_use validated
- Sub claim validated as UUID
- No hardcoded secrets
- Generic 401 messages (no information leakage)

## Test Coverage
- 77 auth-specific tests, 444 total tests passing
- 100% line + branch coverage on auth module
- Mock RSA keys, mock JWKS endpoint — no external services

🤖 Generated via `/pipeline-run P01-03`