### PR TITLE
feat(auth-endpoints): register, login, refresh endpoints [P01-04]

### DIFF
--- a/.claude/agent-memory/architect/MEMORY.md
+++ b/.claude/agent-memory/architect/MEMORY.md
@@ -1,0 +1,49 @@
+# Architect Agent Memory
+
+## Project Structure Observations
+
+- The `backend/` directory was scaffolded with empty subdirectories: `app/routes/`, `app/services/`, `app/models/`, `app/utils/`, and `tests/`. Missing from initial scaffold: `app/core/`, `app/schemas/`, `app/db/`.
+- `docs/standards/backend.md` Section 1 is the authoritative directory layout. It specifies `schemas/` and `db/` which the GitHub issue descriptions sometimes omit. Always cross-reference the standard.
+- `shared/feature-specs/` and `docs/pipeline/` start with only `.gitkeep` files.
+- `shared/api-contracts/` is empty -- no OpenAPI specs exist yet.
+
+## Spec Writing Patterns
+
+- Backend-only features (layer: backend) do not need iOS or Android sections. Skip sections 5 and 6 from the full template.
+- For scaffold/infra features with no business logic, the "API Changes" section is minimal (just health endpoint), and "DB Changes" is "no new tables."
+- The File Manifest should count every `__init__.py` file explicitly.
+- Always include `.env.example`, `.gitignore`, `.dockerignore` in the file manifest for scaffold features.
+
+## Spec Writing Patterns (continued)
+
+- For DB schema features, the "API Changes" section is "no new endpoints" -- state this explicitly.
+- TimestampMixin is not always appropriate. `messages` is append-only (no updated_at), `user_activity` has no created_at. Document WHY each table does or does not use the mixin.
+- The existing `models/__init__.py` is nearly empty. Each new model feature must update it with imports.
+- The existing `env.py` imports Base but not model modules. The wildcard `from app.models import *` must be added.
+- CHECK constraints are preferred over PostgreSQL ENUM types (easier to modify, no ALTER TYPE needed).
+- NUMERIC over FLOAT for health/measurement data (exact decimal storage).
+
+## Key Decisions Log
+
+- P01-01: Health endpoint is public, does not touch DB. Rationale: ECS health checks must not fail during DB failover.
+- P01-01: `get_current_user` stubbed as 501 -- auth is a separate feature (P01-03).
+- P01-01: Alembic configured but zero migrations -- first migration comes with P01-02.
+- P01-02: Messages table omits TimestampMixin (append-only, no updated_at needed).
+- P01-02: user_activity omits TimestampMixin (has updated_at but no created_at per docs/04-veri-api.md).
+- P01-02: CHECK constraints over PG ENUMs for subscription_tier, role, partner status.
+- P01-02: ON DELETE SET NULL for partners.user_id_2, CASCADE for user_id_1.
+- P01-02: Single initial migration for all 7 tables.
+- P01-03: Auth module in `core/auth.py` (not `utils/cognito.py`) -- consistent with `core/logging.py` from P01-01.
+- P01-03: CognitoJWKSProvider class with TTL cache, not simple module-level dict -- needs timestamp + force-refresh logic.
+- P01-03: Validate `token_use=id` (not access) -- Ember uses Cognito ID tokens.
+- P01-03: Stale JWKS cache preferred over hard failure when endpoint unreachable.
+- P01-03: Force JWKS refresh on kid miss (key rotation handling).
+- P01-03: config.py already has cognito_user_pool_id, cognito_app_client_id, aws_region -- no changes needed.
+
+## Implementation State After P01-02
+
+- `backend/app/models/` has all 7 model files + populated `__init__.py` with all imports.
+- `backend/app/dependencies.py` has `get_db` (real) + `get_current_user` (stub returning 501).
+- `backend/app/config.py` Settings class has cognito fields. No changes needed for P01-03.
+- `backend/app/core/` has `__init__.py` + `logging.py`.
+- `backend/requirements.txt` includes python-jose[cryptography] and httpx.

--- a/.claude/agent-memory/backend-dev/MEMORY.md
+++ b/.claude/agent-memory/backend-dev/MEMORY.md
@@ -1,0 +1,30 @@
+# Backend Dev Agent Memory
+
+## Project Setup Patterns
+
+- `config.py` at module level triggers AWS Secrets Manager when `debug=False`. Tests MUST set `os.environ["DEBUG"] = "true"` BEFORE importing any app modules.
+- `db/session.py` creates engine at module level. Use a placeholder URL (`postgresql+asyncpg://localhost/ember_placeholder`) when `DATABASE_URL` is empty so import succeeds (deferred connection pattern).
+- Tests `conftest.py` sets env vars via `os.environ.setdefault()` at the TOP of the file, before any `from app...` imports. Requires `# noqa: E402` on subsequent imports.
+- Ruff has removed ANN101/ANN102 rules. Do NOT add them to the `ignore` list in pyproject.toml.
+- Use `collections.abc.AsyncGenerator` (not `typing.AsyncGenerator`) per UP035.
+- `model_post_init` signature uses `__context: object` (not `Any`) to avoid ANN401.
+- Import order for stdlib: alphabetical within the block (`collections.abc` before `contextlib`).
+
+## Key File Paths
+
+- App entry: `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/main.py`
+- Config: `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/config.py`
+- Dependencies: `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/dependencies.py`
+- DB session: `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/db/session.py`
+- Base model: `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/models/base.py`
+- Health route: `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/routes/health.py`
+- Test conftest: `/Users/atakan/Documents/GitHub/atknatk/ember/backend/tests/conftest.py`
+
+## Quality Check Commands
+
+```bash
+cd /Users/atakan/Documents/GitHub/atknatk/ember/backend && source .venv/bin/activate
+ruff check app/ tests/
+mypy app/ --ignore-missing-imports
+python -m pytest tests/ -x -v
+```

--- a/.claude/agent-memory/backend-tester/MEMORY.md
+++ b/.claude/agent-memory/backend-tester/MEMORY.md
@@ -1,0 +1,39 @@
+# Backend Tester Memory
+
+## SQLAlchemy 2.0 Testing Patterns
+
+### uuid4 default identity
+- `from __future__ import annotations` causes `uuid.uuid4` references to differ across modules
+- Never use `is uuid.uuid4` to check defaults; use `col.default.arg.__name__ == "uuid4"` instead
+
+### mapped_column defaults NOT applied at __init__
+- `mapped_column(default="free")` does NOT set the value on Python object instantiation
+- Defaults are only applied at flush/insert time
+- Test defaults via metadata: `col.default.arg == "free"`, not `instance.field == "free"`
+
+### Nullable columns with default=None
+- SQLAlchemy may not create a `ColumnDefault` for `nullable=True, default=None`
+- `col.default` can be `None` even when `default=None` was specified
+- Verify nullability via `col.nullable is True` instead of checking `col.default.arg is None`
+
+### Cascade "all, delete-orphan"
+- SQLAlchemy expands `cascade="all, delete-orphan"` into individual options
+- `rel.cascade` is a `CascadeOptions` set: `{'delete', 'delete-orphan', 'save-update', 'merge', 'expunge', 'refresh-expire'}`
+- Test with `"delete" in rel.cascade` and `"delete-orphan" in rel.cascade`, not `"all" in rel.cascade`
+
+### DESC index expressions
+- `idx.columns` does not include DESC-wrapped expressions
+- Use `idx.expressions` and convert to strings: `[str(expr) for expr in idx.expressions]`
+- Check for "DESC" in the joined expression string
+
+## Project Structure
+- Backend venv: `backend/.venv/bin/python`
+- Run tests: `cd backend && .venv/bin/python -m pytest tests/ -v --ignore=tests/test_migration.py`
+- Coverage: `cd backend && .venv/bin/python -m pytest tests/ --cov=app.models --cov-report=term-missing`
+- test_migration.py has `@pytest.mark.db` -- requires running PostgreSQL
+
+## Key Conventions
+- Test file naming: `test_{feature}_extended.py` when adding to existing test files
+- Use `sa_inspect(ModelClass)` for relationship introspection
+- Use `model.__table__.columns`, `model.__table__.indexes`, `model.__table__.constraints` for metadata
+- conftest.py uses `os.environ.setdefault("DEBUG", "true")` before any app imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [P01-01] FastAPI project scaffold with health endpoint, Docker setup, and dev tooling
 - [P01-02] SQLAlchemy async models for all 7 domain tables with Alembic migration
 - [P01-03] AWS Cognito JWT authentication middleware with JWKS caching
+- [P01-04] Auth endpoints: register, login, refresh with Cognito integration
 
 ---
 

--- a/backend/.claude/agent-memory/backend-tester/MEMORY.md
+++ b/backend/.claude/agent-memory/backend-tester/MEMORY.md
@@ -1,0 +1,28 @@
+# Backend Tester Memory
+
+## Project Structure
+- Backend root: `backend/`
+- Tests: `backend/tests/`
+- conftest.py sets `DEBUG=true` and test `DATABASE_URL` via `os.environ.setdefault()` before any app imports
+- venv: `backend/.venv/`
+- Run tests: `backend/.venv/bin/python -m pytest backend/tests/ -v`
+
+## Key Patterns
+- Use `_env_file=None` when constructing `Settings()` in config tests to avoid reading `.env`
+- Even with `_env_file=None`, pydantic-settings still reads from `os.environ` -- must save/restore env vars for secret default tests
+- For exception handler tests, use `ASGITransport(raise_app_exceptions=False)` to prevent Starlette middleware from propagating errors
+- For lifespan tests, use `unittest.mock.patch` on `app.main.setup_logging` and `app.main.engine` (with AsyncMock for dispose)
+- TimestampMixin columns accessible via `TimestampMixin.__dict__["field_name"].column`
+- Engine pool config: `engine.pool.size()` for pool_size, `engine.pool._pre_ping` for pre_ping
+- Session factory config: `AsyncSessionLocal.kw` dict for expire_on_commit/autoflush, `.class_` for session class
+
+## Coverage Notes
+- `app/config.py` AWS Secrets Manager path (lines ~24, 80-82) intentionally uncovered -- requires real AWS
+- `app/dependencies.py` get_db yield body (lines ~20-21) uncovered -- requires real DB connection
+- Testing standards doc: `docs/standards/testing.md`
+- Coverage target: >=80% lines, >=70% branches
+
+## Style
+- Test functions: `async def test_{what}_{condition}_{expected}`
+- No test classes used in this project (flat functions with pytest.mark.asyncio)
+- Commit format: `test({feature}): description [agent:backend-tester] [platform:backend]`

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from fastapi.responses import JSONResponse
 from app.config import settings
 from app.core.logging import setup_logging
 from app.db.session import engine
-from app.routes import health
+from app.routes import auth, health
 
 logger = logging.getLogger("ember")
 
@@ -52,6 +52,7 @@ def create_app() -> FastAPI:
 
     # Route registration
     app.include_router(health.router, prefix="/api/v1", tags=["health"])
+    app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 
     # Global exception handler
     @app.exception_handler(Exception)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,0 +1,77 @@
+"""Authentication route handlers — register, login, refresh.
+
+All three endpoints are public (no JWT required). Business logic is
+delegated to AuthService; route handlers only validate input and
+return responses.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_db
+from app.schemas.auth import (
+    AuthResponse,
+    LoginRequest,
+    RefreshRequest,
+    RefreshResponse,
+    RegisterRequest,
+)
+from app.services.auth_service import AuthService
+
+router = APIRouter()
+
+
+@router.post(
+    "/register",
+    response_model=AuthResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def register(
+    body: RegisterRequest,
+    db: AsyncSession = Depends(get_db),
+) -> AuthResponse:
+    """Create a new user account.
+
+    Registers the user in AWS Cognito, creates a profile row, initialises
+    a default 'Ember' companion character, and returns tokens + user data.
+    """
+    service = AuthService(db)
+    return await service.register(
+        email=body.email,
+        password=body.password,
+        name=body.name,
+    )
+
+
+@router.post(
+    "/login",
+    response_model=AuthResponse,
+)
+async def login(
+    body: LoginRequest,
+    db: AsyncSession = Depends(get_db),
+) -> AuthResponse:
+    """Authenticate an existing user and return tokens + profile."""
+    service = AuthService(db)
+    return await service.login(
+        email=body.email,
+        password=body.password,
+    )
+
+
+@router.post(
+    "/refresh",
+    response_model=RefreshResponse,
+)
+async def refresh(
+    body: RefreshRequest,
+) -> RefreshResponse:
+    """Exchange a refresh token for a new access (ID) token.
+
+    The database is not needed for this endpoint since it only calls
+    Cognito's REFRESH_TOKEN_AUTH flow.
+    """
+    service = AuthService(db=None)  # type: ignore[arg-type]
+    return await service.refresh(refresh_token=body.refresh_token)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,90 @@
+"""Pydantic request/response schemas for authentication endpoints.
+
+Covers register, login, and refresh flows. Email validation requires
+the ``email-validator`` package.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+
+
+class RegisterRequest(BaseModel):
+    """Request body for POST /api/v1/auth/register."""
+
+    email: EmailStr
+    password: str = Field(..., min_length=8)
+    name: str = Field(..., min_length=1, max_length=100)
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, v: str) -> str:
+        """Remove leading/trailing whitespace from the name."""
+        stripped = v.strip()
+        if not stripped:
+            msg = "Name must not be empty after trimming whitespace"
+            raise ValueError(msg)
+        return stripped
+
+    @field_validator("email")
+    @classmethod
+    def lowercase_email(cls, v: str) -> str:
+        """Normalise email to lowercase."""
+        return v.lower().strip()
+
+
+class LoginRequest(BaseModel):
+    """Request body for POST /api/v1/auth/login."""
+
+    email: EmailStr
+    password: str = Field(..., min_length=1)
+
+    @field_validator("email")
+    @classmethod
+    def lowercase_email(cls, v: str) -> str:
+        """Normalise email to lowercase."""
+        return v.lower().strip()
+
+
+class RefreshRequest(BaseModel):
+    """Request body for POST /api/v1/auth/refresh."""
+
+    refresh_token: str = Field(..., min_length=1)
+
+
+class UserResponse(BaseModel):
+    """User profile data returned from auth endpoints."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    email: str
+    name: str
+    onboarding_completed: bool
+    subscription_tier: str
+    preferred_language: str
+    timezone: str
+    avatar_url: str | None
+    created_at: datetime
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def coerce_id_to_str(cls, v: object) -> str:
+        """Convert UUID or other types to string for API output."""
+        return str(v)
+
+
+class AuthResponse(BaseModel):
+    """Response for register and login: tokens + user profile."""
+
+    token: str
+    refresh_token: str
+    user: UserResponse
+
+
+class RefreshResponse(BaseModel):
+    """Response for token refresh: new ID token only."""
+
+    token: str

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,361 @@
+"""Authentication service — Cognito signup/login/refresh, DB profile bootstrap.
+
+All boto3 Cognito calls are wrapped with ``asyncio.to_thread`` to avoid
+blocking the FastAPI async event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+import boto3
+from botocore.exceptions import ClientError
+from fastapi import HTTPException, status
+from jose import jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models.character import Character
+from app.models.conversation import Conversation
+from app.models.profile import Profile
+from app.schemas.auth import AuthResponse, RefreshResponse, UserResponse
+
+logger = logging.getLogger("ember")
+
+DEFAULT_COMPANION_PROMPT = (
+    "You are {user_name}'s personal AI companion. "
+    "You are a holistic life friend -- covering fitness, nutrition, work, stress, "
+    "and relationships. "
+    "You are warm, honest, and genuine but never overly positive. "
+    "You remember everything about the user and get to know them better over time. "
+    "Use what you know naturally -- never say 'I remember that...' -- just know it. "
+    "Keep messages concise. Ask questions when needed, don't monologue."
+)
+
+
+class AuthService:
+    """Handles registration, login, and token refresh via AWS Cognito."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+        self._cognito_client: object | None = None
+
+    @property
+    def cognito(self) -> object:
+        """Lazily initialise the boto3 Cognito Identity Provider client."""
+        if self._cognito_client is None:
+            self._cognito_client = boto3.client(
+                "cognito-idp",
+                region_name=settings.aws_region,
+            )
+        return self._cognito_client
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+
+    async def register(
+        self,
+        email: str,
+        password: str,
+        name: str,
+    ) -> AuthResponse:
+        """Register a new user: Cognito signup + DB profile + default character.
+
+        Steps:
+            1. Cognito sign_up
+            2. Cognito admin_confirm_sign_up (auto-confirm for MVP)
+            3. Cognito initiate_auth to obtain tokens
+            4. Decode IdToken for ``sub``
+            5. Create Profile + Character + Conversation in a single DB transaction
+
+        If Cognito signup returns UsernameExistsException, we attempt to
+        authenticate the user. If auth succeeds and no profile row exists,
+        we create the missing DB rows (idempotent recovery).
+        """
+        try:
+            await asyncio.to_thread(
+                self._cognito_sign_up,
+                email,
+                password,
+                name,
+            )
+            await asyncio.to_thread(self._cognito_admin_confirm, email)
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code == "UsernameExistsException":
+                return await self._handle_existing_cognito_user(
+                    email, password, name,
+                )
+            self._raise_cognito_error(code)
+
+        return await self._authenticate_and_create_profile(email, password, name)
+
+    async def login(self, email: str, password: str) -> AuthResponse:
+        """Authenticate an existing user against Cognito and return tokens + profile."""
+        auth_result = await self._cognito_initiate_auth(email, password)
+
+        id_token: str = auth_result["AuthenticationResult"]["IdToken"]
+        refresh_token: str = auth_result["AuthenticationResult"]["RefreshToken"]
+        sub = self._extract_sub(id_token)
+
+        profile = await self._get_profile(sub)
+        if profile is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid email or password",
+            )
+
+        return AuthResponse(
+            token=id_token,
+            refresh_token=refresh_token,
+            user=UserResponse.model_validate(profile),
+        )
+
+    async def refresh(self, refresh_token: str) -> RefreshResponse:
+        """Exchange a Cognito refresh token for a new ID token."""
+        try:
+            result = await asyncio.to_thread(
+                self._cognito_refresh,
+                refresh_token,
+            )
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code in ("NotAuthorizedException", "UserNotFoundException"):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid or expired refresh token",
+                ) from exc
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Authentication service unavailable",
+            ) from exc
+
+        id_token: str = result["AuthenticationResult"]["IdToken"]
+        return RefreshResponse(token=id_token)
+
+    # ------------------------------------------------------------------
+    # Private — Cognito wrappers (synchronous, called via to_thread)
+    # ------------------------------------------------------------------
+
+    def _cognito_sign_up(
+        self,
+        email: str,
+        password: str,
+        name: str,
+    ) -> dict[str, object]:
+        return self.cognito.sign_up(  # type: ignore[union-attr]
+            ClientId=settings.cognito_app_client_id,
+            Username=email,
+            Password=password,
+            UserAttributes=[
+                {"Name": "email", "Value": email},
+                {"Name": "name", "Value": name},
+            ],
+        )
+
+    def _cognito_admin_confirm(self, email: str) -> dict[str, object]:
+        return self.cognito.admin_confirm_sign_up(  # type: ignore[union-attr]
+            UserPoolId=settings.cognito_user_pool_id,
+            Username=email,
+        )
+
+    def _cognito_initiate_auth_sync(
+        self,
+        email: str,
+        password: str,
+    ) -> dict[str, object]:
+        return self.cognito.initiate_auth(  # type: ignore[union-attr]
+            ClientId=settings.cognito_app_client_id,
+            AuthFlow="USER_PASSWORD_AUTH",
+            AuthParameters={
+                "USERNAME": email,
+                "PASSWORD": password,
+            },
+        )
+
+    def _cognito_refresh(self, refresh_token: str) -> dict[str, object]:
+        return self.cognito.initiate_auth(  # type: ignore[union-attr]
+            ClientId=settings.cognito_app_client_id,
+            AuthFlow="REFRESH_TOKEN_AUTH",
+            AuthParameters={
+                "REFRESH_TOKEN": refresh_token,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Private — async Cognito helpers
+    # ------------------------------------------------------------------
+
+    async def _cognito_initiate_auth(
+        self,
+        email: str,
+        password: str,
+    ) -> dict[str, object]:
+        """Call Cognito initiate_auth with USER_PASSWORD_AUTH, mapping errors."""
+        try:
+            result = await asyncio.to_thread(
+                self._cognito_initiate_auth_sync,
+                email,
+                password,
+            )
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code in ("NotAuthorizedException", "UserNotFoundException"):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid email or password",
+                ) from exc
+            if code == "UserNotConfirmedException":
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="User is not confirmed",
+                ) from exc
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Authentication service unavailable",
+            ) from exc
+        return result  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Private — DB helpers
+    # ------------------------------------------------------------------
+
+    async def _get_profile(self, sub: uuid.UUID) -> Profile | None:
+        result = await self.db.execute(
+            select(Profile).where(Profile.id == sub),
+        )
+        return result.scalar_one_or_none()
+
+    async def _create_profile_and_character(
+        self,
+        sub: uuid.UUID,
+        email: str,
+        name: str,
+    ) -> Profile:
+        """Create Profile, default Character, and Conversation in one transaction."""
+        mem0_user_id = f"user_{sub}"
+        mem0_agent_id = f"companion_{sub}"
+
+        profile = Profile(
+            id=sub,
+            email=email,
+            name=name,
+            mem0_user_id=mem0_user_id,
+            timezone="UTC",
+            preferred_language="en",
+            onboarding_completed=False,
+            subscription_tier="free",
+        )
+        self.db.add(profile)
+
+        character = Character(
+            id=uuid.uuid4(),
+            user_id=sub,
+            name="Ember",
+            template="companion",
+            description=None,
+            system_prompt=DEFAULT_COMPANION_PROMPT.format(user_name=name),
+            mem0_agent_id=mem0_agent_id,
+            avatar_style="default",
+            is_default=True,
+            is_active=True,
+        )
+        self.db.add(character)
+
+        conversation = Conversation(
+            id=uuid.uuid4(),
+            user_id=sub,
+            character_id=character.id,
+            last_message_at=None,
+        )
+        self.db.add(conversation)
+
+        await self.db.commit()
+        await self.db.refresh(profile)
+        return profile
+
+    # ------------------------------------------------------------------
+    # Private — misc helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_sub(id_token: str) -> uuid.UUID:
+        """Decode the Cognito ID token (without JWKS verification) to get ``sub``."""
+        claims = jwt.get_unverified_claims(id_token)
+        return uuid.UUID(str(claims["sub"]))
+
+    async def _authenticate_and_create_profile(
+        self,
+        email: str,
+        password: str,
+        name: str,
+    ) -> AuthResponse:
+        """Authenticate via Cognito and create DB profile if missing."""
+        auth_result = await self._cognito_initiate_auth(email, password)
+
+        id_token: str = auth_result["AuthenticationResult"]["IdToken"]
+        refresh_token: str = auth_result["AuthenticationResult"]["RefreshToken"]
+        sub = self._extract_sub(id_token)
+
+        # Check if profile already exists (idempotent recovery)
+        profile = await self._get_profile(sub)
+        if profile is None:
+            profile = await self._create_profile_and_character(sub, email, name)
+
+        return AuthResponse(
+            token=id_token,
+            refresh_token=refresh_token,
+            user=UserResponse.model_validate(profile),
+        )
+
+    async def _handle_existing_cognito_user(
+        self,
+        email: str,
+        password: str,
+        name: str,
+    ) -> AuthResponse:
+        """Handle UsernameExistsException during registration.
+
+        Attempts to authenticate. If the user can authenticate and has no
+        profile in the DB, creates the missing profile (idempotent recovery
+        for the Cognito-DB split-brain scenario). If the password is wrong
+        the user truly already exists and we return a 400.
+        """
+        try:
+            return await self._authenticate_and_create_profile(
+                email, password, name,
+            )
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="An account with this email already exists",
+                ) from exc
+            raise
+
+    @staticmethod
+    def _raise_cognito_error(code: str) -> None:  # noqa: ANN401
+        """Map a Cognito error code to the appropriate HTTPException."""
+        if code == "InvalidPasswordException":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Password does not meet requirements",
+            )
+        if code == "InvalidParameterException":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid request parameters",
+            )
+        if code == "TooManyRequestsException":
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many requests, please try again later",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ firebase-admin>=6.0.0,<7.0.0
 python-multipart>=0.0.18
 httpx>=0.28.0,<1.0.0
 alembic>=1.14.0,<2.0.0
+email-validator>=2.0.0,<3.0.0

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -1,0 +1,429 @@
+"""Route-level integration tests for authentication endpoints.
+
+Uses the FastAPI test client with mocked AuthService to test request
+validation, HTTP status codes, and response structure without touching
+Cognito or a real database.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+from collections.abc import AsyncGenerator  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from app.dependencies import get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_SUB = "550e8400-e29b-41d4-a716-446655440000"
+FAKE_ID_TOKEN = "fake-id-token"
+FAKE_REFRESH_TOKEN = "fake-refresh-token"
+
+
+def _cognito_auth_result() -> dict[str, object]:
+    return {
+        "AuthenticationResult": {
+            "IdToken": FAKE_ID_TOKEN,
+            "RefreshToken": FAKE_REFRESH_TOKEN,
+            "AccessToken": "fake-access-token",
+            "ExpiresIn": 3600,
+        },
+    }
+
+
+def _make_cognito_mock() -> MagicMock:
+    """Create a sync MagicMock for the boto3 Cognito client.
+
+    MUST be MagicMock (not AsyncMock) because the Cognito calls are
+    synchronous methods invoked via asyncio.to_thread.
+    """
+    mock = MagicMock()
+    mock.sign_up.return_value = {"UserSub": FAKE_SUB}
+    mock.admin_confirm_sign_up.return_value = {}
+    mock.initiate_auth.return_value = _cognito_auth_result()
+    return mock
+
+
+def _make_client_error(code: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": f"Mocked {code}"}},
+        "TestOp",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+    mock_db = AsyncMock()
+    # Configure execute -> scalar_one_or_none -> None  (no profile found)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    mock_db.add = MagicMock()
+
+    async def _fake_refresh(obj: object) -> None:
+        if not hasattr(obj, "created_at") or getattr(obj, "created_at", None) is None:
+            object.__setattr__(obj, "created_at", datetime.now(tz=UTC))
+
+    mock_db.refresh = AsyncMock(side_effect=_fake_refresh)
+    mock_db.commit = AsyncMock()
+    yield mock_db
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client with mocked DB."""
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Register endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterEndpoint:
+    """Tests for POST /api/v1/auth/register."""
+
+    @pytest.mark.asyncio
+    async def test_register_success(self, client: AsyncClient) -> None:
+        """Valid registration returns 201 with token, refresh_token, user."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "new@ember.ai",
+                    "password": "SecurePass123!",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["token"] == FAKE_ID_TOKEN
+        assert data["refresh_token"] == FAKE_REFRESH_TOKEN
+        assert data["user"]["email"] == "new@ember.ai"
+        assert data["user"]["name"] == "Alex"
+        assert data["user"]["onboarding_completed"] is False
+        assert data["user"]["subscription_tier"] == "free"
+        assert data["user"]["preferred_language"] == "en"
+        assert data["user"]["timezone"] == "UTC"
+        assert data["user"]["avatar_url"] is None
+        assert "created_at" in data["user"]
+        assert "id" in data["user"]
+
+    @pytest.mark.asyncio
+    async def test_register_email_already_exists(self, client: AsyncClient) -> None:
+        """Registration with existing email returns 400."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error("UsernameExistsException")
+        # When trying to authenticate with wrong password
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "NotAuthorizedException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "existing@ember.ai",
+                    "password": "WrongPass123!",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "An account with this email already exists"
+
+    @pytest.mark.asyncio
+    async def test_register_invalid_password(self, client: AsyncClient) -> None:
+        """Password not meeting Cognito policy returns 400."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error("InvalidPasswordException")
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "new@ember.ai",
+                    "password": "weakpass1",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Password does not meet requirements"
+
+    @pytest.mark.asyncio
+    async def test_register_missing_email(self, client: AsyncClient) -> None:
+        """Missing email field returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"password": "Pass1234!", "name": "Alex"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_missing_name(self, client: AsyncClient) -> None:
+        """Missing name field returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"email": "a@b.com", "password": "Pass1234!"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_invalid_email_format(self, client: AsyncClient) -> None:
+        """Invalid email format returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"email": "not-an-email", "password": "Pass1234!", "name": "Alex"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_short_password(self, client: AsyncClient) -> None:
+        """Password shorter than 8 chars returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"email": "a@b.com", "password": "short", "name": "Alex"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_whitespace_only_name(self, client: AsyncClient) -> None:
+        """Name that is only whitespace returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"email": "a@b.com", "password": "Pass1234!", "name": "   "},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_cognito_unavailable(self, client: AsyncClient) -> None:
+        """Cognito service unavailable returns 503."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error(
+            "ServiceUnavailableException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "new@ember.ai",
+                    "password": "SecurePass123!",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Authentication service unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Login endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoginEndpoint:
+    """Tests for POST /api/v1/auth/login."""
+
+    @pytest.mark.asyncio
+    async def test_login_success(self, client: AsyncClient) -> None:
+        """Valid login returns 200 with token, refresh_token, user."""
+        mock_cognito = _make_cognito_mock()
+        mock_profile = MagicMock()
+        mock_profile.id = uuid.UUID(FAKE_SUB)
+        mock_profile.email = "test@ember.ai"
+        mock_profile.name = "Alex"
+        mock_profile.onboarding_completed = False
+        mock_profile.subscription_tier = "free"
+        mock_profile.preferred_language = "en"
+        mock_profile.timezone = "UTC"
+        mock_profile.avatar_url = None
+        mock_profile.created_at = datetime.now(tz=UTC)
+
+        async def _override_db_with_profile() -> AsyncGenerator[AsyncMock, None]:
+            mock_db = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_profile
+            mock_db.execute = AsyncMock(return_value=mock_result)
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override_db_with_profile
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "test@ember.ai", "password": "Pass1234!"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["token"] == FAKE_ID_TOKEN
+        assert data["refresh_token"] == FAKE_REFRESH_TOKEN
+        assert data["user"]["email"] == "test@ember.ai"
+
+    @pytest.mark.asyncio
+    async def test_login_wrong_password(self, client: AsyncClient) -> None:
+        """Wrong password returns 401."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "NotAuthorizedException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "test@ember.ai", "password": "wrong"},
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid email or password"
+
+    @pytest.mark.asyncio
+    async def test_login_nonexistent_email(self, client: AsyncClient) -> None:
+        """Non-existent email returns 401 with generic message."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "UserNotFoundException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "nobody@ember.ai", "password": "Pass1234!"},
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid email or password"
+
+    @pytest.mark.asyncio
+    async def test_login_user_not_confirmed(self, client: AsyncClient) -> None:
+        """Unconfirmed user returns 401."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "UserNotConfirmedException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "test@ember.ai", "password": "Pass1234!"},
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "User is not confirmed"
+
+    @pytest.mark.asyncio
+    async def test_login_no_profile_in_db(self, client: AsyncClient) -> None:
+        """Valid Cognito auth but no profile row returns 401."""
+        mock_cognito = _make_cognito_mock()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            # Default _override_get_db returns None for scalar_one_or_none
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "test@ember.ai", "password": "Pass1234!"},
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid email or password"
+
+
+# ---------------------------------------------------------------------------
+# Refresh endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshEndpoint:
+    """Tests for POST /api/v1/auth/refresh."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_success(self, client: AsyncClient) -> None:
+        """Valid refresh token returns 200 with new token."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.return_value = {
+            "AuthenticationResult": {
+                "IdToken": "new-id-token",
+                "AccessToken": "new-access-token",
+                "ExpiresIn": 3600,
+            },
+        }
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/refresh",
+                json={"refresh_token": "valid-refresh-token"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["token"] == "new-id-token"
+        assert "refresh_token" not in data
+
+    @pytest.mark.asyncio
+    async def test_refresh_invalid_token(self, client: AsyncClient) -> None:
+        """Invalid refresh token returns 401."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "NotAuthorizedException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/refresh",
+                json={"refresh_token": "expired-token"},
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid or expired refresh token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_missing_field(self, client: AsyncClient) -> None:
+        """Missing refresh_token field returns 422."""
+        resp = await client.post("/api/v1/auth/refresh", json={})
+        assert resp.status_code == 422

--- a/backend/tests/test_auth_routes_extended.py
+++ b/backend/tests/test_auth_routes_extended.py
@@ -1,0 +1,862 @@
+"""Extended route-level tests for authentication endpoints.
+
+Covers scenarios NOT in the backend-dev's initial test suite:
+- Idempotent registration (Cognito user exists, DB profile missing)
+- Cognito error code mapping completeness
+- Response schema field validation
+- Email normalization edge cases at the route level
+- Login Cognito unavailable (503)
+- Refresh UserNotFoundException
+- Password edge cases
+- Name edge cases
+- Missing/extra fields
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+from collections.abc import AsyncGenerator  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from app.dependencies import get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_SUB = "550e8400-e29b-41d4-a716-446655440000"
+FAKE_ID_TOKEN = "fake-id-token"
+FAKE_REFRESH_TOKEN = "fake-refresh-token"
+
+
+def _cognito_auth_result() -> dict[str, object]:
+    return {
+        "AuthenticationResult": {
+            "IdToken": FAKE_ID_TOKEN,
+            "RefreshToken": FAKE_REFRESH_TOKEN,
+            "AccessToken": "fake-access-token",
+            "ExpiresIn": 3600,
+        },
+    }
+
+
+def _make_cognito_mock() -> MagicMock:
+    mock = MagicMock()
+    mock.sign_up.return_value = {"UserSub": FAKE_SUB}
+    mock.admin_confirm_sign_up.return_value = {}
+    mock.initiate_auth.return_value = _cognito_auth_result()
+    return mock
+
+
+def _make_client_error(code: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": f"Mocked {code}"}},
+        "TestOp",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+    mock_db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    mock_db.add = MagicMock()
+
+    async def _fake_refresh(obj: object) -> None:
+        if not hasattr(obj, "created_at") or getattr(obj, "created_at", None) is None:
+            object.__setattr__(obj, "created_at", datetime.now(tz=UTC))
+
+    mock_db.refresh = AsyncMock(side_effect=_fake_refresh)
+    mock_db.commit = AsyncMock()
+    yield mock_db
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Idempotent Registration Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterIdempotent:
+    """Tests for idempotent registration when Cognito user exists but DB profile is missing."""
+
+    @pytest.mark.asyncio
+    async def test_register_idempotent_recovery_creates_profile(
+        self, client: AsyncClient,
+    ) -> None:
+        """When Cognito user exists but DB profile is missing, registration
+        should authenticate and create the missing DB rows."""
+        mock_cognito = MagicMock()
+        # sign_up raises UsernameExistsException
+        mock_cognito.sign_up.side_effect = _make_client_error("UsernameExistsException")
+        # But initiate_auth succeeds with correct password
+        mock_cognito.initiate_auth.return_value = _cognito_auth_result()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "recover@ember.ai",
+                    "password": "CorrectPass123!",
+                    "name": "Recovery",
+                },
+            )
+
+        # Should succeed since auth works and profile gets created
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["token"] == FAKE_ID_TOKEN
+        assert data["refresh_token"] == FAKE_REFRESH_TOKEN
+        assert data["user"]["email"] == "recover@ember.ai"
+        assert data["user"]["name"] == "Recovery"
+
+    @pytest.mark.asyncio
+    async def test_register_existing_user_wrong_password_returns_400(
+        self, client: AsyncClient,
+    ) -> None:
+        """When Cognito user exists and password is wrong, return 400."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error("UsernameExistsException")
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "NotAuthorizedException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "existing@ember.ai",
+                    "password": "WrongPass123!",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "An account with this email already exists"
+
+    @pytest.mark.asyncio
+    async def test_register_idempotent_recovery_skips_if_profile_exists(
+        self, client: AsyncClient,
+    ) -> None:
+        """When Cognito user AND DB profile both exist, registration still
+        succeeds by returning the existing profile."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error("UsernameExistsException")
+        mock_cognito.initiate_auth.return_value = _cognito_auth_result()
+
+        # Profile exists in DB
+        import uuid
+
+        mock_profile = MagicMock()
+        mock_profile.id = uuid.UUID(FAKE_SUB)
+        mock_profile.email = "existing@ember.ai"
+        mock_profile.name = "Existing"
+        mock_profile.onboarding_completed = False
+        mock_profile.subscription_tier = "free"
+        mock_profile.preferred_language = "en"
+        mock_profile.timezone = "UTC"
+        mock_profile.avatar_url = None
+        mock_profile.created_at = datetime.now(tz=UTC)
+
+        async def _override_db_with_profile() -> AsyncGenerator[AsyncMock, None]:
+            mock_db = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_profile
+            mock_db.execute = AsyncMock(return_value=mock_result)
+            mock_db.add = MagicMock()
+            mock_db.commit = AsyncMock()
+            mock_db.refresh = AsyncMock()
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override_db_with_profile
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "existing@ember.ai",
+                    "password": "CorrectPass123!",
+                    "name": "NewName",
+                },
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        # Returns the existing profile data
+        assert data["user"]["name"] == "Existing"
+
+
+# ---------------------------------------------------------------------------
+# Cognito Error Mapping Completeness
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterCognitoErrors:
+    """Tests for Cognito error code mapping during registration."""
+
+    @pytest.mark.asyncio
+    async def test_register_invalid_parameter_returns_400(
+        self, client: AsyncClient,
+    ) -> None:
+        """InvalidParameterException from Cognito returns 400."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error(
+            "InvalidParameterException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "test@ember.ai",
+                    "password": "Pass1234!",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid request parameters"
+
+    @pytest.mark.asyncio
+    async def test_register_too_many_requests_returns_429(
+        self, client: AsyncClient,
+    ) -> None:
+        """TooManyRequestsException from Cognito returns 429."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error(
+            "TooManyRequestsException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "test@ember.ai",
+                    "password": "Pass1234!",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 429
+        assert resp.json()["detail"] == "Too many requests, please try again later"
+
+    @pytest.mark.asyncio
+    async def test_register_unknown_cognito_error_returns_503(
+        self, client: AsyncClient,
+    ) -> None:
+        """Unknown Cognito error code falls back to 503."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error(
+            "LimitExceededException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "test@ember.ai",
+                    "password": "Pass1234!",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Authentication service unavailable"
+
+
+class TestLoginCognitoErrors:
+    """Tests for Cognito error mapping during login."""
+
+    @pytest.mark.asyncio
+    async def test_login_cognito_unavailable_returns_503(
+        self, client: AsyncClient,
+    ) -> None:
+        """Generic Cognito error during login returns 503."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "InternalErrorException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "test@ember.ai", "password": "Pass1234!"},
+            )
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Authentication service unavailable"
+
+    @pytest.mark.asyncio
+    async def test_login_missing_email_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Missing email in login body returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"password": "Pass1234!"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_login_missing_password_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Missing password in login body returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "test@ember.ai"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_login_invalid_email_format_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Invalid email format in login returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "not-an-email", "password": "Pass1234!"},
+        )
+        assert resp.status_code == 422
+
+
+class TestRefreshCognitoErrors:
+    """Tests for Cognito error mapping during refresh."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_user_not_found_returns_401(
+        self, client: AsyncClient,
+    ) -> None:
+        """UserNotFoundException during refresh returns 401."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "UserNotFoundException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/refresh",
+                json={"refresh_token": "some-token"},
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid or expired refresh token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_cognito_unavailable_returns_503(
+        self, client: AsyncClient,
+    ) -> None:
+        """Cognito unavailable during refresh returns 503."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "ServiceUnavailableException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/refresh",
+                json={"refresh_token": "some-token"},
+            )
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Authentication service unavailable"
+
+    @pytest.mark.asyncio
+    async def test_refresh_empty_token_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Empty refresh_token string returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": ""},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Response Schema Validation
+# ---------------------------------------------------------------------------
+
+
+class TestResponseSchemaValidation:
+    """Verify response payloads have the exact fields and types from the spec."""
+
+    @pytest.mark.asyncio
+    async def test_register_response_has_all_user_fields(
+        self, client: AsyncClient,
+    ) -> None:
+        """Register response user object has all spec-required fields."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "schema@ember.ai",
+                    "password": "Pass1234!",
+                    "name": "SchemaTest",
+                },
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+
+        # Top-level fields
+        assert set(data.keys()) == {"token", "refresh_token", "user"}
+        assert isinstance(data["token"], str)
+        assert isinstance(data["refresh_token"], str)
+
+        # User object required fields
+        user = data["user"]
+        required_keys = {
+            "id", "email", "name", "onboarding_completed",
+            "subscription_tier", "preferred_language", "timezone",
+            "avatar_url", "created_at",
+        }
+        assert required_keys.issubset(set(user.keys()))
+
+        # Type checks
+        assert isinstance(user["id"], str)
+        assert isinstance(user["email"], str)
+        assert isinstance(user["name"], str)
+        assert isinstance(user["onboarding_completed"], bool)
+        assert isinstance(user["subscription_tier"], str)
+        assert isinstance(user["preferred_language"], str)
+        assert isinstance(user["timezone"], str)
+        assert user["avatar_url"] is None
+        assert isinstance(user["created_at"], str)
+
+    @pytest.mark.asyncio
+    async def test_register_response_default_values(
+        self, client: AsyncClient,
+    ) -> None:
+        """Register response user has correct default values per spec."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "defaults@ember.ai",
+                    "password": "Pass1234!",
+                    "name": "Defaults",
+                },
+            )
+
+        user = resp.json()["user"]
+        assert user["onboarding_completed"] is False
+        assert user["subscription_tier"] == "free"
+        assert user["preferred_language"] == "en"
+        assert user["timezone"] == "UTC"
+        assert user["avatar_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_response_has_no_refresh_token(
+        self, client: AsyncClient,
+    ) -> None:
+        """Refresh response must contain only 'token', not 'refresh_token'."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.return_value = {
+            "AuthenticationResult": {
+                "IdToken": "new-id-token",
+                "AccessToken": "new-access-token",
+                "ExpiresIn": 3600,
+            },
+        }
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/refresh",
+                json={"refresh_token": "valid-token"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "token" in data
+        assert "refresh_token" not in data
+        assert set(data.keys()) == {"token"}
+
+
+# ---------------------------------------------------------------------------
+# Email Normalization Edge Cases at Route Level
+# ---------------------------------------------------------------------------
+
+
+class TestEmailNormalizationRoutes:
+    """Verify email normalization works end-to-end through routes."""
+
+    @pytest.mark.asyncio
+    async def test_register_uppercase_email_normalized(
+        self, client: AsyncClient,
+    ) -> None:
+        """Email with mixed case is lowercased in response."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "TeSt@EXAMPLE.COM",
+                    "password": "Pass1234!",
+                    "name": "Alex",
+                },
+            )
+
+        assert resp.status_code == 201
+        assert resp.json()["user"]["email"] == "test@example.com"
+
+    @pytest.mark.asyncio
+    async def test_register_email_with_leading_trailing_spaces(
+        self, client: AsyncClient,
+    ) -> None:
+        """Email with surrounding whitespace is trimmed and lowercased."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "  User@Example.COM  ",
+                    "password": "Pass1234!",
+                    "name": "Alex",
+                },
+            )
+
+        # EmailStr + lowercase_email validator should handle this.
+        # Note: leading/trailing whitespace may be rejected by EmailStr
+        # validation. If so, this would be 422 -- either outcome is acceptable.
+        assert resp.status_code in (201, 422)
+        if resp.status_code == 201:
+            assert resp.json()["user"]["email"] == "user@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Password Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordEdgeCases:
+    """Test password validation edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_register_password_exactly_8_chars_accepted(
+        self, client: AsyncClient,
+    ) -> None:
+        """Password of exactly 8 characters passes Pydantic validation."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "pass8@ember.ai",
+                    "password": "12345678",
+                    "name": "Alex",
+                },
+            )
+
+        # Should pass Pydantic validation (min_length=8).
+        # Cognito may still reject it, but we get past the 422 check.
+        assert resp.status_code == 201
+
+    @pytest.mark.asyncio
+    async def test_register_password_7_chars_rejected(
+        self, client: AsyncClient,
+    ) -> None:
+        """Password of 7 characters is rejected with 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "pass7@ember.ai",
+                "password": "1234567",
+                "name": "Alex",
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_missing_password_field(
+        self, client: AsyncClient,
+    ) -> None:
+        """Missing password field returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"email": "a@b.com", "name": "Alex"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_login_password_min_1_char_accepted(
+        self, client: AsyncClient,
+    ) -> None:
+        """Login accepts any non-empty password (min_length=1)."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "NotAuthorizedException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "test@ember.ai", "password": "x"},
+            )
+
+        # Should pass validation but fail at Cognito
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Name Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestNameEdgeCases:
+    """Test name field validation edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_register_name_with_only_spaces_rejected(
+        self, client: AsyncClient,
+    ) -> None:
+        """Name consisting of only spaces (after strip becomes empty) is rejected."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "a@b.com",
+                "password": "Pass1234!",
+                "name": "     ",
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_name_with_tabs_stripped(
+        self, client: AsyncClient,
+    ) -> None:
+        """Name with tabs and spaces is stripped."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "tabs@ember.ai",
+                    "password": "Pass1234!",
+                    "name": "\t Alex \t",
+                },
+            )
+
+        assert resp.status_code == 201
+        assert resp.json()["user"]["name"] == "Alex"
+
+    @pytest.mark.asyncio
+    async def test_register_single_char_name_accepted(
+        self, client: AsyncClient,
+    ) -> None:
+        """Single character name is accepted (min_length=1 after strip)."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "singlechar@ember.ai",
+                    "password": "Pass1234!",
+                    "name": "A",
+                },
+            )
+
+        assert resp.status_code == 201
+        assert resp.json()["user"]["name"] == "A"
+
+    @pytest.mark.asyncio
+    async def test_register_name_101_chars_rejected(
+        self, client: AsyncClient,
+    ) -> None:
+        """Name over 100 chars is rejected with 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "a@b.com",
+                "password": "Pass1234!",
+                "name": "A" * 101,
+            },
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Request Body Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestRequestBodyEdgeCases:
+    """Test unusual request body scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_register_empty_body_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Completely empty JSON body returns 422."""
+        resp = await client.post("/api/v1/auth/register", json={})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_login_empty_body_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Completely empty JSON body for login returns 422."""
+        resp = await client.post("/api/v1/auth/login", json={})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_extra_fields_ignored(
+        self, client: AsyncClient,
+    ) -> None:
+        """Extra fields in request body are silently ignored by Pydantic."""
+        mock_cognito = _make_cognito_mock()
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "extra@ember.ai",
+                    "password": "Pass1234!",
+                    "name": "Alex",
+                    "extra_field": "should be ignored",
+                    "is_admin": True,
+                },
+            )
+
+        assert resp.status_code == 201
+
+    @pytest.mark.asyncio
+    async def test_register_null_name_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Null value for name returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "a@b.com",
+                "password": "Pass1234!",
+                "name": None,
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_null_password_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Null value for password returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "a@b.com",
+                "password": None,
+                "name": "Alex",
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_refresh_null_token_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Null value for refresh_token returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": None},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_no_content_type_returns_422(
+        self, client: AsyncClient,
+    ) -> None:
+        """Request without JSON content type returns 422."""
+        resp = await client.post(
+            "/api/v1/auth/register",
+            content=b"not json",
+            headers={"content-type": "text/plain"},
+        )
+        assert resp.status_code == 422

--- a/backend/tests/test_auth_schemas.py
+++ b/backend/tests/test_auth_schemas.py
@@ -1,0 +1,104 @@
+"""Unit tests for authentication Pydantic schemas.
+
+Tests cover field validation, email normalisation, name trimming,
+and ORM-to-schema mapping for UserResponse.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.auth import LoginRequest, RegisterRequest, UserResponse
+
+
+class TestRegisterRequest:
+    """Tests for RegisterRequest schema validation."""
+
+    def test_valid_request(self) -> None:
+        req = RegisterRequest(email="User@Example.com", password="Pass1234!", name="Alex")
+        assert req.email == "user@example.com"
+        assert req.name == "Alex"
+
+    def test_strip_name_whitespace(self) -> None:
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name="  Alex  ")
+        assert req.name == "Alex"
+
+    def test_lowercase_email(self) -> None:
+        req = RegisterRequest(email="Test@EXAMPLE.COM", password="Pass1234!", name="A")
+        assert req.email == "test@example.com"
+
+    def test_rejects_whitespace_only_name(self) -> None:
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="a@b.com", password="Pass1234!", name="   ")
+
+    def test_rejects_missing_email(self) -> None:
+        with pytest.raises(ValidationError):
+            RegisterRequest(password="Pass1234!", name="Alex")  # type: ignore[call-arg]
+
+    def test_rejects_missing_name(self) -> None:
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="a@b.com", password="Pass1234!")  # type: ignore[call-arg]
+
+    def test_rejects_invalid_email(self) -> None:
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="not-an-email", password="Pass1234!", name="Alex")
+
+    def test_rejects_short_password(self) -> None:
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="a@b.com", password="short", name="Alex")
+
+    def test_name_max_length(self) -> None:
+        long_name = "A" * 101
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="a@b.com", password="Pass1234!", name=long_name)
+
+    def test_name_at_max_length(self) -> None:
+        name = "A" * 100
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name=name)
+        assert req.name == name
+
+
+class TestLoginRequest:
+    """Tests for LoginRequest schema validation."""
+
+    def test_lowercase_email(self) -> None:
+        req = LoginRequest(email="TEST@EXAMPLE.COM", password="secret")
+        assert req.email == "test@example.com"
+
+    def test_rejects_empty_password(self) -> None:
+        with pytest.raises(ValidationError):
+            LoginRequest(email="a@b.com", password="")
+
+
+class TestUserResponse:
+    """Tests for UserResponse from_attributes mapping."""
+
+    def test_model_validate_from_orm_object(self) -> None:
+        profile_id = uuid.uuid4()
+        now = datetime.now(tz=UTC)
+        mock_profile = MagicMock()
+        mock_profile.id = profile_id
+        mock_profile.email = "test@ember.ai"
+        mock_profile.name = "Test"
+        mock_profile.onboarding_completed = False
+        mock_profile.subscription_tier = "free"
+        mock_profile.preferred_language = "en"
+        mock_profile.timezone = "UTC"
+        mock_profile.avatar_url = None
+        mock_profile.created_at = now
+
+        user_resp = UserResponse.model_validate(mock_profile, from_attributes=True)
+        assert user_resp.id == str(profile_id)
+        assert user_resp.email == "test@ember.ai"
+        assert user_resp.name == "Test"
+        assert user_resp.onboarding_completed is False
+        assert user_resp.subscription_tier == "free"
+        assert user_resp.preferred_language == "en"
+        assert user_resp.timezone == "UTC"
+        assert user_resp.avatar_url is None
+        assert user_resp.created_at == now

--- a/backend/tests/test_auth_schemas_extended.py
+++ b/backend/tests/test_auth_schemas_extended.py
@@ -1,0 +1,489 @@
+"""Extended schema tests for authentication Pydantic models.
+
+Covers scenarios NOT in the backend-dev's initial test suite:
+- Email normalization edge cases
+- Password edge cases
+- Name edge cases
+- RefreshRequest validation
+- AuthResponse and RefreshResponse construction
+- UserResponse field types and coercion
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.auth import (
+    AuthResponse,
+    LoginRequest,
+    RefreshRequest,
+    RefreshResponse,
+    RegisterRequest,
+    UserResponse,
+)
+
+
+# ---------------------------------------------------------------------------
+# RegisterRequest — Email Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterRequestEmailEdgeCases:
+    """Email validation and normalization edge cases for RegisterRequest."""
+
+    def test_email_with_plus_addressing(self) -> None:
+        """Email with + addressing (subaddressing) is accepted."""
+        req = RegisterRequest(
+            email="user+tag@example.com",
+            password="Pass1234!",
+            name="Alex",
+        )
+        assert req.email == "user+tag@example.com"
+
+    def test_email_with_dots_in_local_part(self) -> None:
+        """Email with dots in local part is accepted."""
+        req = RegisterRequest(
+            email="first.last@example.com",
+            password="Pass1234!",
+            name="Alex",
+        )
+        assert req.email == "first.last@example.com"
+
+    def test_email_mixed_case_domain(self) -> None:
+        """Email with mixed case domain is lowercased."""
+        req = RegisterRequest(
+            email="user@EXAMPLE.COM",
+            password="Pass1234!",
+            name="Alex",
+        )
+        assert req.email == "user@example.com"
+
+    def test_email_mixed_case_local_part(self) -> None:
+        """Email with mixed case local part is lowercased."""
+        req = RegisterRequest(
+            email="USER@example.com",
+            password="Pass1234!",
+            name="Alex",
+        )
+        assert req.email == "user@example.com"
+
+    def test_email_rejects_no_at_sign(self) -> None:
+        """Email without @ is rejected."""
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="userexample.com", password="Pass1234!", name="A")
+
+    def test_email_rejects_no_domain(self) -> None:
+        """Email without domain is rejected."""
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="user@", password="Pass1234!", name="A")
+
+    def test_email_rejects_empty_string(self) -> None:
+        """Empty email string is rejected."""
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="", password="Pass1234!", name="A")
+
+
+# ---------------------------------------------------------------------------
+# RegisterRequest — Password Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterRequestPasswordEdgeCases:
+    """Password validation edge cases for RegisterRequest."""
+
+    def test_password_exactly_8_chars(self) -> None:
+        """Password of exactly 8 chars passes validation."""
+        req = RegisterRequest(email="a@b.com", password="12345678", name="Alex")
+        assert req.password == "12345678"
+
+    def test_password_very_long(self) -> None:
+        """Very long password is accepted by Pydantic (Cognito may reject)."""
+        long_pass = "A" * 256
+        req = RegisterRequest(email="a@b.com", password=long_pass, name="Alex")
+        assert len(req.password) == 256
+
+    def test_password_with_unicode(self) -> None:
+        """Password with unicode characters passes Pydantic validation."""
+        req = RegisterRequest(
+            email="a@b.com",
+            password="P@sswort!",
+            name="Alex",
+        )
+        assert len(req.password) >= 8
+
+    def test_password_with_spaces(self) -> None:
+        """Password with spaces is accepted (spaces are valid in passwords)."""
+        req = RegisterRequest(
+            email="a@b.com",
+            password="pass word 1",
+            name="Alex",
+        )
+        assert " " in req.password
+
+    def test_password_rejects_7_chars(self) -> None:
+        """Password of 7 chars is rejected."""
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="a@b.com", password="1234567", name="Alex")
+
+    def test_password_rejects_empty(self) -> None:
+        """Empty password is rejected."""
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="a@b.com", password="", name="Alex")
+
+
+# ---------------------------------------------------------------------------
+# RegisterRequest — Name Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterRequestNameEdgeCases:
+    """Name validation edge cases for RegisterRequest."""
+
+    def test_name_single_char(self) -> None:
+        """Single character name is accepted (min_length=1)."""
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name="A")
+        assert req.name == "A"
+
+    def test_name_exactly_100_chars(self) -> None:
+        """Name of exactly 100 chars is accepted."""
+        name = "A" * 100
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name=name)
+        assert req.name == name
+
+    def test_name_101_chars_rejected(self) -> None:
+        """Name of 101 chars is rejected."""
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="a@b.com", password="Pass1234!", name="A" * 101)
+
+    def test_name_strip_leading_spaces(self) -> None:
+        """Leading spaces in name are stripped."""
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name="   Alex")
+        assert req.name == "Alex"
+
+    def test_name_strip_trailing_spaces(self) -> None:
+        """Trailing spaces in name are stripped."""
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name="Alex   ")
+        assert req.name == "Alex"
+
+    def test_name_strip_tabs(self) -> None:
+        """Tab characters in name are stripped."""
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name="\tAlex\t")
+        assert req.name == "Alex"
+
+    def test_name_strip_newlines(self) -> None:
+        """Newline characters in name are stripped."""
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name="\nAlex\n")
+        assert req.name == "Alex"
+
+    def test_name_with_only_newlines_rejected(self) -> None:
+        """Name with only whitespace characters (tabs, newlines) is rejected."""
+        with pytest.raises(ValidationError):
+            RegisterRequest(email="a@b.com", password="Pass1234!", name="\t\n ")
+
+    def test_name_internal_spaces_preserved(self) -> None:
+        """Internal spaces in name are preserved (only leading/trailing stripped)."""
+        req = RegisterRequest(
+            email="a@b.com",
+            password="Pass1234!",
+            name="  John Doe  ",
+        )
+        assert req.name == "John Doe"
+
+    def test_name_with_unicode(self) -> None:
+        """Name with unicode characters is accepted."""
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name="Atakan")
+        assert req.name == "Atakan"
+
+    def test_name_with_numbers(self) -> None:
+        """Name with numbers is accepted."""
+        req = RegisterRequest(email="a@b.com", password="Pass1234!", name="Alex99")
+        assert req.name == "Alex99"
+
+    def test_name_with_special_chars(self) -> None:
+        """Name with special characters is accepted."""
+        req = RegisterRequest(
+            email="a@b.com",
+            password="Pass1234!",
+            name="O'Brien-Smith",
+        )
+        assert req.name == "O'Brien-Smith"
+
+
+# ---------------------------------------------------------------------------
+# LoginRequest — Additional Cases
+# ---------------------------------------------------------------------------
+
+
+class TestLoginRequestExtended:
+    """Extended LoginRequest validation tests."""
+
+    def test_valid_login(self) -> None:
+        """Valid login request is accepted."""
+        req = LoginRequest(email="user@example.com", password="secret123")
+        assert req.email == "user@example.com"
+        assert req.password == "secret123"
+
+    def test_email_normalized(self) -> None:
+        """Login email is lowercased."""
+        req = LoginRequest(email="USER@EXAMPLE.COM", password="secret")
+        assert req.email == "user@example.com"
+
+    def test_rejects_missing_email(self) -> None:
+        """Missing email raises ValidationError."""
+        with pytest.raises(ValidationError):
+            LoginRequest(password="secret")  # type: ignore[call-arg]
+
+    def test_rejects_missing_password(self) -> None:
+        """Missing password raises ValidationError."""
+        with pytest.raises(ValidationError):
+            LoginRequest(email="a@b.com")  # type: ignore[call-arg]
+
+    def test_rejects_invalid_email(self) -> None:
+        """Invalid email format is rejected."""
+        with pytest.raises(ValidationError):
+            LoginRequest(email="not-email", password="secret")
+
+    def test_password_single_char(self) -> None:
+        """Login password with single char is accepted (min_length=1)."""
+        req = LoginRequest(email="a@b.com", password="x")
+        assert req.password == "x"
+
+    def test_short_password_accepted(self) -> None:
+        """Login accepts short passwords (min_length=1, not 8 like register)."""
+        req = LoginRequest(email="a@b.com", password="ab")
+        assert req.password == "ab"
+
+
+# ---------------------------------------------------------------------------
+# RefreshRequest
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshRequest:
+    """Tests for RefreshRequest schema validation."""
+
+    def test_valid_refresh_request(self) -> None:
+        """Valid refresh request with token string."""
+        req = RefreshRequest(refresh_token="some-token-value")
+        assert req.refresh_token == "some-token-value"
+
+    def test_rejects_empty_token(self) -> None:
+        """Empty refresh_token string is rejected (min_length=1)."""
+        with pytest.raises(ValidationError):
+            RefreshRequest(refresh_token="")
+
+    def test_rejects_missing_token(self) -> None:
+        """Missing refresh_token field raises ValidationError."""
+        with pytest.raises(ValidationError):
+            RefreshRequest()  # type: ignore[call-arg]
+
+    def test_long_token_accepted(self) -> None:
+        """Long refresh token string is accepted."""
+        long_token = "x" * 2048
+        req = RefreshRequest(refresh_token=long_token)
+        assert req.refresh_token == long_token
+
+
+# ---------------------------------------------------------------------------
+# UserResponse — Extended
+# ---------------------------------------------------------------------------
+
+
+class TestUserResponseExtended:
+    """Extended tests for UserResponse schema."""
+
+    def test_id_coercion_from_uuid(self) -> None:
+        """UUID id is coerced to string."""
+        uid = uuid.uuid4()
+        resp = UserResponse(
+            id=uid,  # type: ignore[arg-type]
+            email="test@ember.ai",
+            name="Test",
+            onboarding_completed=False,
+            subscription_tier="free",
+            preferred_language="en",
+            timezone="UTC",
+            avatar_url=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert resp.id == str(uid)
+        assert isinstance(resp.id, str)
+
+    def test_id_coercion_from_string(self) -> None:
+        """String id is passed through."""
+        uid = "550e8400-e29b-41d4-a716-446655440000"
+        resp = UserResponse(
+            id=uid,
+            email="test@ember.ai",
+            name="Test",
+            onboarding_completed=False,
+            subscription_tier="free",
+            preferred_language="en",
+            timezone="UTC",
+            avatar_url=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert resp.id == uid
+
+    def test_avatar_url_can_be_string(self) -> None:
+        """avatar_url can be a string (URL)."""
+        resp = UserResponse(
+            id="some-id",
+            email="test@ember.ai",
+            name="Test",
+            onboarding_completed=False,
+            subscription_tier="free",
+            preferred_language="en",
+            timezone="UTC",
+            avatar_url="https://example.com/avatar.png",
+            created_at=datetime.now(tz=UTC),
+        )
+        assert resp.avatar_url == "https://example.com/avatar.png"
+
+    def test_avatar_url_can_be_none(self) -> None:
+        """avatar_url can be None."""
+        resp = UserResponse(
+            id="some-id",
+            email="test@ember.ai",
+            name="Test",
+            onboarding_completed=False,
+            subscription_tier="free",
+            preferred_language="en",
+            timezone="UTC",
+            avatar_url=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert resp.avatar_url is None
+
+    def test_from_attributes_with_mock_orm(self) -> None:
+        """model_validate works with Mock ORM objects using from_attributes."""
+        now = datetime.now(tz=UTC)
+        profile_id = uuid.uuid4()
+        mock_profile = MagicMock()
+        mock_profile.id = profile_id
+        mock_profile.email = "orm@ember.ai"
+        mock_profile.name = "OrmUser"
+        mock_profile.onboarding_completed = True
+        mock_profile.subscription_tier = "premium"
+        mock_profile.preferred_language = "tr"
+        mock_profile.timezone = "Europe/Istanbul"
+        mock_profile.avatar_url = "https://example.com/pic.jpg"
+        mock_profile.created_at = now
+
+        resp = UserResponse.model_validate(mock_profile, from_attributes=True)
+        assert resp.id == str(profile_id)
+        assert resp.email == "orm@ember.ai"
+        assert resp.name == "OrmUser"
+        assert resp.onboarding_completed is True
+        assert resp.subscription_tier == "premium"
+        assert resp.preferred_language == "tr"
+        assert resp.timezone == "Europe/Istanbul"
+        assert resp.avatar_url == "https://example.com/pic.jpg"
+        assert resp.created_at == now
+
+    def test_created_at_serializes_as_iso(self) -> None:
+        """created_at datetime is serializable."""
+        now = datetime(2026, 2, 23, 14, 30, 0, tzinfo=UTC)
+        resp = UserResponse(
+            id="some-id",
+            email="test@ember.ai",
+            name="Test",
+            onboarding_completed=False,
+            subscription_tier="free",
+            preferred_language="en",
+            timezone="UTC",
+            avatar_url=None,
+            created_at=now,
+        )
+        dumped = resp.model_dump()
+        assert dumped["created_at"] == now
+        # JSON serialization should produce ISO format
+        json_str = resp.model_dump_json()
+        assert "2026-02-23" in json_str
+
+
+# ---------------------------------------------------------------------------
+# AuthResponse
+# ---------------------------------------------------------------------------
+
+
+class TestAuthResponse:
+    """Tests for AuthResponse schema."""
+
+    def test_construction(self) -> None:
+        """AuthResponse can be constructed with required fields."""
+        user = UserResponse(
+            id="some-id",
+            email="test@ember.ai",
+            name="Test",
+            onboarding_completed=False,
+            subscription_tier="free",
+            preferred_language="en",
+            timezone="UTC",
+            avatar_url=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        resp = AuthResponse(
+            token="fake-token",
+            refresh_token="fake-refresh",
+            user=user,
+        )
+        assert resp.token == "fake-token"
+        assert resp.refresh_token == "fake-refresh"
+        assert resp.user.email == "test@ember.ai"
+
+    def test_json_serialization(self) -> None:
+        """AuthResponse serializes to JSON with all expected keys."""
+        user = UserResponse(
+            id="some-id",
+            email="test@ember.ai",
+            name="Test",
+            onboarding_completed=False,
+            subscription_tier="free",
+            preferred_language="en",
+            timezone="UTC",
+            avatar_url=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        resp = AuthResponse(
+            token="fake-token",
+            refresh_token="fake-refresh",
+            user=user,
+        )
+        data = resp.model_dump()
+        assert "token" in data
+        assert "refresh_token" in data
+        assert "user" in data
+        assert isinstance(data["user"], dict)
+
+
+# ---------------------------------------------------------------------------
+# RefreshResponse
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshResponse:
+    """Tests for RefreshResponse schema."""
+
+    def test_construction(self) -> None:
+        """RefreshResponse can be constructed with just token."""
+        resp = RefreshResponse(token="new-id-token")
+        assert resp.token == "new-id-token"
+
+    def test_no_refresh_token_field(self) -> None:
+        """RefreshResponse does NOT have a refresh_token field."""
+        resp = RefreshResponse(token="new-id-token")
+        data = resp.model_dump()
+        assert "refresh_token" not in data
+        assert set(data.keys()) == {"token"}
+
+    def test_json_serialization(self) -> None:
+        """RefreshResponse serializes correctly."""
+        resp = RefreshResponse(token="new-id-token")
+        json_data = resp.model_dump_json()
+        assert "new-id-token" in json_data

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,351 @@
+"""Unit tests for AuthService — Cognito and DB interactions.
+
+All external calls (boto3 Cognito, database) are mocked. Tests verify
+that the service orchestrates Cognito calls correctly, builds the right
+DB rows, and maps errors to HTTPExceptions.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+# Ensure test environment is set before any app imports.
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+from datetime import UTC, datetime  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from app.models.character import Character  # noqa: E402
+from app.models.conversation import Conversation  # noqa: E402
+from app.models.profile import Profile  # noqa: E402
+from app.services.auth_service import DEFAULT_COMPANION_PROMPT, AuthService  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_SUB = "550e8400-e29b-41d4-a716-446655440000"
+FAKE_ID_TOKEN = "fake-id-token"
+FAKE_REFRESH_TOKEN = "fake-refresh-token"
+
+
+def _cognito_auth_result() -> dict[str, object]:
+    return {
+        "AuthenticationResult": {
+            "IdToken": FAKE_ID_TOKEN,
+            "RefreshToken": FAKE_REFRESH_TOKEN,
+            "AccessToken": "fake-access-token",
+            "ExpiresIn": 3600,
+        },
+    }
+
+
+def _make_cognito_mock() -> MagicMock:
+    mock = MagicMock()
+    mock.sign_up.return_value = {"UserSub": FAKE_SUB}
+    mock.admin_confirm_sign_up.return_value = {}
+    mock.initiate_auth.return_value = _cognito_auth_result()
+    return mock
+
+
+def _make_client_error(code: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": f"Mocked {code}"}},
+        "TestOp",
+    )
+
+
+def _make_mock_db(
+    *,
+    profile_exists: bool = False,
+) -> tuple[AsyncMock, list[object]]:
+    """Create a properly configured mock AsyncSession.
+
+    Returns the mock_db and a list that collects all db.add() calls.
+    """
+    mock_db = AsyncMock()
+    added_objects: list[object] = []
+    mock_db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+
+    # Configure execute -> scalar_one_or_none for _get_profile
+    mock_result = MagicMock()
+    if profile_exists:
+        mock_result.scalar_one_or_none.return_value = _mock_profile()
+    else:
+        mock_result.scalar_one_or_none.return_value = None
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    # Configure refresh to set created_at on the object
+    async def _fake_refresh(obj: object) -> None:
+        if not hasattr(obj, "created_at") or obj.created_at is None:  # type: ignore[union-attr]
+            object.__setattr__(obj, "created_at", datetime.now(tz=UTC))
+
+    mock_db.refresh = AsyncMock(side_effect=_fake_refresh)
+    mock_db.commit = AsyncMock()
+
+    return mock_db, added_objects
+
+
+def _mock_profile() -> MagicMock:
+    """Create a mock Profile with all required fields."""
+    p = MagicMock(spec=Profile)
+    p.id = uuid.UUID(FAKE_SUB)
+    p.email = "test@ember.ai"
+    p.name = "Test"
+    p.mem0_user_id = f"user_{FAKE_SUB}"
+    p.onboarding_completed = False
+    p.subscription_tier = "free"
+    p.preferred_language = "en"
+    p.timezone = "UTC"
+    p.avatar_url = None
+    p.created_at = datetime.now(tz=UTC)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    """Tests for AuthService.register()."""
+
+    @pytest.mark.asyncio
+    async def test_register_calls_cognito_in_order(self) -> None:
+        """sign_up, admin_confirm_sign_up, initiate_auth called in sequence."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, _added = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            result = await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        mock_cognito.sign_up.assert_called_once()
+        mock_cognito.admin_confirm_sign_up.assert_called_once()
+        mock_cognito.initiate_auth.assert_called_once()
+        assert result.token == FAKE_ID_TOKEN
+        assert result.refresh_token == FAKE_REFRESH_TOKEN
+
+    @pytest.mark.asyncio
+    async def test_register_creates_profile_character_conversation(self) -> None:
+        """All three DB rows are added and committed in a single transaction."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        assert len(added_objects) == 3
+        assert isinstance(added_objects[0], Profile)
+        assert isinstance(added_objects[1], Character)
+        assert isinstance(added_objects[2], Conversation)
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_register_sets_mem0_ids_correctly(self) -> None:
+        """Profile.mem0_user_id and Character.mem0_agent_id use correct format."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        profile: Profile = added_objects[0]  # type: ignore[assignment]
+        character: Character = added_objects[1]  # type: ignore[assignment]
+        assert profile.mem0_user_id == f"user_{FAKE_SUB}"
+        assert character.mem0_agent_id == f"companion_{FAKE_SUB}"
+
+    @pytest.mark.asyncio
+    async def test_register_character_name_and_prompt(self) -> None:
+        """Default character is named 'Ember' with user_name substituted in prompt."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("test@ember.ai", "Pass1234!", "TestUser")
+
+        character: Character = added_objects[1]  # type: ignore[assignment]
+        assert character.name == "Ember"
+        assert character.template == "companion"
+        assert character.is_default is True
+        expected_prompt = DEFAULT_COMPANION_PROMPT.format(user_name="TestUser")
+        assert character.system_prompt == expected_prompt
+
+
+# ---------------------------------------------------------------------------
+# Login tests
+# ---------------------------------------------------------------------------
+
+
+class TestLogin:
+    """Tests for AuthService.login()."""
+
+    @pytest.mark.asyncio
+    async def test_login_success(self) -> None:
+        """Login returns tokens and user profile when credentials are valid."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, _added = _make_mock_db(profile_exists=True)
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            result = await svc.login("test@ember.ai", "Pass1234!")
+
+        assert result.token == FAKE_ID_TOKEN
+        assert result.refresh_token == FAKE_REFRESH_TOKEN
+        assert result.user.email == "test@ember.ai"
+
+    @pytest.mark.asyncio
+    async def test_login_no_profile_raises_401(self) -> None:
+        """Login with valid Cognito auth but no DB profile returns 401."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, _added = _make_mock_db(profile_exists=False)
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.login("test@ember.ai", "Pass1234!")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid email or password"
+
+    @pytest.mark.asyncio
+    async def test_login_wrong_password_raises_401(self) -> None:
+        """Login with wrong password returns 401."""
+        mock_cognito = _make_cognito_mock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "NotAuthorizedException",
+        )
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.login("test@ember.ai", "wrong")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid email or password"
+
+    @pytest.mark.asyncio
+    async def test_login_user_not_confirmed(self) -> None:
+        """Login with unconfirmed user returns 401."""
+        mock_cognito = _make_cognito_mock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "UserNotConfirmedException",
+        )
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.login("test@ember.ai", "Pass1234!")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "User is not confirmed"
+
+
+# ---------------------------------------------------------------------------
+# Refresh tests
+# ---------------------------------------------------------------------------
+
+
+class TestRefresh:
+    """Tests for AuthService.refresh()."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_success(self) -> None:
+        """Refresh returns a new ID token."""
+        mock_cognito = _make_cognito_mock()
+        # For refresh, Cognito does not return RefreshToken
+        mock_cognito.initiate_auth.return_value = {
+            "AuthenticationResult": {
+                "IdToken": "new-id-token",
+                "AccessToken": "new-access-token",
+                "ExpiresIn": 3600,
+            },
+        }
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=None)  # type: ignore[arg-type]
+            result = await svc.refresh("valid-refresh-token")
+
+        assert result.token == "new-id-token"
+        mock_cognito.initiate_auth.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_invalid_token_raises_401(self) -> None:
+        """Refresh with invalid token returns 401."""
+        mock_cognito = _make_cognito_mock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "NotAuthorizedException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=None)  # type: ignore[arg-type]
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.refresh("expired-token")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid or expired refresh token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_cognito_unavailable_raises_503(self) -> None:
+        """Refresh raises 503 when Cognito is unavailable."""
+        mock_cognito = _make_cognito_mock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "InternalErrorException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=None)  # type: ignore[arg-type]
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.refresh("some-token")
+
+        assert exc_info.value.status_code == 503

--- a/backend/tests/test_auth_service_extended.py
+++ b/backend/tests/test_auth_service_extended.py
@@ -1,0 +1,765 @@
+"""Extended unit tests for AuthService.
+
+Covers scenarios NOT in the backend-dev's initial test suite:
+- Idempotent registration (Cognito user exists, DB profile missing)
+- DB transaction rollback on failure
+- Cognito error code mapping completeness (all _raise_cognito_error branches)
+- _handle_existing_cognito_user non-401 re-raise
+- Login Cognito 503 fallback
+- asyncio.to_thread wrapping verification
+- Conversation/Character field validation during registration
+- _extract_sub edge cases
+- Refresh with UserNotFoundException
+- DEFAULT_COMPANION_PROMPT constant
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+from datetime import UTC, datetime  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from app.models.character import Character  # noqa: E402
+from app.models.conversation import Conversation  # noqa: E402
+from app.models.profile import Profile  # noqa: E402
+from app.services.auth_service import DEFAULT_COMPANION_PROMPT, AuthService  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_SUB = "550e8400-e29b-41d4-a716-446655440000"
+FAKE_ID_TOKEN = "fake-id-token"
+FAKE_REFRESH_TOKEN = "fake-refresh-token"
+
+
+def _cognito_auth_result() -> dict[str, object]:
+    return {
+        "AuthenticationResult": {
+            "IdToken": FAKE_ID_TOKEN,
+            "RefreshToken": FAKE_REFRESH_TOKEN,
+            "AccessToken": "fake-access-token",
+            "ExpiresIn": 3600,
+        },
+    }
+
+
+def _make_cognito_mock() -> MagicMock:
+    mock = MagicMock()
+    mock.sign_up.return_value = {"UserSub": FAKE_SUB}
+    mock.admin_confirm_sign_up.return_value = {}
+    mock.initiate_auth.return_value = _cognito_auth_result()
+    return mock
+
+
+def _make_client_error(code: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": f"Mocked {code}"}},
+        "TestOp",
+    )
+
+
+def _make_mock_db(
+    *,
+    profile_exists: bool = False,
+) -> tuple[AsyncMock, list[object]]:
+    mock_db = AsyncMock()
+    added_objects: list[object] = []
+    mock_db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+
+    mock_result = MagicMock()
+    if profile_exists:
+        mock_result.scalar_one_or_none.return_value = _mock_profile()
+    else:
+        mock_result.scalar_one_or_none.return_value = None
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    async def _fake_refresh(obj: object) -> None:
+        if not hasattr(obj, "created_at") or obj.created_at is None:  # type: ignore[union-attr]
+            object.__setattr__(obj, "created_at", datetime.now(tz=UTC))
+
+    mock_db.refresh = AsyncMock(side_effect=_fake_refresh)
+    mock_db.commit = AsyncMock()
+
+    return mock_db, added_objects
+
+
+def _mock_profile() -> MagicMock:
+    p = MagicMock(spec=Profile)
+    p.id = uuid.UUID(FAKE_SUB)
+    p.email = "test@ember.ai"
+    p.name = "Test"
+    p.mem0_user_id = f"user_{FAKE_SUB}"
+    p.onboarding_completed = False
+    p.subscription_tier = "free"
+    p.preferred_language = "en"
+    p.timezone = "UTC"
+    p.avatar_url = None
+    p.created_at = datetime.now(tz=UTC)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Idempotent Registration (Service Level)
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentRegistration:
+    """Service-level tests for idempotent registration when Cognito user exists
+    but DB profile is missing."""
+
+    @pytest.mark.asyncio
+    async def test_idempotent_creates_profile_when_missing(self) -> None:
+        """When Cognito user exists and auth succeeds but no profile in DB,
+        creates profile/character/conversation."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error("UsernameExistsException")
+        mock_cognito.initiate_auth.return_value = _cognito_auth_result()
+
+        mock_db, added_objects = _make_mock_db(profile_exists=False)
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            result = await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        # Cognito sign_up was attempted then failed
+        mock_cognito.sign_up.assert_called_once()
+        # admin_confirm was NOT called (user already exists)
+        mock_cognito.admin_confirm_sign_up.assert_not_called()
+        # initiate_auth was called for authentication
+        mock_cognito.initiate_auth.assert_called_once()
+        # DB rows were created
+        assert len(added_objects) == 3
+        assert isinstance(added_objects[0], Profile)
+        assert isinstance(added_objects[1], Character)
+        assert isinstance(added_objects[2], Conversation)
+        # Result has tokens
+        assert result.token == FAKE_ID_TOKEN
+        assert result.refresh_token == FAKE_REFRESH_TOKEN
+
+    @pytest.mark.asyncio
+    async def test_idempotent_skips_creation_when_profile_exists(self) -> None:
+        """When Cognito user exists and profile already in DB, returns existing
+        profile without creating new rows."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error("UsernameExistsException")
+        mock_cognito.initiate_auth.return_value = _cognito_auth_result()
+
+        mock_db, added_objects = _make_mock_db(profile_exists=True)
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            result = await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        # No new DB rows created
+        assert len(added_objects) == 0
+        # Existing profile data returned
+        assert result.user.email == "test@ember.ai"
+        mock_db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_wrong_password_raises_400(self) -> None:
+        """When Cognito user exists but password is wrong, return 400."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error("UsernameExistsException")
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "NotAuthorizedException",
+        )
+
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.register("test@ember.ai", "WrongPass!", "Test")
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "An account with this email already exists"
+
+
+# ---------------------------------------------------------------------------
+# DB Transaction Rollback
+# ---------------------------------------------------------------------------
+
+
+class TestDBTransactionRollback:
+    """Verify DB commit failure is properly handled."""
+
+    @pytest.mark.asyncio
+    async def test_commit_failure_propagates_error(self) -> None:
+        """When db.commit() raises, the error propagates (SQLAlchemy auto-rollback)."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, _added = _make_mock_db()
+        mock_db.commit = AsyncMock(side_effect=Exception("DB commit failed"))
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(Exception, match="DB commit failed"):
+                await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        # The commit was attempted
+        mock_db.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Cognito Error Mapping (Service Level)
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseCognitoError:
+    """Tests for _raise_cognito_error mapping completeness."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_parameter_exception(self) -> None:
+        """InvalidParameterException maps to 400."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error(
+            "InvalidParameterException",
+        )
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Invalid request parameters"
+
+    @pytest.mark.asyncio
+    async def test_too_many_requests_exception(self) -> None:
+        """TooManyRequestsException maps to 429."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error(
+            "TooManyRequestsException",
+        )
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail == "Too many requests, please try again later"
+
+    @pytest.mark.asyncio
+    async def test_unknown_error_code_maps_to_503(self) -> None:
+        """Unknown error code maps to 503."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error(
+            "SomeUnknownException",
+        )
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Handle Existing Cognito User — Non-401 Error Re-raise
+# ---------------------------------------------------------------------------
+
+
+class TestHandleExistingCognitoUserNon401:
+    """Test the re-raise path in _handle_existing_cognito_user when
+    the HTTPException is NOT a 401."""
+
+    @pytest.mark.asyncio
+    async def test_503_during_idempotent_recovery_propagates(self) -> None:
+        """If Cognito returns 503 during idempotent auth attempt, it propagates."""
+        mock_cognito = MagicMock()
+        mock_cognito.sign_up.side_effect = _make_client_error("UsernameExistsException")
+        # Cognito unavailable during auth attempt
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "InternalErrorException",
+        )
+
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        # The 503 should propagate, not be converted to 400
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Login Cognito 503 Fallback
+# ---------------------------------------------------------------------------
+
+
+class TestLoginCognitoFallback:
+    """Test login error paths not yet covered."""
+
+    @pytest.mark.asyncio
+    async def test_login_cognito_unavailable_raises_503(self) -> None:
+        """Generic Cognito error during login maps to 503."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "InternalErrorException",
+        )
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.login("test@ember.ai", "Pass1234!")
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service unavailable"
+
+    @pytest.mark.asyncio
+    async def test_login_user_not_found_raises_401(self) -> None:
+        """UserNotFoundException during login maps to 401 with generic message."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "UserNotFoundException",
+        )
+        mock_db, _added = _make_mock_db()
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=mock_db)
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.login("nobody@ember.ai", "Pass1234!")
+
+        assert exc_info.value.status_code == 401
+        # Must be generic to prevent email enumeration
+        assert exc_info.value.detail == "Invalid email or password"
+
+
+# ---------------------------------------------------------------------------
+# Refresh Error Paths
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshErrors:
+    """Extended refresh error tests."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_user_not_found_raises_401(self) -> None:
+        """UserNotFoundException during refresh maps to 401."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = _make_client_error(
+            "UserNotFoundException",
+        )
+
+        with patch("app.services.auth_service.boto3.client", return_value=mock_cognito):
+            svc = AuthService(db=None)  # type: ignore[arg-type]
+            with pytest.raises(HTTPException) as exc_info:
+                await svc.refresh("some-token")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid or expired refresh token"
+
+
+# ---------------------------------------------------------------------------
+# Character and Conversation Field Validation
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationDBRows:
+    """Verify all fields on created DB rows match the spec."""
+
+    @pytest.mark.asyncio
+    async def test_profile_fields(self) -> None:
+        """Profile has correct fields: id=sub, email, name, mem0_user_id, defaults."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("user@ember.ai", "Pass1234!", "UserName")
+
+        profile: Profile = added_objects[0]  # type: ignore[assignment]
+        assert profile.id == uuid.UUID(FAKE_SUB)
+        assert profile.email == "user@ember.ai"
+        assert profile.name == "UserName"
+        assert profile.mem0_user_id == f"user_{FAKE_SUB}"
+        assert profile.timezone == "UTC"
+        assert profile.preferred_language == "en"
+        assert profile.onboarding_completed is False
+        assert profile.subscription_tier == "free"
+
+    @pytest.mark.asyncio
+    async def test_character_fields(self) -> None:
+        """Character has correct fields: template=companion, is_default=True, etc."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("user@ember.ai", "Pass1234!", "CharUser")
+
+        character: Character = added_objects[1]  # type: ignore[assignment]
+        assert character.user_id == uuid.UUID(FAKE_SUB)
+        assert character.name == "Ember"
+        assert character.template == "companion"
+        assert character.description is None
+        assert character.mem0_agent_id == f"companion_{FAKE_SUB}"
+        assert character.avatar_style == "default"
+        assert character.is_default is True
+        assert character.is_active is True
+        # System prompt contains user's name
+        assert "CharUser" in character.system_prompt
+        expected_prompt = DEFAULT_COMPANION_PROMPT.format(user_name="CharUser")
+        assert character.system_prompt == expected_prompt
+
+    @pytest.mark.asyncio
+    async def test_conversation_fields(self) -> None:
+        """Conversation links to correct user and character, last_message_at is None."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("user@ember.ai", "Pass1234!", "ConvUser")
+
+        character: Character = added_objects[1]  # type: ignore[assignment]
+        conversation: Conversation = added_objects[2]  # type: ignore[assignment]
+
+        assert conversation.user_id == uuid.UUID(FAKE_SUB)
+        assert conversation.character_id == character.id
+        assert conversation.last_message_at is None
+
+    @pytest.mark.asyncio
+    async def test_character_id_is_valid_uuid(self) -> None:
+        """Character.id is a valid UUID4."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("user@ember.ai", "Pass1234!", "Test")
+
+        character: Character = added_objects[1]  # type: ignore[assignment]
+        conversation: Conversation = added_objects[2]  # type: ignore[assignment]
+
+        # Character and conversation IDs are valid UUIDs
+        assert isinstance(character.id, uuid.UUID)
+        assert isinstance(conversation.id, uuid.UUID)
+        # They are different UUIDs
+        assert character.id != conversation.id
+
+    @pytest.mark.asyncio
+    async def test_db_commit_called_once(self) -> None:
+        """Only one db.commit() call during registration (single transaction)."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, _added = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("user@ember.ai", "Pass1234!", "Test")
+
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_db_refresh_called_on_profile(self) -> None:
+        """db.refresh() is called after commit to populate server-generated fields."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("user@ember.ai", "Pass1234!", "Test")
+
+        mock_db.refresh.assert_called_once()
+        # The argument to refresh should be the Profile object
+        refresh_arg = mock_db.refresh.call_args[0][0]
+        assert isinstance(refresh_arg, Profile)
+
+
+# ---------------------------------------------------------------------------
+# asyncio.to_thread Wrapping
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncioToThread:
+    """Verify Cognito calls go through asyncio.to_thread."""
+
+    @pytest.mark.asyncio
+    async def test_register_uses_to_thread_for_cognito_calls(self) -> None:
+        """Registration wraps Cognito calls in asyncio.to_thread."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, _added = _make_mock_db()
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+            patch(
+                "app.services.auth_service.asyncio.to_thread",
+                wraps=__import__("asyncio").to_thread,
+            ) as mock_to_thread,
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.register("test@ember.ai", "Pass1234!", "Test")
+
+        # to_thread should be called for sign_up, admin_confirm, and initiate_auth
+        assert mock_to_thread.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_login_uses_to_thread(self) -> None:
+        """Login wraps Cognito initiate_auth in asyncio.to_thread."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, _added = _make_mock_db(profile_exists=True)
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+            patch(
+                "app.services.auth_service.asyncio.to_thread",
+                wraps=__import__("asyncio").to_thread,
+            ) as mock_to_thread,
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.login("test@ember.ai", "Pass1234!")
+
+        # to_thread called once for initiate_auth
+        assert mock_to_thread.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_uses_to_thread(self) -> None:
+        """Refresh wraps Cognito initiate_auth in asyncio.to_thread."""
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.return_value = {
+            "AuthenticationResult": {
+                "IdToken": "new-id-token",
+                "AccessToken": "new-access-token",
+                "ExpiresIn": 3600,
+            },
+        }
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.asyncio.to_thread",
+                wraps=__import__("asyncio").to_thread,
+            ) as mock_to_thread,
+        ):
+            svc = AuthService(db=None)  # type: ignore[arg-type]
+            await svc.refresh("valid-token")
+
+        assert mock_to_thread.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_COMPANION_PROMPT Constant
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultCompanionPrompt:
+    """Tests for the DEFAULT_COMPANION_PROMPT constant."""
+
+    def test_prompt_contains_placeholder(self) -> None:
+        """Prompt template contains {user_name} placeholder."""
+        assert "{user_name}" in DEFAULT_COMPANION_PROMPT
+
+    def test_prompt_can_be_formatted(self) -> None:
+        """Prompt template can be formatted with user_name."""
+        result = DEFAULT_COMPANION_PROMPT.format(user_name="Alex")
+        assert "Alex" in result
+        assert "{user_name}" not in result
+
+    def test_prompt_contains_key_personality_traits(self) -> None:
+        """Prompt contains essential personality descriptors from the spec."""
+        assert "warm" in DEFAULT_COMPANION_PROMPT.lower()
+        assert "honest" in DEFAULT_COMPANION_PROMPT.lower()
+        assert "genuine" in DEFAULT_COMPANION_PROMPT.lower()
+        assert "concise" in DEFAULT_COMPANION_PROMPT.lower()
+
+
+# ---------------------------------------------------------------------------
+# _extract_sub Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSub:
+    """Tests for AuthService._extract_sub static method."""
+
+    def test_extract_sub_returns_uuid(self) -> None:
+        """_extract_sub returns a UUID from a JWT with sub claim."""
+        with patch(
+            "app.services.auth_service.jwt.get_unverified_claims",
+            return_value={"sub": FAKE_SUB},
+        ):
+            result = AuthService._extract_sub("any-token")
+
+        assert isinstance(result, uuid.UUID)
+        assert str(result) == FAKE_SUB
+
+    def test_extract_sub_with_different_uuid(self) -> None:
+        """_extract_sub works with different UUID values."""
+        other_sub = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        with patch(
+            "app.services.auth_service.jwt.get_unverified_claims",
+            return_value={"sub": other_sub},
+        ):
+            result = AuthService._extract_sub("any-token")
+
+        assert str(result) == other_sub
+
+
+# ---------------------------------------------------------------------------
+# Cognito Lazy Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestCognitoLazyInit:
+    """Tests for the lazy initialization of the Cognito client."""
+
+    def test_cognito_client_initially_none(self) -> None:
+        """The _cognito_client attribute starts as None."""
+        svc = AuthService(db=AsyncMock())
+        assert svc._cognito_client is None
+
+    def test_cognito_property_creates_client(self) -> None:
+        """Accessing the cognito property initializes the boto3 client."""
+        with patch("app.services.auth_service.boto3.client") as mock_boto:
+            mock_boto.return_value = MagicMock()
+            svc = AuthService(db=AsyncMock())
+            client = svc.cognito
+
+        mock_boto.assert_called_once_with(
+            "cognito-idp",
+            region_name=__import__("app.config", fromlist=["settings"]).settings.aws_region,
+        )
+        assert client is not None
+
+    def test_cognito_property_reuses_client(self) -> None:
+        """Accessing the cognito property twice returns the same client."""
+        with patch("app.services.auth_service.boto3.client") as mock_boto:
+            mock_boto.return_value = MagicMock()
+            svc = AuthService(db=AsyncMock())
+            client1 = svc.cognito
+            client2 = svc.cognito
+
+        # Only called once (lazy)
+        mock_boto.assert_called_once()
+        assert client1 is client2
+
+
+# ---------------------------------------------------------------------------
+# Login DB Query Verification
+# ---------------------------------------------------------------------------
+
+
+class TestLoginDBQuery:
+    """Verify login queries the database correctly."""
+
+    @pytest.mark.asyncio
+    async def test_login_calls_db_execute_once(self) -> None:
+        """Login calls db.execute exactly once to look up the profile."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, _added = _make_mock_db(profile_exists=True)
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.login("test@ember.ai", "Pass1234!")
+
+        mock_db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_login_does_not_modify_db(self) -> None:
+        """Login does not call db.add, db.commit, or db.refresh."""
+        mock_cognito = _make_cognito_mock()
+        mock_db, added_objects = _make_mock_db(profile_exists=True)
+
+        with (
+            patch("app.services.auth_service.boto3.client", return_value=mock_cognito),
+            patch(
+                "app.services.auth_service.jwt.get_unverified_claims",
+                return_value={"sub": FAKE_SUB},
+            ),
+        ):
+            svc = AuthService(db=mock_db)
+            await svc.login("test@ember.ai", "Pass1234!")
+
+        assert len(added_objects) == 0
+        mock_db.commit.assert_not_called()
+        mock_db.refresh.assert_not_called()

--- a/docs/features/auth-endpoints.md
+++ b/docs/features/auth-endpoints.md
@@ -1,0 +1,400 @@
+# Auth Endpoints
+
+> Provides public registration, login, and token refresh endpoints backed by AWS Cognito, bootstrapping each new user with a database profile, a default companion character, and an auto-conversation.
+
+**Status**: Released
+**Added in**: Phase 1 (P01-04)
+**Platforms**: Backend
+**GitHub Issue**: #6
+
+---
+
+## Overview
+
+Auth Endpoints is the entry point for every user in Ember. Without these three endpoints, no one can create an account, sign in, or maintain a session. The feature implements `POST /api/v1/auth/register`, `POST /api/v1/auth/login`, and `POST /api/v1/auth/refresh` -- all public (no JWT required).
+
+The registration flow is particularly significant because it does more than create a Cognito user. It bootstraps the user's entire environment in a single database transaction: a `profiles` row, a default "Ember" companion character (template `companion`, `is_default=true`), and the corresponding auto-conversation for that character. This means a newly registered user can immediately start chatting with their AI companion without any additional setup steps.
+
+The login flow authenticates against Cognito using the `USER_PASSWORD_AUTH` flow, looks up the profile in the database, and returns tokens plus user data. The refresh flow exchanges a Cognito refresh token for a new ID token. All three endpoints delegate business logic to the `AuthService` class; route handlers contain no business logic themselves.
+
+---
+
+## Architecture
+
+### Registration Flow (End-to-End)
+
+1. Client sends `POST /api/v1/auth/register` with `{ email, password, name }`
+2. Pydantic validates the request body (`RegisterRequest`). Email is lowercased and stripped. Name is whitespace-trimmed.
+3. `AuthService.register()` calls `cognito.sign_up()` via `asyncio.to_thread()` to create the user in Cognito.
+4. `AuthService` calls `cognito.admin_confirm_sign_up()` to auto-confirm the user (no email verification during MVP).
+5. `AuthService` calls `cognito.initiate_auth()` with `USER_PASSWORD_AUTH` to obtain tokens (`IdToken`, `RefreshToken`, `AccessToken`).
+6. The `IdToken` is decoded (without JWKS verification, since it was just obtained from Cognito) using `jose.jwt.get_unverified_claims()` to extract the `sub` claim (UUID).
+7. A `Profile` row is created with `id = sub`, `mem0_user_id = "user_{sub}"`, `subscription_tier = "free"`, `onboarding_completed = false`.
+8. A default `Character` row is created with `name = "Ember"`, `template = "companion"`, `is_default = true`, `mem0_agent_id = "companion_{sub}"`, and the `DEFAULT_COMPANION_PROMPT` with the user's name substituted.
+9. A `Conversation` row is created linking the user and the default character.
+10. All three DB rows are committed in a single transaction.
+11. The response `201 Created` includes the `IdToken` (as `token`), the `RefreshToken`, and the full `UserResponse`.
+
+### Idempotent Registration (Cognito-DB Split-Brain Recovery)
+
+If Cognito signup succeeds but the database transaction fails (e.g., due to a transient DB error), the next registration attempt with the same email will receive a `UsernameExistsException` from Cognito. The service handles this gracefully:
+
+1. Catches `UsernameExistsException` from `sign_up`.
+2. Attempts to authenticate the user with the provided password via `initiate_auth`.
+3. If authentication succeeds and no profile exists in the database, creates the missing Profile, Character, and Conversation rows.
+4. If authentication succeeds and a profile already exists, returns the existing profile (true idempotency).
+5. If authentication fails (wrong password), converts the 401 to a `400 "An account with this email already exists"`.
+
+### Login Flow
+
+1. Client sends `POST /api/v1/auth/login` with `{ email, password }`
+2. `AuthService.login()` calls `cognito.initiate_auth()` with `USER_PASSWORD_AUTH`.
+3. Extracts `IdToken` and `RefreshToken` from the Cognito response.
+4. Decodes the `IdToken` to extract the `sub` claim.
+5. Queries the `profiles` table for a row with `id = sub`.
+6. If found, returns `200 OK` with tokens and user data.
+7. If not found (orphaned Cognito user), returns `401 "Invalid email or password"` -- the generic message prevents information leakage.
+
+### Refresh Flow
+
+1. Client sends `POST /api/v1/auth/refresh` with `{ refresh_token }`
+2. `AuthService.refresh()` calls `cognito.initiate_auth()` with `REFRESH_TOKEN_AUTH`.
+3. Extracts the new `IdToken` from the Cognito response.
+4. Returns `200 OK` with `{ token }`. No new refresh token is issued -- Cognito's `REFRESH_TOKEN_AUTH` flow reuses the existing refresh token (valid for 30 days).
+
+### Async Handling of boto3
+
+The `boto3` Cognito client is synchronous. All Cognito API calls are wrapped with `asyncio.to_thread()` to run in a thread pool worker, preventing the FastAPI async event loop from being blocked. This is a standard-library approach preferred over third-party async wrappers.
+
+The Cognito client is lazily initialized on first use via a `@property` on `AuthService`. Subsequent calls within the same request reuse the same client instance.
+
+### Mem0 Memory Integration
+
+During registration, Mem0 identifiers are assigned but no Mem0 API calls are made:
+
+- **`mem0_user_id`**: `"user_{cognito_sub}"` -- stored on the `profiles` row. Used for all future Mem0 calls involving this user.
+- **`mem0_agent_id`**: `"companion_{cognito_sub}"` -- stored on the default character row. Follows the `{template}_{user_id}` pattern from the Ember memory architecture.
+- Mem0 creates user records lazily on the first `add()` or `search()` call, so no explicit initialization is needed.
+
+### Database Tables Involved
+
+| Table | Operation | Notes |
+|-------|-----------|-------|
+| `profiles` | INSERT (register), SELECT (login) | Profile `id` is set to the Cognito `sub` UUID |
+| `characters` | INSERT (register) | Default "Ember" character with `template="companion"`, `is_default=true` |
+| `conversations` | INSERT (register) | Auto-conversation linked to the default character |
+
+All three INSERT operations during registration are committed in a single transaction. If any row fails, the entire transaction rolls back (though the Cognito user will still exist -- see the idempotent recovery section above).
+
+---
+
+## API Reference
+
+All three endpoints are under `/api/v1/auth` and are public (no `Authorization` header required). For the broader API contract, see [`docs/04-veri-api.md`](../04-veri-api.md).
+
+### POST /api/v1/auth/register
+
+**Auth**: None (public)
+**Content-Type**: `application/json`
+**Success Status**: `201 Created`
+
+**Request Body**:
+
+```json
+{
+  "email": "user@example.com",
+  "password": "SecurePass123!",
+  "name": "Alex"
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `email` | string | yes | Valid email format (Pydantic `EmailStr`), max 320 chars, lowercased and stripped |
+| `password` | string | yes | Min 8 chars (Cognito enforces its own policy on top) |
+| `name` | string | yes | Min 1 char, max 100 chars, whitespace-trimmed; empty-after-trim is rejected |
+
+**Response Body** (201):
+
+```json
+{
+  "token": "eyJraWQiOiJ...",
+  "refresh_token": "eyJjdHkiOiJ...",
+  "user": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "email": "user@example.com",
+    "name": "Alex",
+    "onboarding_completed": false,
+    "subscription_tier": "free",
+    "preferred_language": "en",
+    "timezone": "UTC",
+    "avatar_url": null,
+    "created_at": "2026-02-23T14:30:00Z"
+  }
+}
+```
+
+**Error Responses**:
+
+| Status | Detail | When |
+|--------|--------|------|
+| 400 | `"An account with this email already exists"` | Email already registered in Cognito (and password does not match for idempotent recovery) |
+| 400 | `"Password does not meet requirements"` | Password fails Cognito policy |
+| 400 | `"Invalid request parameters"` | Cognito `InvalidParameterException` |
+| 422 | Standard FastAPI validation error | Missing fields, invalid email format, password < 8 chars, empty name after trim |
+| 429 | `"Too many requests, please try again later"` | Cognito rate limit exceeded |
+| 503 | `"Authentication service unavailable"` | Cognito service error or unrecognized error |
+
+### POST /api/v1/auth/login
+
+**Auth**: None (public)
+**Content-Type**: `application/json`
+**Success Status**: `200 OK`
+
+**Request Body**:
+
+```json
+{
+  "email": "user@example.com",
+  "password": "SecurePass123!"
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `email` | string | yes | Valid email format, lowercased and stripped |
+| `password` | string | yes | Non-empty (min 1 char) |
+
+**Response Body** (200): Same structure as the register response (`token`, `refresh_token`, `user`).
+
+**Error Responses**:
+
+| Status | Detail | When |
+|--------|--------|------|
+| 401 | `"Invalid email or password"` | Wrong email, wrong password, or valid Cognito user with no DB profile |
+| 401 | `"User is not confirmed"` | User has not been confirmed in Cognito |
+| 422 | Standard FastAPI validation error | Missing fields, invalid email format |
+| 503 | `"Authentication service unavailable"` | Cognito service error |
+
+The generic "Invalid email or password" message is used for multiple failure cases to prevent email enumeration attacks.
+
+### POST /api/v1/auth/refresh
+
+**Auth**: None (public)
+**Content-Type**: `application/json`
+**Success Status**: `200 OK`
+
+**Request Body**:
+
+```json
+{
+  "refresh_token": "eyJjdHkiOiJ..."
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `refresh_token` | string | yes | Non-empty (min 1 char) |
+
+**Response Body** (200):
+
+```json
+{
+  "token": "eyJraWQiOiJ..."
+}
+```
+
+The response contains only a new ID token. No `refresh_token` is returned -- Cognito's `REFRESH_TOKEN_AUTH` flow does not issue a new refresh token. The client retains its existing refresh token (valid for 30 days).
+
+**Error Responses**:
+
+| Status | Detail | When |
+|--------|--------|------|
+| 401 | `"Invalid or expired refresh token"` | Token is invalid, expired, or revoked |
+| 422 | Standard FastAPI validation error | Missing `refresh_token` field |
+| 503 | `"Authentication service unavailable"` | Cognito service error |
+
+---
+
+## Pydantic Schemas
+
+All schemas are in `backend/app/schemas/auth.py` and use Pydantic v2 patterns.
+
+**Request schemas**:
+
+- `RegisterRequest` -- validates `email` (EmailStr, lowercased), `password` (min 8 chars), `name` (1-100 chars, whitespace-trimmed, empty-after-trim rejected)
+- `LoginRequest` -- validates `email` (EmailStr, lowercased), `password` (min 1 char)
+- `RefreshRequest` -- validates `refresh_token` (min 1 char)
+
+**Response schemas**:
+
+- `UserResponse` -- maps from the `Profile` ORM object via `ConfigDict(from_attributes=True)`. The `id` field has a `field_validator("id", mode="before")` that coerces `uuid.UUID` to `str` for API output.
+- `AuthResponse` -- contains `token` (str), `refresh_token` (str), `user` (UserResponse)
+- `RefreshResponse` -- contains only `token` (str)
+
+The `email-validator` package (added to `requirements.txt`) is required by Pydantic's `EmailStr` type.
+
+---
+
+## Configuration
+
+No new configuration variables were introduced. The required settings already exist from P01-01:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `COGNITO_USER_POOL_ID` | str | AWS Cognito user pool ID |
+| `COGNITO_APP_CLIENT_ID` | str | AWS Cognito app client ID |
+| `AWS_REGION` | str | AWS region for Cognito |
+
+**Infrastructure requirements** (not code concerns, but must be configured):
+
+- The Cognito User Pool App Client must have `USER_PASSWORD_AUTH` enabled as an allowed auth flow.
+- The ECS task IAM role must have `cognito-idp:AdminConfirmSignUp` permission (used during registration to auto-confirm users).
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `backend/app/routes/auth.py` | Route handlers: `register`, `login`, `refresh`. Delegates to `AuthService`. |
+| `backend/app/services/auth_service.py` | `AuthService` class with all business logic. Contains `DEFAULT_COMPANION_PROMPT`. |
+| `backend/app/schemas/auth.py` | 6 Pydantic schemas: 3 request, 3 response. |
+| `backend/app/main.py` | Modified to register auth router at `/api/v1/auth`. |
+| `backend/requirements.txt` | Modified to add `email-validator>=2.0.0,<3.0.0`. |
+
+### Service Layer
+
+`AuthService` is instantiated per-request with the database session: `AuthService(db)`. The Cognito client is lazily initialized via the `cognito` property. Private helper methods handle specific concerns:
+
+- `_cognito_sign_up`, `_cognito_admin_confirm`, `_cognito_initiate_auth_sync`, `_cognito_refresh` -- synchronous Cognito wrappers called via `asyncio.to_thread()`
+- `_cognito_initiate_auth` -- async wrapper that calls `_cognito_initiate_auth_sync` and maps Cognito errors to HTTP exceptions
+- `_create_profile_and_character` -- creates all three DB rows in one transaction
+- `_handle_existing_cognito_user` -- idempotent recovery for the Cognito-DB split-brain case
+- `_extract_sub` -- decodes the ID token without JWKS verification
+- `_raise_cognito_error` -- maps Cognito error codes to HTTP exceptions
+
+### Default Companion System Prompt
+
+The default character's system prompt is a constant in `auth_service.py`:
+
+```
+You are {user_name}'s personal AI companion. You are a holistic life friend --
+covering fitness, nutrition, work, stress, and relationships. You are warm,
+honest, and genuine but never overly positive. You remember everything about
+the user and get to know them better over time. Use what you know naturally --
+never say 'I remember that...' -- just know it. Keep messages concise. Ask
+questions when needed, don't monologue.
+```
+
+The `{user_name}` placeholder is substituted with the registering user's name via `str.format()` at character creation time. This prompt is not generated dynamically via Claude -- dynamic generation is for custom characters in a later phase.
+
+---
+
+## Testing
+
+### Coverage Summary
+
+| File | Tests | Line Coverage | Branch Coverage |
+|------|-------|---------------|-----------------|
+| `test_auth_routes.py` | 17 | -- | -- |
+| `test_auth_routes_extended.py` | 33 | -- | -- |
+| `test_auth_service.py` | 11 | -- | -- |
+| `test_auth_service_extended.py` | 30 | -- | -- |
+| `test_auth_schemas.py` | 13 | -- | -- |
+| `test_auth_schemas_extended.py` | 47 | -- | -- |
+| **Total** | **151** | **100%** (186/186 statements) | **100%** (24/24 branches) |
+
+All 30 test scenarios from the feature spec are covered. An additional 80+ scenarios were added by the tester covering edge cases, boundary values, idempotent recovery paths, error code mappings, and response schema validation.
+
+### Test Approach
+
+- **Route tests**: Use the FastAPI test client (`httpx.AsyncClient`). Cognito is mocked at the service level via `unittest.mock.patch` on `boto3.client`. The `get_db` dependency is overridden to inject a mock `AsyncSession`.
+- **Service tests**: Unit-test `AuthService` directly. Both Cognito (via a `MagicMock`) and the database session (via `AsyncMock`) are mocked. Cognito exceptions are simulated using `botocore.exceptions.ClientError` with appropriate error codes.
+- **Schema tests**: Validate Pydantic request/response schemas directly -- email normalization, name trimming, boundary values, ORM-to-response mapping, UUID-to-string coercion.
+
+### Running Tests
+
+Auth tests only:
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests/test_auth_routes.py backend/tests/test_auth_routes_extended.py backend/tests/test_auth_service.py backend/tests/test_auth_service_extended.py backend/tests/test_auth_schemas.py backend/tests/test_auth_schemas_extended.py -v
+```
+
+Full backend suite:
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests/ -v --ignore=backend/tests/test_migration.py
+```
+
+Code quality:
+
+```bash
+ruff check backend/app/routes/auth.py backend/app/services/auth_service.py backend/app/schemas/auth.py
+```
+
+---
+
+## Known Limitations
+
+- **No email verification**: Users are auto-confirmed via `admin_confirm_sign_up` during registration. In production, this may be replaced by a Cognito pre-sign-up Lambda trigger or a proper email verification flow (planned for Phase 2).
+- **No forgot-password or reset-password**: These are Phase 2 features, not implemented here.
+- **No social login**: Google and Apple sign-in are Phase 4 features.
+- **Cognito-DB partial failure**: If Cognito signup succeeds but the database transaction fails, the Cognito user exists without a profile. The idempotent recovery mechanism handles this on the next registration attempt with the same email and password. If the user tries a different password, they see "An account with this email already exists" and must use the original password.
+- **No onboarding memories**: Registration does not create any Mem0 memories. Mem0 identifiers are assigned, but actual memory creation happens during the onboarding flow (a separate feature).
+- **Refresh does not return a new refresh token**: This is Cognito's behavior, not a limitation of the implementation. Clients must retain their original refresh token (valid for 30 days).
+
+---
+
+## Design Decisions
+
+### Why auto-confirm via `admin_confirm_sign_up`
+
+During MVP, email verification adds friction without critical value. Auto-confirming allows immediate login after registration, which is the expected mobile app experience. The `admin_confirm_sign_up` call requires IAM permissions on the ECS task role. In production, this can be replaced by a Cognito pre-sign-up Lambda trigger.
+
+### Why `USER_PASSWORD_AUTH` (not SRP)
+
+The backend communicates with Cognito over HTTPS on AWS-internal networking. SRP (Secure Remote Password) is designed for client-side SDKs where the password must never leave the device. Since the password is sent to the backend over HTTPS and then forwarded to Cognito over HTTPS, `USER_PASSWORD_AUTH` is sufficient and simpler.
+
+### Why a single transaction for Profile + Character + Conversation
+
+The user expects to see the default character immediately after registration. If character or conversation creation failed independently, the user would see an empty app. A single transaction ensures atomicity.
+
+### Why generic login error messages
+
+Both "wrong email" and "wrong password" return `"Invalid email or password"`. This prevents email enumeration attacks where an attacker could discover which emails have accounts by observing different error messages.
+
+### Why `asyncio.to_thread()` instead of `aioboto3`
+
+`asyncio.to_thread()` is a standard-library solution that works with any synchronous code. `aioboto3` is a third-party wrapper with limited maintenance. The standard-library approach is more reliable and easier to understand.
+
+### Why the default character is named "Ember"
+
+The default companion character matches the app name to reinforce brand identity. Users can rename it later via character settings.
+
+### Why `mem0_user_id` is `"user_{sub}"` (not just `"{sub}"`)
+
+The `"user_"` prefix distinguishes Mem0 user identifiers from agent IDs and memory IDs, preventing potential collisions and making logs easier to read.
+
+---
+
+## Extending This Feature
+
+To add a new auth endpoint (e.g., forgot-password), create a new method on `AuthService` in `backend/app/services/auth_service.py`, add request/response schemas in `backend/app/schemas/auth.py`, and add a route handler in `backend/app/routes/auth.py`. The router is already registered at `/api/v1/auth` in `main.py`, so the new route will be available automatically.
+
+To replace auto-confirm with email verification, remove the `_cognito_admin_confirm` call from `AuthService.register()` and implement a `POST /api/v1/auth/confirm` endpoint that calls `cognito.confirm_sign_up()` with the verification code. Alternatively, configure a Cognito pre-sign-up Lambda trigger that auto-confirms users based on custom logic.
+
+To add social login (Google, Apple), add new Cognito Identity Provider configurations and implement endpoints that handle the federated auth flow. The `AuthResponse` schema can be reused since the response format is the same.
+
+To change the default character name or system prompt, modify the `DEFAULT_COMPANION_PROMPT` constant and the character creation logic in `_create_profile_and_character()` within `backend/app/services/auth_service.py`.
+
+---
+
+## Related Documentation
+
+- [Cognito Auth Middleware](./cognito-auth-middleware.md) -- JWT verification used by protected endpoints (this feature creates tokens; the middleware verifies them)
+- [Database Schema](./database-schema.md) -- the `profiles`, `characters`, and `conversations` tables written during registration
+- [Project Setup](./project-setup.md) -- the FastAPI scaffold this feature builds on
+- [Database Schema and API Endpoints](../04-veri-api.md) -- authoritative source for table definitions and API contracts
+- [AI Memory System](../05-ai-bellek.md) -- Mem0 integration patterns and the `agent_id` format
+- [Security and Performance](../08-guvenlik-performans.md) -- JWT strategy, token lifetimes, rate limiting

--- a/docs/pipeline/auth-endpoints-architect.handoff.md
+++ b/docs/pipeline/auth-endpoints-architect.handoff.md
@@ -1,0 +1,83 @@
+# Architect Handoff: Auth Endpoints
+
+**Date**: 2026-02-23
+**Agent**: architect
+**Status**: COMPLETE
+**Feature ID**: P01-04
+**GitHub Issue**: #6
+**Layer**: backend
+
+---
+
+## What Was Designed
+
+Three public authentication endpoints for the Ember backend: POST /api/v1/auth/register (Cognito signup + profiles row + Mem0 user identifier assignment + default "General Friend" character creation + auto-conversation), POST /api/v1/auth/login (Cognito USER_PASSWORD_AUTH authentication, profile lookup, return tokens + user), and POST /api/v1/auth/refresh (Cognito REFRESH_TOKEN_AUTH, return new ID token). All endpoints use Pydantic v2 request/response schemas. The register flow bootstraps the user's entire environment in a single database transaction.
+
+## Spec Location
+
+`shared/feature-specs/auth-endpoints.md`
+
+## Key Decisions
+
+- **Auto-confirm users via `admin_confirm_sign_up`**: During MVP/early development, email verification adds friction without critical value. Auto-confirming allows immediate login after registration. In production, this can be replaced by a Cognito pre-sign-up Lambda trigger or a proper email verification flow in Phase 2.
+- **`USER_PASSWORD_AUTH` flow (not `ALLOW_USER_SRP_AUTH`)**: The backend communicates with Cognito over HTTPS on AWS-internal network. SRP is for client-side SDKs where the password must never leave the device. `USER_PASSWORD_AUTH` is sufficient and simpler.
+- **`asyncio.to_thread()` for all boto3 calls**: boto3 is synchronous. Wrapping with `asyncio.to_thread()` prevents blocking the FastAPI event loop. This is a standard-library solution preferred over `aioboto3` (third-party, limited maintenance).
+- **Default character named "Ember"**: The default "General Friend" character uses template `companion` and is named after the app itself. Users can rename it later.
+- **`mem0_user_id` format is `"user_{sub}"`**: The `"user_"` prefix distinguishes Mem0 user identifiers from agent IDs and memory IDs. No explicit Mem0 API call is made during registration -- Mem0 creates user records lazily on first `add()` or `search()` call.
+- **Single database transaction for Profile + Character + Conversation**: Ensures atomicity. Either the entire user setup succeeds or nothing is committed. Without this, a user could end up with a profile but no character to talk to.
+- **Generic "Invalid email or password" on login failure**: Both wrong-email and wrong-password cases return the same message to prevent email enumeration attacks.
+- **Refresh does not return a new refresh_token**: This is Cognito's behavior with `REFRESH_TOKEN_AUTH` -- it returns a new ID token but reuses the existing refresh token (valid for 30 days).
+- **Idempotent registration for Cognito-DB split-brain**: If Cognito signup succeeds but DB insertion fails, the next registration attempt with the same email catches `UsernameExistsException`, attempts authentication, and if successful (same password), creates the missing DB rows.
+- **ID token decoded without JWKS verification after `initiate_auth`**: The token was just obtained directly from Cognito over TLS. Using `jose.jwt.get_unverified_claims()` avoids a dependency on the JWKS cache for registration and login flows.
+- **`email-validator` added to requirements.txt**: Required by Pydantic's `EmailStr` type used in request schemas. Without it, Pydantic raises an import error at runtime.
+
+## Assumptions Made
+
+- P01-01 is complete: `config.py` has `cognito_user_pool_id`, `cognito_app_client_id`, `aws_region`; `main.py` has `create_app()` with `include_router` pattern; `core/` directory exists.
+- P01-02 is complete: `Profile`, `Character`, and `Conversation` SQLAlchemy models exist with the exact column names and types documented in `docs/04-veri-api.md`.
+- P01-03 is complete: `core/auth.py` has `verify_cognito_token()` and `CognitoJWKSProvider`; `dependencies.py` has real `get_current_user` (not the 501 stub).
+- `boto3` is in `requirements.txt` (verified -- it is).
+- `python-jose[cryptography]` is in `requirements.txt` (verified -- it is).
+- The Cognito User Pool App Client has `USER_PASSWORD_AUTH` enabled (infrastructure concern, not code).
+- The ECS task role has `cognito-idp:AdminConfirmSignUp` IAM permission (infrastructure concern, not code).
+
+## Dependencies
+
+- **Requires**: P01-01 (project-setup), P01-02 (database-schema), P01-03 (cognito-auth-middleware)
+- **Blocks**: All subsequent features that require an authenticated user (character CRUD, messaging, memory, profile, etc.)
+
+## File Manifest
+
+```
+Backend:
+  CREATE  backend/app/routes/auth.py
+  CREATE  backend/app/services/auth_service.py
+  CREATE  backend/app/schemas/auth.py
+  MODIFY  backend/app/main.py
+  MODIFY  backend/requirements.txt
+  CREATE  backend/tests/test_auth_routes.py
+  CREATE  backend/tests/test_auth_service.py
+  CREATE  backend/tests/test_auth_schemas.py
+
+Shared:
+  CREATE  shared/feature-specs/auth-endpoints.md
+  CREATE  docs/pipeline/auth-endpoints-architect.handoff.md
+```
+
+## Notes for Developers
+
+- **Read the full spec first**: `shared/feature-specs/auth-endpoints.md` -- it contains the complete registration/login/refresh flows, all error scenarios, Pydantic schema definitions, 30 test scenarios, and 20 acceptance criteria.
+- **Build order**: Start with schemas (`app/schemas/auth.py`), then the service (`app/services/auth_service.py`), then the route (`app/routes/auth.py`), then wire up in `main.py`. This order lets you test each layer incrementally.
+- **Add `email-validator>=2.0.0,<3.0.0` to `requirements.txt`**: Without it, Pydantic's `EmailStr` fails at import time.
+- **All three auth routes are public**: None use `Depends(get_current_user)`. The router must NOT have a global auth dependency.
+- **Router prefix**: Register with `prefix="/api/v1/auth"` in `main.py`. Route functions use relative paths: `@router.post("/register")`, `@router.post("/login")`, `@router.post("/refresh")`.
+- **Wrap boto3 calls with `asyncio.to_thread()`**: Every `self.cognito.sign_up(...)`, `self.cognito.admin_confirm_sign_up(...)`, and `self.cognito.initiate_auth(...)` must be wrapped.
+- **Decode ID token with `jose.jwt.get_unverified_claims()`**: Do NOT use `verify_cognito_token()` from `core/auth.py`. The token was just obtained from Cognito and does not need JWKS verification.
+- **Import `Profile` from `app.models.profile`**: The model file is `profile.py`, not `user.py`.
+- **System prompt placeholder**: `DEFAULT_COMPANION_PROMPT` uses `{user_name}`. Use `str.format(user_name=name)` to substitute.
+- **Cognito exception handling**: Catch `botocore.exceptions.ClientError` and dispatch on `e.response["Error"]["Code"]`. See the error mapping table in the spec (Section 4).
+- **Transaction management**: Call `db.add()` for each new object (Profile, Character, Conversation), then a single `db.commit()`. If commit fails, SQLAlchemy automatically rolls back.
+
+## Next Steps
+
+backend-dev should read the spec at `shared/feature-specs/auth-endpoints.md` and implement all 8 files (3 new modules, 2 modifications, 3 test files). backend-tester should then verify all 20 acceptance criteria.

--- a/docs/pipeline/auth-endpoints-backend-dev.handoff.md
+++ b/docs/pipeline/auth-endpoints-backend-dev.handoff.md
@@ -1,0 +1,80 @@
+# Backend Dev Handoff: Auth Endpoints
+
+**Date**: 2026-02-23
+**Agent**: backend-dev
+**Status**: COMPLETE
+**Feature ID**: P01-04
+**GitHub Issue**: #6
+
+## Implemented Files
+
+### Created
+- `backend/app/schemas/auth.py` -- 6 schemas (RegisterRequest, LoginRequest, RefreshRequest, UserResponse, AuthResponse, RefreshResponse)
+- `backend/app/services/auth_service.py` -- AuthService class with 3 public methods (register, login, refresh) + DEFAULT_COMPANION_PROMPT constant
+- `backend/app/routes/auth.py` -- 3 route handlers (POST /register, POST /login, POST /refresh)
+- `backend/tests/test_auth_routes.py` -- 17 route-level integration tests
+- `backend/tests/test_auth_service.py` -- 11 service-level unit tests
+- `backend/tests/test_auth_schemas.py` -- 13 schema validation tests
+
+### Modified
+- `backend/app/main.py` -- Added auth router registration at `/api/v1/auth`
+- `backend/requirements.txt` -- Added `email-validator>=2.0.0,<3.0.0`
+
+## Endpoints Implemented
+
+| Method | Path | Status Code | Description |
+|--------|------|-------------|-------------|
+| POST | `/api/v1/auth/register` | 201 | Cognito signup + DB profile + default character + auto-conversation |
+| POST | `/api/v1/auth/login` | 200 | Cognito USER_PASSWORD_AUTH + profile lookup |
+| POST | `/api/v1/auth/refresh` | 200 | Cognito REFRESH_TOKEN_AUTH, returns new ID token |
+
+All three endpoints are public (no JWT required).
+
+## Test Results
+
+```
+pytest: 485 passed (41 new auth tests + 444 pre-existing), 0 failed
+ruff: clean (all new/modified files)
+No hardcoded secrets found
+```
+
+## Test Command
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests/test_auth_routes.py backend/tests/test_auth_service.py backend/tests/test_auth_schemas.py -v
+```
+
+## Known Issues / Deviations from Spec
+
+- None. All 20 acceptance criteria from the spec are covered by the implementation and tests.
+
+## Notes for Backend Tester
+
+### Mocking Strategy
+
+- **Cognito client**: Mock `app.services.auth_service.boto3.client` with a `MagicMock` (NOT `AsyncMock`). The boto3 calls are synchronous and run via `asyncio.to_thread()`. Using `AsyncMock` causes "coroutine not subscriptable" errors.
+- **JWT decode**: Mock `app.services.auth_service.jwt.get_unverified_claims` to return `{"sub": "test-uuid"}`.
+- **Database**: Override `get_db` dependency to yield a configured `AsyncMock` session. Key mock setup:
+  - `mock_db.execute` returns a `MagicMock` with `.scalar_one_or_none()` configured
+  - `mock_db.add` should be a `MagicMock` (sync call)
+  - `mock_db.commit` and `mock_db.refresh` should be `AsyncMock`
+- **Cognito errors**: Use `botocore.exceptions.ClientError` with the appropriate error code in the `Error.Code` field.
+
+### Key Code Paths to Test Thoroughly
+
+- **Register idempotent recovery**: When Cognito returns `UsernameExistsException`, the service attempts authentication. If auth succeeds and no profile exists, it creates the missing DB rows. If auth fails (wrong password), it returns 400.
+- **UserResponse.id coercion**: The `UserResponse` schema has a `field_validator("id", mode="before")` to convert `uuid.UUID` to `str`. Verify this works with real Profile ORM objects.
+- **Email normalization**: Both `RegisterRequest` and `LoginRequest` lowercase and strip email before passing to Cognito.
+- **Name trimming**: `RegisterRequest` strips whitespace from name. A name that becomes empty after trimming fails validation.
+
+### Cognito Error Code Mapping
+
+| Error Code | Register | Login | Refresh |
+|-----------|----------|-------|---------|
+| UsernameExistsException | 400 (or idempotent recovery) | N/A | N/A |
+| InvalidPasswordException | 400 | N/A | N/A |
+| NotAuthorizedException | N/A | 401 | 401 |
+| UserNotConfirmedException | N/A | 401 | N/A |
+| UserNotFoundException | N/A | 401 | 401 |
+| TooManyRequestsException | 429 | N/A | N/A |
+| Other ClientError | 503 | 503 | 503 |

--- a/docs/pipeline/auth-endpoints-backend-test.handoff.md
+++ b/docs/pipeline/auth-endpoints-backend-test.handoff.md
@@ -1,0 +1,109 @@
+# Backend Test Handoff: Auth Endpoints
+
+**Date**: 2026-02-23
+**Agent**: backend-tester
+**Status**: COMPLETE
+**Feature ID**: P01-04
+**GitHub Issue**: #6
+
+## Test Files Written
+- `backend/tests/test_auth_routes_extended.py` -- 33 tests (idempotent registration, Cognito error mapping, response schema validation, email normalization, password edge cases, name edge cases, request body edge cases)
+- `backend/tests/test_auth_service_extended.py` -- 30 tests (idempotent registration, DB transaction rollback, Cognito error mapping completeness, non-401 re-raise, login Cognito 503, asyncio.to_thread verification, DB row field validation, DEFAULT_COMPANION_PROMPT, _extract_sub, lazy init, login DB query)
+- `backend/tests/test_auth_schemas_extended.py` -- 47 tests (email edge cases, password edge cases, name edge cases, RefreshRequest, UserResponse extended, AuthResponse, RefreshResponse)
+
+## Pre-existing Test Files (from backend-dev)
+- `backend/tests/test_auth_routes.py` -- 17 tests
+- `backend/tests/test_auth_service.py` -- 11 tests
+- `backend/tests/test_auth_schemas.py` -- 13 tests
+
+## Coverage Results
+- Lines: 100% (target: >= 80%) -- 186/186 statements covered
+- Branches: 100% (target: >= 70%) -- 24/24 branches covered
+- All previously uncovered lines (217, 338, 349, 354 in auth_service.py) now covered
+
+## Test Run Results
+- Total auth tests: 151 (41 original + 110 new)
+- Full suite: 595 passed (151 auth + 444 pre-existing)
+- Failed: 0
+- Skipped: 0
+
+## Test Command
+```bash
+backend/.venv/bin/python -m pytest backend/tests/ -v --tb=short --ignore=backend/tests/test_migration.py
+```
+
+## Spec Scenario Coverage (30 scenarios from spec)
+
+All 30 scenarios from `shared/feature-specs/auth-endpoints.md` Section 6 are covered:
+
+| Spec # | Scenario | Covered By |
+|--------|----------|-----------|
+| 1 | Register success (201) | test_auth_routes.py + extended |
+| 2 | Register email exists (400) | test_auth_routes.py + extended idempotent tests |
+| 3 | Register bad password (400) | test_auth_routes.py |
+| 4 | Register missing email (422) | test_auth_routes.py |
+| 5 | Register missing name (422) | test_auth_routes.py |
+| 6 | Register invalid email (422) | test_auth_routes.py + extended email edge cases |
+| 7 | Register short password (422) | test_auth_routes.py + extended password edge cases |
+| 8 | Register whitespace name (422) | test_auth_routes.py + extended name edge cases |
+| 9 | Login success (200) | test_auth_routes.py |
+| 10 | Login wrong password (401) | test_auth_routes.py |
+| 11 | Login non-existent email (401) | test_auth_routes.py |
+| 12 | Login UserNotConfirmed (401) | test_auth_routes.py |
+| 13 | Login no profile in DB (401) | test_auth_routes.py |
+| 14 | Refresh success (200) | test_auth_routes.py + extended |
+| 15 | Refresh invalid token (401) | test_auth_routes.py + extended |
+| 16 | Refresh missing field (422) | test_auth_routes.py + extended |
+| 17 | Register Cognito unavailable (503) | test_auth_routes.py + extended |
+| 18 | Register Cognito call order | test_auth_service.py |
+| 19 | Register creates 3 DB rows | test_auth_service.py + extended |
+| 20 | Register mem0 IDs | test_auth_service.py + extended |
+| 21 | Register character name/prompt | test_auth_service.py + extended |
+| 22 | Login Cognito + DB query | test_auth_service.py + extended |
+| 23 | Login no profile raises | test_auth_service.py |
+| 24 | Refresh calls Cognito correctly | test_auth_service.py + extended |
+| 25 | asyncio.to_thread wrapping | test_auth_service_extended.py |
+| 26 | Strip name whitespace | test_auth_schemas.py + extended |
+| 27 | Lowercase email | test_auth_schemas.py + extended |
+| 28 | Whitespace-only name rejected | test_auth_schemas.py + extended |
+| 29 | Login email lowercase | test_auth_schemas.py + extended |
+| 30 | UserResponse from ORM | test_auth_schemas.py + extended |
+
+## Additional Scenarios Tested (beyond spec)
+
+- Idempotent registration: Cognito user exists + DB profile missing (recovery path)
+- Idempotent registration: Cognito user exists + DB profile exists (skip creation)
+- Idempotent registration: wrong password during recovery returns 400
+- Non-401 exception during idempotent recovery propagates (503, not converted to 400)
+- DB commit failure propagates error
+- InvalidParameterException maps to 400
+- TooManyRequestsException maps to 429
+- Login Cognito unavailable maps to 503
+- Refresh UserNotFoundException maps to 401
+- Refresh Cognito unavailable maps to 503
+- asyncio.to_thread used for all 3 flows (register/login/refresh)
+- Character/Conversation field-level validation
+- UUID generation for Character and Conversation IDs
+- db.commit called exactly once during registration
+- db.refresh called on Profile after commit
+- Login does not modify DB (no add/commit/refresh)
+- Cognito client lazy initialization and reuse
+- DEFAULT_COMPANION_PROMPT content validation
+- _extract_sub with different UUID values
+- Response schema field presence and types (all fields)
+- RefreshResponse excludes refresh_token
+- Email normalization with plus addressing, dots, mixed case
+- Password boundary values (7 vs 8 chars, empty, very long, unicode, spaces)
+- Name boundary values (1 char, 100 chars, 101 chars, tabs, newlines, unicode, special chars)
+- Request body edge cases (empty body, null fields, extra fields, wrong content type)
+- RefreshRequest validation (empty, missing, long token)
+- UserResponse id coercion from UUID and string
+- AuthResponse and RefreshResponse serialization
+
+## Issues Found During Testing
+- None. All implementation code matches the spec. Coverage was already 98% from the backend-dev's tests; the extended tests brought it to 100% by covering the remaining 4 uncovered lines and all 24 branches.
+
+## Notes for Reviewer
+- The `_handle_existing_cognito_user` method has a re-raise path (line 338) for non-401 HTTP exceptions during idempotent recovery. This is now tested by `TestHandleExistingCognitoUserNon401`.
+- All Cognito error codes from the spec's error mapping table are tested at both route and service level.
+- The asyncio.to_thread wrapping is verified using `wraps=asyncio.to_thread` to ensure calls actually go through the thread executor.

--- a/docs/pipeline/auth-endpoints-doc.handoff.md
+++ b/docs/pipeline/auth-endpoints-doc.handoff.md
@@ -1,0 +1,15 @@
+# Doc Writer Handoff: Auth Endpoints
+
+**Date**: 2026-02-23
+**Agent**: doc-writer
+**Status**: COMPLETE
+
+## Documents Written
+- `docs/features/auth-endpoints.md` -- main feature documentation
+- `CHANGELOG.md` -- added entry under [Unreleased]
+
+## Summary
+Documented the three public auth endpoints (register, login, refresh) including the full registration data flow, idempotent recovery for Cognito-DB split-brain scenarios, Cognito error mapping, Pydantic schema details, the default companion character setup, Mem0 identifier assignment, and all design decisions. Testing section references the 151 tests achieving 100% line and branch coverage.
+
+## Notes
+- None. All handoff files (architect, backend-dev, backend-tester) were consistent with each other and with the implementation code. No ambiguities or deviations found.

--- a/docs/pipeline/auth-endpoints-review.handoff.md
+++ b/docs/pipeline/auth-endpoints-review.handoff.md
@@ -1,0 +1,98 @@
+# Reviewer Handoff: Auth Endpoints
+
+**Date**: 2026-02-23
+**Agent**: reviewer
+**Status**: APPROVED
+**Feature ID**: P01-04
+**GitHub Issue**: #6
+**Layer**: backend
+
+## Review Summary
+
+| Category | Passed | Warnings | Issues |
+|----------|--------|----------|--------|
+| Security | 7 | 0 | 0 |
+| Architecture | 5 | 0 | 0 |
+| Backend Code Quality | 7 | 0 | 0 |
+| Testing | 7 | 0 | 0 |
+| **Total** | **26** | **0** | **0** |
+
+## Grep Check Results
+
+| Check | Result |
+|-------|--------|
+| `OFFSET` in backend/app/ | No matches |
+| Hardcoded secrets (api_key, password, secret) | No matches |
+| `print()` in backend/app/ | No matches |
+| `user_id` from request body in routes | No matches |
+| Synchronous `def` in routes/ | No matches |
+| `/conversations` path in routes | No matches |
+| `TODO`/`FIXME` in new production code | No matches |
+| All route handlers `async def` | 3/3 (register, login, refresh) |
+| All service public methods `async def` | 3/3 (register, login, refresh) |
+| `asyncio.to_thread` wrapping Cognito calls | 4 call sites confirmed |
+
+## Security Review
+
+- **No email enumeration**: Both `NotAuthorizedException` and `UserNotFoundException` return identical "Invalid email or password" message. Profile-not-found case also returns this generic message.
+- **Password handling**: Password is passed through to Cognito only, never stored, never logged. No `logging` calls reference password values.
+- **No hardcoded secrets**: All configuration via `pydantic-settings` from environment variables. Grep confirmed zero hardcoded API keys, passwords, or tokens.
+- **Cognito calls non-blocking**: All 4 synchronous Cognito wrappers (`_cognito_sign_up`, `_cognito_admin_confirm`, `_cognito_initiate_auth_sync`, `_cognito_refresh`) are called exclusively via `asyncio.to_thread()`. Verified by test class `TestAsyncioToThread` which wraps `asyncio.to_thread` to confirm call counts.
+- **DB transaction atomicity**: `_create_profile_and_character` performs 3 `db.add()` calls then a single `db.commit()`. Verified by `test_db_commit_called_once`.
+- **Idempotent registration**: `_handle_existing_cognito_user` handles the Cognito-DB split-brain scenario. If Cognito user exists but DB profile is missing, it authenticates and creates the profile. If password is wrong, returns 400. If Cognito is unavailable (503), it propagates the 503 (not 400). All three paths tested.
+- **ID token decoded without JWKS verification**: Uses `jose.jwt.get_unverified_claims()` only for tokens obtained directly from Cognito over TLS. This is the correct approach per the spec.
+- **SQL injection prevention**: Only query is `select(Profile).where(Profile.id == sub)` using SQLAlchemy parameterized statement. No raw SQL.
+
+## Files Reviewed
+
+**Backend Implementation**:
+- `backend/app/routes/auth.py` -- PASS (3 route handlers, all async, no business logic, correct status codes)
+- `backend/app/services/auth_service.py` -- PASS (AuthService with register/login/refresh, proper error mapping, asyncio.to_thread wrapping, single-transaction DB writes)
+- `backend/app/schemas/auth.py` -- PASS (6 Pydantic v2 schemas, email normalization, name trimming, id coercion)
+- `backend/app/main.py` -- PASS (auth router registered at `/api/v1/auth`)
+- `backend/requirements.txt` -- PASS (`email-validator>=2.0.0,<3.0.0` added)
+
+**Backend Tests**:
+- `backend/tests/test_auth_routes.py` -- PASS (17 route-level tests covering all 3 endpoints)
+- `backend/tests/test_auth_routes_extended.py` -- PASS (33 tests: idempotent registration, error mapping, schema validation, edge cases)
+- `backend/tests/test_auth_service.py` -- PASS (11 service-level tests: Cognito call order, DB row creation, Mem0 IDs, character fields)
+- `backend/tests/test_auth_service_extended.py` -- PASS (30 tests: idempotent recovery, DB rollback, error mapping completeness, asyncio.to_thread verification, field validation, lazy init)
+- `backend/tests/test_auth_schemas.py` -- PASS (13 schema validation tests)
+- `backend/tests/test_auth_schemas_extended.py` -- PASS (47 tests: email edge cases, password edge cases, name edge cases, response schema construction)
+
+**Coverage**: 100% line (186/186 statements), 100% branch (24/24 branches). Exceeds 80% minimum.
+
+## Spec Compliance
+
+All 20 acceptance criteria from `shared/feature-specs/auth-endpoints.md` Section 8 are satisfied:
+1. Register returns 201 with correct response shape -- verified
+2. Profile row created with correct fields -- verified
+3. Character row created with template=companion, is_default=true, name=Ember -- verified
+4. Conversation row created linked to default character -- verified
+5. Duplicate email returns 400 -- verified
+6. Weak password returns 400 -- verified
+7. Valid login returns 200 with correct shape -- verified
+8. Wrong password returns 401 with generic message -- verified
+9. Non-existent email returns 401 with generic message -- verified
+10. Valid refresh returns 200 with token only -- verified
+11. Invalid refresh token returns 401 -- verified
+12. Pydantic validation failures return 422 -- verified
+13. Business logic in service layer, not routes -- verified
+14. All Cognito calls wrapped with asyncio.to_thread -- verified
+15. Email lowercased and stripped -- verified
+16. Name whitespace stripped -- verified
+17. ruff passes on all new files -- verified per backend-dev handoff
+18. All tests pass -- verified per backend-tester handoff (595 passed, 0 failed)
+19. Response format matches docs/04-veri-api.md contract -- verified
+20. Endpoints available at /api/v1/auth/* -- verified via main.py router registration
+
+All 30 test scenarios from the spec Section 6 are covered, plus 25+ additional scenarios beyond spec.
+
+## Issues Resolved During Review
+
+- None (first-pass clean)
+
+## Warnings (Not Blocking)
+
+- `auth_service.py` line 341: `# noqa: ANN401` suppression is unnecessary -- the method `_raise_cognito_error(code: str) -> None` does not use `Any`. Harmless but could be cleaned up.
+- `routes/auth.py` line 76: `AuthService(db=None)` with `type: ignore[arg-type]` for the refresh endpoint is a pragmatic choice. A future improvement could make `db` an `Optional[AsyncSession]` in the `AuthService.__init__` to avoid the type ignore.

--- a/shared/feature-specs/auth-endpoints.md
+++ b/shared/feature-specs/auth-endpoints.md
@@ -1,0 +1,923 @@
+# Feature Spec: P01-04 -- Auth Endpoints
+
+**Feature ID**: P01-04
+**Phase**: 1
+**Layer**: backend
+**GitHub Issue**: #6
+**Date**: 2026-02-23
+**Author**: architect
+
+---
+
+## 1. Overview
+
+### What This Feature Does
+
+This feature implements three public authentication endpoints for the Ember backend:
+
+1. **POST /api/v1/auth/register** -- Creates a new user in AWS Cognito, creates a `profiles` row in the database, initializes a Mem0 user, creates a default "General Friend" character with the `companion` template, creates the corresponding auto-conversation for that character, and returns tokens plus user data.
+
+2. **POST /api/v1/auth/login** -- Authenticates an existing user against AWS Cognito using `USER_PASSWORD_AUTH` flow, looks up the profile in the database, and returns tokens plus user data.
+
+3. **POST /api/v1/auth/refresh** -- Exchanges a Cognito refresh token for a new access (ID) token.
+
+All three endpoints are **public** (no JWT required). The register and login endpoints return the Cognito ID token (which Ember uses as its access token), a refresh token, and the user profile. The refresh endpoint returns only a new ID token.
+
+### Why It Exists
+
+Without these endpoints, no user can create an account, sign in, or refresh their session. This is the entry point for every user in the Ember application. The register flow is particularly important because it bootstraps the user's entire environment: database profile, Mem0 memory space, and the default character that every user starts with.
+
+### Dependencies
+
+- **Requires**: P01-01 (project-setup -- FastAPI scaffold, config, health endpoint)
+- **Requires**: P01-02 (database-schema -- Profile, Character, Conversation models)
+- **Requires**: P01-03 (cognito-auth-middleware -- `verify_cognito_token`, `get_current_user`)
+- **Blocks**: All subsequent features that require an authenticated user
+
+### What This Feature Does NOT Do
+
+- It does not implement email verification flows. Cognito handles verification emails if configured.
+- It does not implement forgot-password or reset-password. Those are Phase 2 features.
+- It does not implement social login (Google, Apple). Those are Phase 4 features.
+- It does not generate dynamic system prompts via Claude. The default companion character uses a hardcoded template prompt. Dynamic prompt generation (via Claude Haiku) is a separate feature for custom characters.
+- It does not create onboarding memories in Mem0. Onboarding is a separate feature that runs after the first login.
+
+---
+
+## 2. Data Models
+
+### No New Tables
+
+This feature does not create or modify any database tables. It writes to three existing tables defined in P01-02 (documented in `docs/04-veri-api.md`):
+
+- **profiles** -- A new row is inserted during registration with the Cognito `sub` as the primary key.
+- **characters** -- A new row is inserted for the default "General Friend" character with `template="companion"` and `is_default=true`.
+- **conversations** -- A new row is inserted for the auto-conversation linked to the default character.
+
+### Key Column References
+
+| Table | Column | Usage in This Feature |
+|-------|--------|----------------------|
+| `profiles.id` | UUID PK | Set to the Cognito `sub` UUID returned by `sign_up` |
+| `profiles.email` | TEXT UNIQUE | Set from the registration request body |
+| `profiles.name` | TEXT | Set from the registration request body |
+| `profiles.mem0_user_id` | TEXT UNIQUE | Set to `"user_{cognito_sub}"` during registration |
+| `characters.user_id` | UUID FK | Points to the new profile |
+| `characters.template` | TEXT | Set to `"companion"` for the default character |
+| `characters.mem0_agent_id` | TEXT UNIQUE | Set to `"companion_{cognito_sub}"` |
+| `characters.is_default` | BOOLEAN | Set to `true` for the default character |
+| `characters.system_prompt` | TEXT | Set to the hardcoded companion template prompt |
+| `conversations.character_id` | UUID FK UNIQUE | Points to the default character |
+| `conversations.user_id` | UUID FK | Points to the new profile |
+
+### Mem0 Operations
+
+During registration, a Mem0 user is initialized. No memories are added at this stage -- that happens during onboarding and conversations.
+
+- **Mem0 user_id**: `"user_{cognito_sub}"` -- this is stored in `profiles.mem0_user_id`.
+- **Mem0 agent_id** for the default character: `"companion_{cognito_sub}"` -- this follows the `{template}_{user_id}` pattern from `docs/05-ai-bellek.md`.
+
+The actual Mem0 "user creation" is implicit. Mem0 creates user records lazily on the first `add()` or `search()` call. The registration flow does NOT need to make an explicit Mem0 API call to create the user. The `mem0_user_id` stored in the profile is simply the identifier that will be passed to all future Mem0 calls.
+
+---
+
+## 3. API Endpoints
+
+All endpoints are under the `/api/v1` prefix. All three are **public** (no `Authorization` header required).
+
+---
+
+### POST /api/v1/auth/register
+
+Creates a new user account.
+
+```
+Auth: None (public endpoint)
+Content-Type: application/json
+```
+
+**Request Body:**
+
+```json
+{
+  "email": "user@example.com",
+  "password": "SecurePass123!",
+  "name": "Alex"
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `email` | string | yes | Valid email format, max 320 chars |
+| `password` | string | yes | Min 8 chars (Cognito enforces its own policy on top) |
+| `name` | string | yes | Min 1 char, max 100 chars, whitespace-trimmed |
+
+**Response 201 Created:**
+
+```json
+{
+  "token": "eyJraWQiOiJ...",
+  "refresh_token": "eyJjdHkiOiJ...",
+  "user": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "email": "user@example.com",
+    "name": "Alex",
+    "onboarding_completed": false,
+    "subscription_tier": "free",
+    "preferred_language": "en",
+    "timezone": "UTC",
+    "avatar_url": null,
+    "created_at": "2026-02-23T14:30:00Z"
+  }
+}
+```
+
+**Error Responses:**
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| 400 | Email already registered in Cognito | `{"detail": "An account with this email already exists"}` |
+| 400 | Password does not meet Cognito policy | `{"detail": "Password does not meet requirements"}` |
+| 422 | Pydantic validation failure (missing fields, invalid email format) | Standard FastAPI 422 response |
+| 503 | Cognito service unavailable | `{"detail": "Authentication service unavailable"}` |
+
+---
+
+### POST /api/v1/auth/login
+
+Authenticates an existing user.
+
+```
+Auth: None (public endpoint)
+Content-Type: application/json
+```
+
+**Request Body:**
+
+```json
+{
+  "email": "user@example.com",
+  "password": "SecurePass123!"
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `email` | string | yes | Valid email format |
+| `password` | string | yes | Non-empty |
+
+**Response 200 OK:**
+
+```json
+{
+  "token": "eyJraWQiOiJ...",
+  "refresh_token": "eyJjdHkiOiJ...",
+  "user": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "email": "user@example.com",
+    "name": "Alex",
+    "onboarding_completed": false,
+    "subscription_tier": "free",
+    "preferred_language": "en",
+    "timezone": "UTC",
+    "avatar_url": null,
+    "created_at": "2026-02-23T14:30:00Z"
+  }
+}
+```
+
+**Error Responses:**
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| 401 | Wrong email or password | `{"detail": "Invalid email or password"}` |
+| 401 | User not confirmed in Cognito | `{"detail": "User is not confirmed"}` |
+| 401 | Profile not found in database (orphaned Cognito user) | `{"detail": "Invalid email or password"}` |
+| 422 | Pydantic validation failure | Standard FastAPI 422 response |
+| 503 | Cognito service unavailable | `{"detail": "Authentication service unavailable"}` |
+
+**Security note**: The "Invalid email or password" message is intentionally generic for both wrong-email and wrong-password cases. This prevents email enumeration attacks. The "Profile not found" case also uses the same generic message.
+
+---
+
+### POST /api/v1/auth/refresh
+
+Refreshes an expired access token.
+
+```
+Auth: None (public endpoint)
+Content-Type: application/json
+```
+
+**Request Body:**
+
+```json
+{
+  "refresh_token": "eyJjdHkiOiJ..."
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `refresh_token` | string | yes | Non-empty |
+
+**Response 200 OK:**
+
+```json
+{
+  "token": "eyJraWQiOiJ..."
+}
+```
+
+**Error Responses:**
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| 401 | Refresh token is invalid or expired | `{"detail": "Invalid or expired refresh token"}` |
+| 422 | Pydantic validation failure | Standard FastAPI 422 response |
+| 503 | Cognito service unavailable | `{"detail": "Authentication service unavailable"}` |
+
+**Note**: The refresh endpoint does NOT return `refresh_token` in the response. Cognito's `REFRESH_TOKEN_AUTH` flow returns a new ID token and access token but does NOT issue a new refresh token. The client retains its existing refresh token (valid for 30 days per `docs/08-guvenlik-performans.md`).
+
+---
+
+## 4. Backend Logic
+
+### Registration Flow (Step-by-Step)
+
+```
+Client sends: POST /api/v1/auth/register
+    { email, password, name }
+         |
+         v
+    1. Validate request body (Pydantic)
+         |
+         v
+    2. Call Cognito sign_up(email, password)
+         |
+         +--> UsernameExistsException → 400 "An account with this email already exists"
+         +--> InvalidPasswordException → 400 "Password does not meet requirements"
+         +--> ClientError (other) → 503 "Authentication service unavailable"
+         |
+         v
+    3. Call Cognito admin_confirm_sign_up(username=email)
+         |   (Auto-confirm the user so they can log in immediately.
+         |    In production, this may be replaced by email verification
+         |    via a Cognito pre-sign-up Lambda trigger.)
+         |
+         v
+    4. Call Cognito initiate_auth(USER_PASSWORD_AUTH, email, password)
+         |   Returns: IdToken, RefreshToken, AccessToken
+         |   (We use IdToken as Ember's "access token")
+         |
+         v
+    5. Decode the IdToken to extract the Cognito `sub` (UUID)
+         |   Use jose.jwt.get_unverified_claims() — we trust this token
+         |   because we just obtained it directly from Cognito.
+         |
+         v
+    6. Build mem0_user_id = f"user_{sub}"
+       Build mem0_agent_id = f"companion_{sub}"
+         |
+         v
+    7. Create Profile row:
+         id = sub (UUID)
+         email = request.email
+         name = request.name
+         mem0_user_id = mem0_user_id
+         timezone = "UTC" (default)
+         preferred_language = "en" (default)
+         onboarding_completed = false
+         subscription_tier = "free"
+         |
+         v
+    8. Create default Character row:
+         id = uuid4()
+         user_id = sub
+         name = "Ember"
+         template = "companion"
+         description = null
+         system_prompt = DEFAULT_COMPANION_PROMPT (hardcoded constant)
+         mem0_agent_id = mem0_agent_id
+         avatar_style = "default"
+         is_default = true
+         is_active = true
+         |
+         v
+    9. Create Conversation row:
+         id = uuid4()
+         user_id = sub
+         character_id = character.id
+         last_message_at = null
+         |
+         v
+   10. Commit all DB writes in a single transaction
+         |
+         v
+   11. Return 201 { token: IdToken, refresh_token: RefreshToken, user: UserResponse }
+```
+
+**Important**: Steps 7-9 are all part of a single database transaction. If any step fails, the entire transaction rolls back. However, the Cognito user (steps 2-3) has already been created. The service must handle this partial-failure scenario:
+
+- If DB insertion fails after Cognito signup, the Cognito user exists but has no profile. On the next login attempt, the backend will not find a profile and return 401 "Invalid email or password". The user can try registering again, which will get a "email already exists" error from Cognito. To handle this gracefully, the register flow should check if a Cognito user already exists but has no profile, and if so, proceed from step 4 (authenticate and create the profile). This is a known edge case.
+- **Recommended approach**: Catch the `UsernameExistsException` in step 2. When caught, attempt to authenticate (step 4). If authentication succeeds and no profile exists in the DB, proceed with steps 5-10 to create the profile and character. If authentication fails (wrong password), return 400 "An account with this email already exists". This makes registration idempotent for the case where Cognito signup succeeded but DB creation failed.
+
+### Login Flow (Step-by-Step)
+
+```
+Client sends: POST /api/v1/auth/login
+    { email, password }
+         |
+         v
+    1. Validate request body (Pydantic)
+         |
+         v
+    2. Call Cognito initiate_auth(USER_PASSWORD_AUTH, email, password)
+         |
+         +--> NotAuthorizedException → 401 "Invalid email or password"
+         +--> UserNotConfirmedException → 401 "User is not confirmed"
+         +--> ClientError (other) → 503 "Authentication service unavailable"
+         |
+         v
+    3. Extract IdToken, RefreshToken from Cognito response
+         |
+         v
+    4. Decode the IdToken to extract the Cognito `sub` (UUID)
+         |
+         v
+    5. Look up Profile by id = sub
+         |
+         +--> Not found → 401 "Invalid email or password"
+         |       (Generic message to prevent information leakage)
+         |
+         v
+    6. Return 200 { token: IdToken, refresh_token: RefreshToken, user: UserResponse }
+```
+
+### Refresh Flow (Step-by-Step)
+
+```
+Client sends: POST /api/v1/auth/refresh
+    { refresh_token }
+         |
+         v
+    1. Validate request body (Pydantic)
+         |
+         v
+    2. Call Cognito initiate_auth(REFRESH_TOKEN_AUTH, refresh_token)
+         |
+         +--> NotAuthorizedException → 401 "Invalid or expired refresh token"
+         +--> ClientError (other) → 503 "Authentication service unavailable"
+         |
+         v
+    3. Extract new IdToken from Cognito response
+         |
+         v
+    4. Return 200 { token: IdToken }
+```
+
+### Service Layer Design
+
+#### AuthService Class
+
+The `AuthService` class in `backend/app/services/auth_service.py` encapsulates all authentication business logic. Route handlers delegate to this service; they do not contain business logic themselves.
+
+```
+class AuthService:
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+        self._cognito_client = None  # Lazy-initialized boto3 client
+
+    @property
+    def cognito(self) -> CognitoIdentityProviderClient:
+        """Lazy-initialize the boto3 Cognito client."""
+        if self._cognito_client is None:
+            self._cognito_client = boto3.client(
+                "cognito-idp",
+                region_name=settings.aws_region,
+            )
+        return self._cognito_client
+
+    async def register(self, email: str, password: str, name: str) -> AuthResponse:
+        """Register a new user: Cognito signup + DB profile + default character."""
+
+    async def login(self, email: str, password: str) -> AuthResponse:
+        """Authenticate user via Cognito and return tokens + profile."""
+
+    async def refresh(self, refresh_token: str) -> RefreshResponse:
+        """Refresh an access token via Cognito."""
+```
+
+**Why boto3 sync client in async service**: The `boto3` Cognito IDP client is synchronous. Since all Cognito API calls are I/O-bound (network calls to AWS), they must be wrapped with `asyncio.to_thread()` to avoid blocking the event loop:
+
+```python
+result = await asyncio.to_thread(
+    self.cognito.sign_up,
+    ClientId=settings.cognito_app_client_id,
+    Username=email,
+    Password=password,
+    UserAttributes=[{"Name": "email", "Value": email}],
+)
+```
+
+All three Cognito calls (`sign_up`, `admin_confirm_sign_up`, `initiate_auth`) must use `asyncio.to_thread()`.
+
+#### Default Companion System Prompt
+
+The default companion character's system prompt is a constant defined in the auth service module (or a separate constants file). It is NOT generated dynamically via Claude. Dynamic generation is for custom characters in a future feature.
+
+```
+DEFAULT_COMPANION_PROMPT = (
+    "You are {user_name}'s personal AI companion. "
+    "You are a holistic life friend -- covering fitness, nutrition, work, stress, and relationships. "
+    "You are warm, honest, and genuine but never overly positive. "
+    "You remember everything about the user and get to know them better over time. "
+    "Use what you know naturally -- never say 'I remember that...' -- just know it. "
+    "Keep messages concise. Ask questions when needed, don't monologue."
+)
+```
+
+The `{user_name}` placeholder is replaced with the user's `name` at character creation time.
+
+#### Cognito API Details
+
+The following Cognito Identity Provider API calls are used:
+
+**sign_up** (registration step 2):
+```python
+cognito.sign_up(
+    ClientId=settings.cognito_app_client_id,
+    Username=email,        # Cognito username = email
+    Password=password,
+    UserAttributes=[
+        {"Name": "email", "Value": email},
+        {"Name": "name", "Value": name},
+    ],
+)
+```
+
+**admin_confirm_sign_up** (registration step 3):
+```python
+cognito.admin_confirm_sign_up(
+    UserPoolId=settings.cognito_user_pool_id,
+    Username=email,
+)
+```
+
+This requires the backend's IAM role to have `cognito-idp:AdminConfirmSignUp` permission. This is acceptable because:
+- The backend runs on ECS Fargate with an IAM task role.
+- Auto-confirming during development simplifies the flow. In production, a Cognito pre-sign-up Lambda trigger can replace this.
+
+**initiate_auth** (login and registration step 4):
+```python
+cognito.initiate_auth(
+    ClientId=settings.cognito_app_client_id,
+    AuthFlow="USER_PASSWORD_AUTH",
+    AuthParameters={
+        "USERNAME": email,
+        "PASSWORD": password,
+    },
+)
+```
+
+Returns `AuthenticationResult` containing `IdToken`, `AccessToken`, `RefreshToken`, `ExpiresIn`.
+
+**initiate_auth** (refresh):
+```python
+cognito.initiate_auth(
+    ClientId=settings.cognito_app_client_id,
+    AuthFlow="REFRESH_TOKEN_AUTH",
+    AuthParameters={
+        "REFRESH_TOKEN": refresh_token,
+    },
+)
+```
+
+Returns `AuthenticationResult` containing `IdToken`, `AccessToken`, `ExpiresIn` (no new `RefreshToken`).
+
+**Important**: `USER_PASSWORD_AUTH` must be enabled in the Cognito User Pool App Client configuration. This is an infrastructure concern, not a code concern, but the developer should document this requirement.
+
+### Error Handling
+
+All Cognito exceptions from `botocore.exceptions.ClientError` are caught and mapped to appropriate HTTP responses. The service MUST NOT expose raw AWS error messages to the client.
+
+| Cognito Exception Code | HTTP Status | Response Detail |
+|------------------------|-------------|-----------------|
+| `UsernameExistsException` | 400 | "An account with this email already exists" |
+| `InvalidPasswordException` | 400 | "Password does not meet requirements" |
+| `InvalidParameterException` | 400 | "Invalid request parameters" |
+| `NotAuthorizedException` | 401 | "Invalid email or password" (login) or "Invalid or expired refresh token" (refresh) |
+| `UserNotConfirmedException` | 401 | "User is not confirmed" |
+| `UserNotFoundException` | 401 | "Invalid email or password" |
+| `TooManyRequestsException` | 429 | "Too many requests, please try again later" |
+| Any other `ClientError` | 503 | "Authentication service unavailable" |
+
+The error handling pattern:
+
+```python
+try:
+    result = await asyncio.to_thread(self.cognito.sign_up, ...)
+except self.cognito.exceptions.UsernameExistsException:
+    raise HTTPException(status_code=400, detail="An account with this email already exists")
+except ClientError as e:
+    code = e.response["Error"]["Code"]
+    # Map code to HTTP status and detail
+    ...
+```
+
+Note: `boto3` client exceptions are accessed via `client.exceptions.ExceptionName`, but `botocore.exceptions.ClientError` is the base class. The service should catch `ClientError` as the fallback after catching specific named exceptions.
+
+---
+
+## 5. Pydantic Schemas
+
+All schemas use Pydantic v2 patterns from `docs/standards/backend.md` Section 4.
+
+### Request Schemas
+
+```
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(..., min_length=8)
+    name: str = Field(..., min_length=1, max_length=100)
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, v: str) -> str:
+        return v.strip()
+
+    @field_validator("email")
+    @classmethod
+    def lowercase_email(cls, v: str) -> str:
+        return v.lower().strip()
+```
+
+```
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(..., min_length=1)
+
+    @field_validator("email")
+    @classmethod
+    def lowercase_email(cls, v: str) -> str:
+        return v.lower().strip()
+```
+
+```
+class RefreshRequest(BaseModel):
+    refresh_token: str = Field(..., min_length=1)
+```
+
+### Response Schemas
+
+```
+class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str                        # UUID as string
+    email: str
+    name: str
+    onboarding_completed: bool
+    subscription_tier: str
+    preferred_language: str
+    timezone: str
+    avatar_url: str | None
+    created_at: datetime
+```
+
+```
+class AuthResponse(BaseModel):
+    token: str                     # Cognito ID token
+    refresh_token: str             # Cognito refresh token
+    user: UserResponse
+```
+
+```
+class RefreshResponse(BaseModel):
+    token: str                     # New Cognito ID token
+```
+
+### Notes
+
+- `EmailStr` requires the `email-validator` package. It must be added to `requirements.txt`.
+- The `UserResponse.id` field is `str` (not `UUID`) because all IDs in Ember API responses are UUID strings per `docs/standards/common.md` Section 5.
+- `from_attributes=True` allows constructing `UserResponse` directly from the `Profile` ORM object.
+- The `created_at` field serializes as ISO 8601 UTC automatically via Pydantic v2.
+
+---
+
+## 6. Test Requirements
+
+### Route Tests (`backend/tests/test_auth_routes.py`)
+
+These tests use the FastAPI test client. Cognito calls are mocked at the service level.
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Register with valid email/password/name | 201, response contains `token`, `refresh_token`, and `user` with correct fields |
+| 2 | Register with email that already exists in Cognito | 400, detail = "An account with this email already exists" |
+| 3 | Register with password that fails Cognito policy | 400, detail = "Password does not meet requirements" |
+| 4 | Register with missing email field | 422 (Pydantic validation) |
+| 5 | Register with missing name field | 422 (Pydantic validation) |
+| 6 | Register with invalid email format | 422 (Pydantic validation) |
+| 7 | Register with password shorter than 8 chars | 422 (Pydantic validation) |
+| 8 | Register with name that is only whitespace | 422 (after strip, name is empty, fails min_length=1) |
+| 9 | Login with valid credentials | 200, response contains `token`, `refresh_token`, and `user` |
+| 10 | Login with wrong password | 401, detail = "Invalid email or password" |
+| 11 | Login with non-existent email | 401, detail = "Invalid email or password" |
+| 12 | Login when Cognito returns UserNotConfirmedException | 401, detail = "User is not confirmed" |
+| 13 | Login with valid Cognito auth but no profile in DB | 401, detail = "Invalid email or password" |
+| 14 | Refresh with valid refresh token | 200, response contains `token` |
+| 15 | Refresh with invalid/expired refresh token | 401, detail = "Invalid or expired refresh token" |
+| 16 | Refresh with missing refresh_token field | 422 (Pydantic validation) |
+| 17 | Register when Cognito is unavailable | 503, detail = "Authentication service unavailable" |
+
+### Service Tests (`backend/tests/test_auth_service.py`)
+
+These tests unit-test the `AuthService` class directly. Both Cognito (boto3) and the database session are mocked.
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 18 | `register()` calls Cognito sign_up, admin_confirm_sign_up, initiate_auth in order | Three Cognito calls made in the correct sequence |
+| 19 | `register()` creates Profile, Character (is_default=true, template=companion), and Conversation | All three rows added to the session; session.commit() called once |
+| 20 | `register()` sets mem0_user_id to `"user_{sub}"` and mem0_agent_id to `"companion_{sub}"` | Profile and Character have correct Mem0 identifiers |
+| 21 | `register()` sets character name to "Ember" and system_prompt to the companion template with user's name substituted | Character fields match expected values |
+| 22 | `login()` calls Cognito initiate_auth then queries Profile by sub | Cognito called once; DB queried once |
+| 23 | `login()` returns None/raises when no profile found in DB | Appropriate error raised |
+| 24 | `refresh()` calls Cognito initiate_auth with REFRESH_TOKEN_AUTH | Cognito called with correct AuthFlow |
+| 25 | All Cognito calls use `asyncio.to_thread` | Verify calls are wrapped (or mock correctly handles async) |
+
+### Schema Tests (`backend/tests/test_auth_schemas.py`)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 26 | `RegisterRequest` strips whitespace from name | Leading/trailing spaces removed |
+| 27 | `RegisterRequest` lowercases email | Uppercase letters converted to lowercase |
+| 28 | `RegisterRequest` rejects name that is only spaces (after strip) | ValidationError |
+| 29 | `LoginRequest` lowercases email | Uppercase letters converted to lowercase |
+| 30 | `UserResponse.model_validate` from Profile ORM object | All fields correctly mapped |
+
+### How to Mock Cognito
+
+Use `unittest.mock.patch` to mock the boto3 Cognito client. The service lazily initializes the client, so patching can target the service instance's `_cognito_client` attribute or the `boto3.client` factory.
+
+Recommended approach:
+
+```python
+from unittest.mock import MagicMock, patch, AsyncMock
+
+mock_cognito = MagicMock()
+mock_cognito.sign_up.return_value = {"UserSub": "test-uuid-123"}
+mock_cognito.admin_confirm_sign_up.return_value = {}
+mock_cognito.initiate_auth.return_value = {
+    "AuthenticationResult": {
+        "IdToken": "fake-id-token",
+        "RefreshToken": "fake-refresh-token",
+        "AccessToken": "fake-access-token",
+        "ExpiresIn": 3600,
+    }
+}
+
+# Patch boto3.client to return mock_cognito
+with patch("boto3.client", return_value=mock_cognito):
+    service = AuthService(db=mock_db)
+    result = await service.register(email="test@ember.ai", password="Pass1234!", name="Test")
+```
+
+For testing Cognito exceptions:
+
+```python
+from botocore.exceptions import ClientError
+
+mock_cognito.sign_up.side_effect = ClientError(
+    {"Error": {"Code": "UsernameExistsException", "Message": "User already exists"}},
+    "SignUp"
+)
+```
+
+### How to Mock the Database
+
+Use an `AsyncMock` for the `AsyncSession`. The register flow calls `db.add()`, `db.commit()`, and `db.refresh()`. The login flow calls `db.execute()` with a `select()` statement.
+
+For route-level tests, override the `get_db` dependency to yield a mock session. For service-level tests, pass a mock session directly to `AuthService(db=mock_db)`.
+
+### Code Quality Checks
+
+```bash
+ruff check backend/app/routes/auth.py backend/app/services/auth_service.py backend/app/schemas/auth.py
+mypy backend/app/routes/auth.py backend/app/services/auth_service.py backend/app/schemas/auth.py
+pytest backend/tests/test_auth_routes.py backend/tests/test_auth_service.py backend/tests/test_auth_schemas.py -v
+```
+
+---
+
+## 7. File Manifest
+
+Every file to be created or modified, grouped by purpose.
+
+### Route Handler
+
+```
+Backend:
+  CREATE  backend/app/routes/auth.py
+```
+
+Contains the three route functions (`register`, `login`, `refresh`). Each delegates to `AuthService`. No business logic in the route handlers.
+
+### Service Layer
+
+```
+Backend:
+  CREATE  backend/app/services/auth_service.py
+```
+
+Contains the `AuthService` class with `register()`, `login()`, and `refresh()` methods. Contains the `DEFAULT_COMPANION_PROMPT` constant.
+
+### Pydantic Schemas
+
+```
+Backend:
+  CREATE  backend/app/schemas/auth.py
+```
+
+Contains `RegisterRequest`, `LoginRequest`, `RefreshRequest`, `UserResponse`, `AuthResponse`, `RefreshResponse`.
+
+### Application Wiring
+
+```
+Backend:
+  MODIFY  backend/app/main.py
+```
+
+Add `from app.routes import auth` and register the auth router:
+```python
+app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
+```
+
+### Dependencies
+
+```
+Backend:
+  MODIFY  backend/requirements.txt
+```
+
+Add `email-validator>=2.0.0,<3.0.0` (required by Pydantic `EmailStr`).
+
+### Tests
+
+```
+Backend:
+  CREATE  backend/tests/test_auth_routes.py
+  CREATE  backend/tests/test_auth_service.py
+  CREATE  backend/tests/test_auth_schemas.py
+```
+
+### Documentation (Pipeline)
+
+```
+Shared:
+  CREATE  shared/feature-specs/auth-endpoints.md          (this file)
+  CREATE  docs/pipeline/auth-endpoints-architect.handoff.md
+```
+
+### Summary
+
+| Action | Count |
+|--------|-------|
+| CREATE | 6 |
+| MODIFY | 2 |
+| DELETE | 0 |
+| **Total** | **8** |
+
+### Files NOT Modified
+
+- `backend/app/config.py` -- Already has `cognito_user_pool_id`, `cognito_app_client_id`, `aws_region`. No changes needed.
+- `backend/app/dependencies.py` -- The auth routes are public (no `get_current_user`). No changes needed.
+- `backend/app/core/auth.py` -- The existing JWT verification is used only by `get_current_user` for protected endpoints. The auth routes do not call `verify_cognito_token` (they obtain tokens from Cognito directly, not verify them).
+- `backend/app/models/` -- No model changes. Existing models from P01-02 are used as-is.
+- `backend/app/schemas/__init__.py` -- If the developer follows the pattern from P01-01 where `health.py` is imported directly in the route, no change to `__init__.py` is needed. If the developer prefers re-exporting from `__init__.py`, that is also acceptable.
+- `backend/.env.example` -- Already has `COGNITO_USER_POOL_ID` and `COGNITO_APP_CLIENT_ID`.
+
+---
+
+## 8. Acceptance Criteria
+
+1. Given a valid email, password, and name, when a client sends `POST /api/v1/auth/register`, then the response is HTTP 201 with body containing `token` (non-empty string), `refresh_token` (non-empty string), and `user` object with `id`, `email`, `name`, `onboarding_completed` (false), `subscription_tier` ("free"), `preferred_language` ("en"), `timezone` ("UTC"), `avatar_url` (null), and `created_at` (ISO 8601 string).
+
+2. Given a successful registration, when the database is inspected, then a `profiles` row exists with `id` equal to the Cognito `sub`, `email` equal to the request email (lowercased), `name` equal to the request name (trimmed), and `mem0_user_id` equal to `"user_{sub}"`.
+
+3. Given a successful registration, when the database is inspected, then a `characters` row exists with `user_id` equal to the Cognito `sub`, `template` equal to `"companion"`, `is_default` equal to `true`, `name` equal to `"Ember"`, `mem0_agent_id` matching the pattern `"companion_{sub}"`, and `system_prompt` containing the companion template text with the user's name.
+
+4. Given a successful registration, when the database is inspected, then a `conversations` row exists with `user_id` equal to the Cognito `sub`, `character_id` equal to the default character's `id`, and `last_message_at` equal to `null`.
+
+5. Given an email that is already registered in Cognito, when a client sends `POST /api/v1/auth/register` with that email, then the response is HTTP 400 with detail "An account with this email already exists".
+
+6. Given a password that does not meet Cognito's password policy, when a client sends `POST /api/v1/auth/register`, then the response is HTTP 400 with detail "Password does not meet requirements".
+
+7. Given valid login credentials, when a client sends `POST /api/v1/auth/login`, then the response is HTTP 200 with body containing `token`, `refresh_token`, and `user` with the correct profile data.
+
+8. Given an incorrect password, when a client sends `POST /api/v1/auth/login`, then the response is HTTP 401 with detail "Invalid email or password".
+
+9. Given a non-existent email, when a client sends `POST /api/v1/auth/login`, then the response is HTTP 401 with detail "Invalid email or password".
+
+10. Given a valid refresh token, when a client sends `POST /api/v1/auth/refresh`, then the response is HTTP 200 with body containing `token` (a new ID token) and no `refresh_token` field.
+
+11. Given an expired or invalid refresh token, when a client sends `POST /api/v1/auth/refresh`, then the response is HTTP 401 with detail "Invalid or expired refresh token".
+
+12. Given any auth endpoint, when the request body fails Pydantic validation (missing fields, invalid email format, password too short), then the response is HTTP 422 with standard FastAPI validation error format.
+
+13. Given the register route handler, when a developer inspects the code, then all business logic is in `AuthService` and the route handler only calls service methods, validates input (Pydantic), and returns responses.
+
+14. Given all Cognito API calls in `AuthService`, when a developer inspects the code, then every call is wrapped with `asyncio.to_thread()` to avoid blocking the async event loop.
+
+15. Given the `email` field in both `RegisterRequest` and `LoginRequest`, when any email is submitted, then it is lowercased and stripped of whitespace before being sent to Cognito.
+
+16. Given the `name` field in `RegisterRequest`, when a name with leading/trailing whitespace is submitted, then the whitespace is stripped before storage.
+
+17. Given the backend source code, when a developer runs `ruff check` on all new files, then zero errors are reported.
+
+18. Given the backend test suite, when a developer runs `pytest` on the new test files, then all tests pass with exit code 0.
+
+19. Given the register and login response schemas, when a developer inspects the API output, then the response follows the format documented in `docs/04-veri-api.md` Section "Kimlik Dogrulama": `{ "token": "...", "refresh_token": "...", "user": { ... } }`.
+
+20. Given the auth router registration in `main.py`, when the application starts, then the three auth endpoints are available at `/api/v1/auth/register`, `/api/v1/auth/login`, and `/api/v1/auth/refresh`.
+
+---
+
+## 9. Design Decisions and Rationale
+
+### Why auto-confirm users via `admin_confirm_sign_up`
+
+During early development and MVP, email verification adds friction without providing critical value. Auto-confirming allows immediate login after registration, which is the expected mobile app experience. In production, this can be replaced with either:
+- A Cognito pre-sign-up Lambda trigger that auto-confirms.
+- Removing auto-confirm and implementing an email verification flow in Phase 2.
+
+The `admin_confirm_sign_up` call requires `AdminConfirmSignUp` IAM permissions on the ECS task role.
+
+### Why Cognito `USER_PASSWORD_AUTH` flow (not `ALLOW_USER_SRP_AUTH`)
+
+`USER_PASSWORD_AUTH` sends the password directly to Cognito over HTTPS. `ALLOW_USER_SRP_AUTH` uses the Secure Remote Password protocol which is more complex. Since the backend communicates with Cognito over a secure AWS-internal network and HTTPS, `USER_PASSWORD_AUTH` is sufficient and simpler to implement. SRP is typically used for client-side SDKs where the password must never leave the device.
+
+### Why `asyncio.to_thread` for boto3 calls
+
+The `boto3` library is synchronous. Calling it directly in an `async def` route handler would block the event loop, preventing other requests from being processed. `asyncio.to_thread()` runs the synchronous call in a thread pool worker, allowing the event loop to remain responsive. An alternative would be `aioboto3`, but it is a third-party wrapper with limited maintenance, while `asyncio.to_thread()` is a standard library solution that works with any sync code.
+
+### Why the default character is named "Ember"
+
+The default character is the "General Friend" with template `companion`. Its name matches the app name "Ember" to reinforce brand identity. Users can rename it later via character settings.
+
+### Why `mem0_user_id` is `"user_{sub}"` and not just `"{sub}"`
+
+Prefixing with `"user_"` distinguishes Mem0 user identifiers from other types of identifiers in the Mem0 system (agent IDs, memory IDs). This prevents potential collisions and makes logs easier to read.
+
+### Why registration creates all three rows (Profile + Character + Conversation) in one transaction
+
+The user expects to see the General Friend character immediately after registration. If the character or conversation creation fails independently, the user would see an empty app with no character to talk to. A single transaction ensures atomicity: either the entire setup succeeds or nothing is committed.
+
+### Why login returns a generic "Invalid email or password" for both wrong email and wrong password
+
+This prevents email enumeration attacks. If the error message distinguished between "email not found" and "wrong password", an attacker could use the register endpoint to verify which emails have accounts.
+
+### Why refresh does not return a new refresh_token
+
+This is a Cognito behavior, not a design choice. The `REFRESH_TOKEN_AUTH` flow returns a new ID token and access token but reuses the same refresh token (valid for 30 days per `docs/08-guvenlik-performans.md`).
+
+---
+
+## 10. Notes for Developers
+
+### For backend-dev
+
+- **Start with schemas** (`app/schemas/auth.py`), then the service (`app/services/auth_service.py`), then the route (`app/routes/auth.py`), then wire up in `main.py`. This order lets you test each layer incrementally.
+
+- **EmailStr dependency**: Add `email-validator>=2.0.0,<3.0.0` to `requirements.txt`. Without it, Pydantic's `EmailStr` raises an import error at runtime.
+
+- **boto3 exception handling**: Cognito exceptions are not standard Python exceptions. They are dynamically generated from the service model. Access them via `client.exceptions.UsernameExistsException` or catch the base `botocore.exceptions.ClientError` and check `e.response["Error"]["Code"]`. The recommended approach is to catch `ClientError` and dispatch on the error code string.
+
+- **Decoding the ID token without verification**: After calling `initiate_auth`, the returned `IdToken` is trusted (it came directly from Cognito over TLS). Use `jose.jwt.get_unverified_claims(token)` to extract the `sub` claim without needing JWKS verification. This avoids a dependency on the JWKS cache for the registration flow.
+
+- **UUID handling**: The Cognito `sub` is a UUID string like `"550e8400-e29b-41d4-a716-446655440000"`. Convert it with `uuid.UUID(sub)` before using it as the Profile `id`.
+
+- **Transaction management**: The route handler gets a `db` session from `Depends(get_db)`. Pass this to `AuthService(db=db)`. The service calls `db.add()` for each new object (Profile, Character, Conversation) and then a single `db.commit()`. If the commit fails, SQLAlchemy automatically rolls back.
+
+- **Router prefix**: Register the auth router with `prefix="/api/v1/auth"` in `main.py`. The route functions use relative paths: `@router.post("/register")`, `@router.post("/login")`, `@router.post("/refresh")`.
+
+- **No auth dependency**: None of the three auth routes use `Depends(get_current_user)`. They are fully public. The router must NOT have a global dependency on `get_current_user`.
+
+- **System prompt format**: The `DEFAULT_COMPANION_PROMPT` uses `{user_name}` as a placeholder. Use Python's `str.format(user_name=name)` to substitute the user's name at character creation time.
+
+- **Import path for Profile**: `from app.models.profile import Profile` (the file is `profile.py`, not `user.py` -- the standards doc shows `user.py` but P01-02 implemented it as `profile.py`).
+
+### For backend-tester
+
+- **Mock boto3, not Cognito directly**: Patch `boto3.client` or patch the specific service instance's Cognito client. Do not make real calls to AWS.
+
+- **Test the full route flow**: Use the FastAPI test client with mock Cognito. Override `get_db` to use a mock session (for route tests) or pass a mock session directly (for service tests).
+
+- **Verify DB writes**: In service tests, verify that `db.add()` was called with the correct objects (check types and field values). Verify that `db.commit()` was called exactly once per successful registration.
+
+- **Verify async wrapping**: Assert that Cognito calls go through `asyncio.to_thread`. You can mock `asyncio.to_thread` itself or verify that the mock Cognito client methods are called (which proves they were invoked, regardless of the async wrapper).
+
+- **Test email normalization**: Register with `"Test@Example.COM"` and verify the stored email is `"test@example.com"`.
+
+- **Test name trimming**: Register with `"  Alex  "` and verify the stored name is `"Alex"`.


### PR DESCRIPTION
## auth-endpoints

Register, login, and refresh endpoints with AWS Cognito integration. Registration creates Cognito user + Profile + default "Ember" companion Character + auto-Conversation in a single atomic transaction. Includes idempotent registration for Cognito-DB split-brain recovery.

Closes #6

---

## Pipeline Summary

| Stage | Agent | Status |
|-------|-------|--------|
| Architecture | architect | ✅ |
| Backend | backend-dev | ✅ |
| Backend Tests | backend-tester | ✅ |
| Documentation | doc-writer | ✅ |
| Code Review | reviewer | ✅ Approved (26/26) |

## Spec
`shared/feature-specs/auth-endpoints.md`

## Endpoints
| Method | Path | Status | Auth |
|--------|------|--------|------|
| POST | /api/v1/auth/register | 201 | Public |
| POST | /api/v1/auth/login | 200 | Public |
| POST | /api/v1/auth/refresh | 200 | Public |

## Key Features
- Cognito USER_PASSWORD_AUTH flow
- Atomic DB transaction: Profile + Character + Conversation
- Idempotent registration (handles split-brain)
- Generic error messages (prevents email enumeration)
- All boto3 calls wrapped with asyncio.to_thread()
- Default companion character with system prompt

## Test Coverage
- 151 auth endpoint tests, 595 total tests passing
- 100% line + branch coverage on all auth code
- All Cognito/Mem0 calls mocked

🤖 Generated via `/pipeline-run P01-04`