### PR TITLE
feat(chat-streaming): chat-streaming [P01-06]

### DIFF
--- a/.claude/agent-memory/architect/MEMORY.md
+++ b/.claude/agent-memory/architect/MEMORY.md
@@ -74,3 +74,25 @@
 - P01-05: mem0_agent_id uniqueness fallback: {template}_{uuid[:8]}_{user_id} for duplicate templates.
 - P01-05: New config field: claude_haiku_model = "claude-haiku-4-5".
 - P01-05: No Mem0 API calls during character CRUD -- agent_id stored for future messaging use.
+
+## Key Decisions Log (P01-06)
+
+- P01-06: SSE over WebSocket for chat streaming -- request-response, not bidirectional.
+- P01-06: Background task persistence (after stream) -- minimizes TTFT (<1s target).
+- P01-06: Background tasks use separate AsyncSessionLocal() -- request session closes with StreamingResponse.
+- P01-06: Separate Haiku call for intent extraction -- keeps Sonnet response natural, cheaper.
+- P01-06: 50 messages context (configurable via max_context_messages) -- CLAUDE.md says 30-50.
+- P01-06: 3 parallel fetches in asyncio.gather(): global Mem0, character Mem0, DB last 50 messages.
+- P01-06: Mem0 SDK is synchronous -- all calls wrapped in asyncio.to_thread().
+- P01-06: Chat router registered under /api/v1/characters prefix -- routes use /{character_id}/messages, no conflict with character CRUD router.
+- P01-06: Auto-create conversation if missing (defensive).
+- P01-06: Action metadata stored on assistant message's JSONB metadata_ column.
+- P01-06: SSE format: data: {json}\n\n with type field in JSON (no event: header).
+
+## Implementation State After P01-05
+
+- `backend/app/config.py` now has `claude_haiku_model: str = "claude-haiku-4-5"`.
+- `backend/app/routes/` has `__init__.py` + `health.py` + `auth.py` + `characters.py`.
+- `backend/app/services/` has `__init__.py` (empty) + `auth_service.py` + `character_service.py`.
+- `backend/app/schemas/` has `__init__.py` (empty) + `health.py` + `auth.py` + `character.py`.
+- `backend/app/main.py` registers health, auth, and characters routers.

--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -11,7 +11,7 @@
 - Auth model uses `Profile` (not `User`) -- `backend/app/models/profile.py`
 - Auth dependency is `get_current_user` returning `Profile` from `app.dependencies`
 - Route prefix set in `main.py`, routes use relative paths (`""`, `"/{character_id}"`)
-- Backend-tester adds `_extended.py` test files alongside backend-dev's base test files
+- Backend-tester adds additional tests in the SAME test files (appended as extra classes)
 - Tests use `os.environ.setdefault("DEBUG", "true")` at top to bypass AWS Secrets Manager
 
 ## Grep Checks to Always Run
@@ -24,5 +24,14 @@
 7. `TODO|FIXME` in implementation files
 8. f-string SQL patterns (SQL injection check)
 
+## Chat Streaming Review Notes
+- Validation-before-streaming: `validate_send_message()` runs BEFORE `StreamingResponse` is created; HTTPExceptions produce proper 4xx JSON errors
+- Background tasks use `AsyncSessionLocal()` (own session), NOT request-scoped `db`
+- Mem0 SDK is synchronous; all calls wrapped in `asyncio.to_thread()`
+- SSE events use JSON `type` field (no SSE `event:` header)
+- Message model uses `metadata_` (Python name) mapped to `metadata` (column name) via `mapped_column("metadata", JSONB)`
+- `asyncio.gather(..., return_exceptions=True)` for Mem0 resilience
+
 ## Completed Reviews
 - P01-05 character-crud (backend layer): APPROVED 2026-02-23, 0 issues found
+- P01-06 chat-streaming (backend layer): APPROVED 2026-02-24, 0 issues found, 130 tests at 100% coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [P01-03] AWS Cognito JWT authentication middleware with JWKS caching
 - [P01-04] Auth endpoints: register, login, refresh with Cognito integration
 - [P01-05] Character CRUD endpoints with Claude Haiku prompt generation
+- [P01-06] SSE streaming chat endpoint with Claude AI integration, Mem0 memory, and device action intents
 
 ---
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -61,6 +61,9 @@ class Settings(BaseSettings):
     # Memory
     mem0_api_key: str = ""
 
+    # Chat context
+    max_context_messages: int = 50
+
     # Voice
     elevenlabs_api_key: str = ""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from fastapi.responses import JSONResponse
 from app.config import settings
 from app.core.logging import setup_logging
 from app.db.session import engine
-from app.routes import auth, characters, health
+from app.routes import auth, characters, chat, health
 
 logger = logging.getLogger("ember")
 
@@ -54,6 +54,7 @@ def create_app() -> FastAPI:
     app.include_router(health.router, prefix="/api/v1", tags=["health"])
     app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
     app.include_router(characters.router, prefix="/api/v1/characters", tags=["characters"])
+    app.include_router(chat.router, prefix="/api/v1/characters", tags=["chat"])
 
     # Global exception handler
     @app.exception_handler(Exception)

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -1,0 +1,93 @@
+"""Chat streaming route handlers.
+
+Provides endpoints for sending messages (SSE streaming response) and
+retrieving paginated message history. All endpoints require JWT
+authentication. Business logic is delegated to ChatService.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_current_user, get_db
+from app.models.profile import Profile
+from app.schemas.chat import MessageListResponse, SendMessageRequest
+from app.services.chat_service import ChatService
+
+router = APIRouter()
+
+
+@router.post("/{character_id}/messages")
+async def send_message(
+    character_id: uuid.UUID,
+    body: SendMessageRequest,
+    current_user: Profile = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """Send a message to a character and stream the AI response via SSE.
+
+    Validation (character lookup, ownership check, context gathering) runs
+    BEFORE the StreamingResponse is created so that HTTPExceptions result
+    in proper 4xx JSON error responses. The streaming generator only runs
+    after validation succeeds.
+    """
+    service = ChatService(db)
+
+    # Validate and prepare context — may raise 403/404
+    context = await service.validate_send_message(
+        character_id=character_id,
+        user_id=current_user.id,
+        profile=current_user,
+        content=body.content,
+    )
+
+    return StreamingResponse(
+        service.stream_response(
+            context=context,
+            user_id=current_user.id,
+            profile=current_user,
+            content=body.content,
+            media_url=body.media_url,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.get(
+    "/{character_id}/messages",
+    response_model=MessageListResponse,
+)
+async def get_messages(
+    character_id: uuid.UUID,
+    current_user: Profile = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+) -> MessageListResponse:
+    """Retrieve paginated message history for a character's conversation.
+
+    Uses cursor-based pagination. Messages are returned newest-first.
+    Pass the ``next_cursor`` from a previous response as the ``cursor``
+    query parameter to load the next page.
+    """
+    # Parse cursor from ISO 8601 string to datetime
+    parsed_cursor: datetime | None = None
+    if cursor is not None:
+        parsed_cursor = datetime.fromisoformat(cursor)
+
+    service = ChatService(db)
+    return await service.get_messages(
+        character_id=character_id,
+        user_id=current_user.id,
+        cursor=parsed_cursor,
+        limit=limit,
+    )

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,0 +1,121 @@
+"""Pydantic request/response schemas for chat streaming endpoints.
+
+Covers sending messages (SSE streaming), message history pagination,
+and SSE event serialization models.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
+class SendMessageRequest(BaseModel):
+    """Request body for POST /api/v1/characters/:id/messages."""
+
+    content: str = Field(..., min_length=1, max_length=4000)
+    media_url: str | None = Field(default=None, max_length=2048)
+
+    @field_validator("content")
+    @classmethod
+    def strip_content(cls, v: str) -> str:
+        """Remove leading/trailing whitespace; reject if empty after trim."""
+        stripped = v.strip()
+        if not stripped:
+            msg = "Message content must not be empty after trimming whitespace"
+            raise ValueError(msg)
+        return stripped
+
+    @field_validator("media_url")
+    @classmethod
+    def validate_media_url(cls, v: str | None) -> str | None:
+        """Validate that media_url is a valid HTTP or HTTPS URL if provided."""
+        if v is None:
+            return v
+        v = v.strip()
+        if not v.startswith(("http://", "https://")):
+            msg = "media_url must be a valid HTTP or HTTPS URL"
+            raise ValueError(msg)
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class MessageItem(BaseModel):
+    """A single message in the paginated message list response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    role: str
+    content: str
+    media_url: str | None
+    metadata: dict[str, Any] | None
+    created_at: datetime
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def coerce_id_to_str(cls, v: object) -> str:
+        """Convert UUID or other types to string for API output."""
+        return str(v)
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def coerce_metadata(cls, v: object) -> dict[str, Any] | None:
+        """Handle the ORM column name metadata_ -> metadata."""
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v  # type: ignore[return-value]
+        return None
+
+
+class MessageListResponse(BaseModel):
+    """Response for GET /api/v1/characters/:id/messages."""
+
+    items: list[MessageItem]
+    next_cursor: str | None
+    has_more: bool
+
+
+# ---------------------------------------------------------------------------
+# SSE event models (used for serialization, NOT as response_model)
+# ---------------------------------------------------------------------------
+
+
+class ChunkEvent(BaseModel):
+    """SSE chunk event — a text fragment of the streaming AI response."""
+
+    type: str = "chunk"
+    content: str
+
+
+class ActionEvent(BaseModel):
+    """SSE action event — a device action intent detected in the response."""
+
+    type: str = "action"
+    action: str
+    payload: dict[str, Any]
+
+
+class DoneEvent(BaseModel):
+    """SSE done event — signals the stream is complete."""
+
+    type: str = "done"
+    message_id: str
+
+
+class ErrorEvent(BaseModel):
+    """SSE error event — signals an error occurred mid-stream."""
+
+    type: str = "error"
+    message: str

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -1,0 +1,570 @@
+"""Chat service — business logic for streaming chat and message history.
+
+Handles sending messages via SSE streaming (Claude Sonnet), intent extraction
+(Claude Haiku), Mem0 memory integration, background persistence, and cursor-based
+message history retrieval.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from anthropic import AsyncAnthropic
+from fastapi import HTTPException, status
+from mem0 import MemoryClient
+from sqlalchemy import select, true, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.db.session import AsyncSessionLocal
+from app.models.character import Character
+from app.models.conversation import Conversation
+from app.models.message import Message
+from app.models.profile import Profile
+from app.models.user_activity import UserActivity
+from app.schemas.chat import (
+    ActionEvent,
+    ChunkEvent,
+    DoneEvent,
+    ErrorEvent,
+    MessageItem,
+    MessageListResponse,
+)
+
+logger = logging.getLogger("ember")
+
+# Intent extraction prompt template for Claude Haiku
+_INTENT_EXTRACTION_PROMPT = """\
+Analyze the following AI assistant response and determine \
+if it contains an intent to perform a device action.
+
+Supported actions:
+- SET_ALARM: Setting an alarm or reminder. Extract time and label.
+- ADD_CALENDAR_EVENT: Adding a calendar event. Extract title, date, time, duration.
+
+If the response contains a device action intent, respond with ONLY this JSON:
+{{"action": "<ACTION_NAME>", "payload": {{<relevant fields>}}}}
+
+If the response does NOT contain any device action intent, respond with ONLY:
+none
+
+The "time" field must be in ISO 8601 format. The "date" field must be YYYY-MM-DD format.
+
+User's timezone: {timezone}
+Current date: {current_date}
+
+Assistant response to analyze:
+{assistant_response}"""
+
+_SUPPORTED_ACTIONS = frozenset({"SET_ALARM", "ADD_CALENDAR_EVENT"})
+
+
+class ChatService:
+    """Encapsulates all messaging business logic."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    # ------------------------------------------------------------------
+    # Send Message (Streaming)
+    # ------------------------------------------------------------------
+
+    async def validate_send_message(
+        self,
+        character_id: uuid.UUID,
+        user_id: uuid.UUID,
+        profile: Profile,
+        content: str,
+    ) -> dict[str, Any]:
+        """Validate and prepare context for streaming. Raises HTTPException on failure.
+
+        This method runs BEFORE the StreamingResponse is created, so
+        HTTPExceptions are properly caught and returned as JSON errors.
+
+        Returns a context dict with character, conversation, system_prompt,
+        and formatted_messages for use in the streaming generator.
+        """
+        # Step 2: Look up character (active, ownership check)
+        character = await self._get_active_character(character_id)
+        if character.user_id != user_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Character does not belong to user",
+            )
+
+        # Step 3: Look up (or auto-create) conversation
+        conversation = await self._get_or_create_conversation(
+            character_id=character_id,
+            user_id=user_id,
+        )
+
+        # Step 4: Parallel fetch — Mem0 memories + recent messages
+        global_memories, character_memories, recent_messages = await asyncio.gather(
+            self._search_memories(content, profile.mem0_user_id, agent_id=None),
+            self._search_memories(
+                content, profile.mem0_user_id, agent_id=character.mem0_agent_id,
+            ),
+            self._get_recent_messages(conversation.id),
+            return_exceptions=True,
+        )
+
+        # Handle Mem0 search failures gracefully
+        if isinstance(global_memories, BaseException):
+            logger.error("Global Mem0 search failed: %s", global_memories)
+            global_memories = []
+        if isinstance(character_memories, BaseException):
+            logger.error("Character Mem0 search failed: %s", character_memories)
+            character_memories = []
+        if isinstance(recent_messages, BaseException):
+            logger.error("Recent messages fetch failed: %s", recent_messages)
+            recent_messages = []
+
+        # Step 5: Build LLM prompt
+        system_prompt = self._build_system_prompt(
+            character_system_prompt=character.system_prompt,
+            global_memories=global_memories,
+            character_memories=character_memories,
+            profile=profile,
+        )
+        formatted_messages = self._format_messages(recent_messages, content)
+
+        return {
+            "character": character,
+            "conversation": conversation,
+            "system_prompt": system_prompt,
+            "formatted_messages": formatted_messages,
+        }
+
+    async def stream_response(  # noqa: ANN201
+        self,
+        context: dict[str, Any],
+        user_id: uuid.UUID,
+        profile: Profile,
+        content: str,
+        media_url: str | None,
+    ):
+        """Yield SSE events for the AI response.
+
+        This async generator runs inside a StreamingResponse.
+        Validation has already been performed by validate_send_message().
+
+        Yields SSE-formatted strings: 'data: {"type":"chunk","content":"..."}\n\n'
+        """
+        character: Character = context["character"]
+        conversation: Conversation = context["conversation"]
+        system_prompt: str = context["system_prompt"]
+        formatted_messages: list[dict[str, str]] = context["formatted_messages"]
+
+        full_response = ""
+        assistant_message_id = uuid.uuid4()
+
+        try:
+            client = AsyncAnthropic(api_key=settings.anthropic_api_key)
+            async with client.messages.stream(
+                model=settings.claude_model,
+                system=system_prompt,
+                messages=formatted_messages,
+                max_tokens=2048,
+            ) as stream:
+                async for text in stream.text_stream:
+                    full_response += text
+                    event = ChunkEvent(content=text)
+                    yield f"data: {event.model_dump_json()}\n\n"
+
+        except Exception:
+            logger.exception(
+                "Claude streaming error for character_id=%s",
+                character.id,
+            )
+            error_event = ErrorEvent(
+                message="AI service temporarily unavailable",
+            )
+            yield f"data: {error_event.model_dump_json()}\n\n"
+            return
+
+        # Intent extraction via Haiku
+        action_metadata = await self._extract_intent(
+            full_response, profile.timezone,
+        )
+        if action_metadata is not None:
+            action_event = ActionEvent(
+                action=action_metadata["action"],
+                payload=action_metadata["payload"],
+            )
+            yield f"data: {action_event.model_dump_json()}\n\n"
+
+        # Done event
+        done_event = DoneEvent(message_id=str(assistant_message_id))
+        yield f"data: {done_event.model_dump_json()}\n\n"
+
+        # Background tasks (fire-and-forget)
+        asyncio.create_task(  # noqa: RUF006
+            _persist_exchange(
+                user_id=user_id,
+                conversation_id=conversation.id,
+                user_content=content,
+                user_media_url=media_url,
+                assistant_content=full_response,
+                assistant_message_id=assistant_message_id,
+                action_metadata=action_metadata,
+                mem0_user_id=profile.mem0_user_id,
+                mem0_agent_id=character.mem0_agent_id,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Get Messages (Paginated)
+    # ------------------------------------------------------------------
+
+    async def get_messages(
+        self,
+        character_id: uuid.UUID,
+        user_id: uuid.UUID,
+        cursor: datetime | None,
+        limit: int,
+    ) -> MessageListResponse:
+        """Retrieve paginated message history for a character's conversation."""
+        # Validate character access
+        character = await self._get_active_character(character_id)
+        if character.user_id != user_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Character does not belong to user",
+            )
+
+        # Look up conversation
+        result = await self.db.execute(
+            select(Conversation).where(Conversation.character_id == character_id),
+        )
+        conversation = result.scalar_one_or_none()
+        if conversation is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Conversation not found",
+            )
+
+        # Cursor-based query
+        stmt = (
+            select(Message)
+            .where(Message.conversation_id == conversation.id)
+            .order_by(Message.created_at.desc(), Message.id.desc())
+            .limit(limit + 1)
+        )
+        if cursor is not None:
+            stmt = stmt.where(Message.created_at < cursor)
+
+        result = await self.db.execute(stmt)
+        rows = result.scalars().all()
+
+        has_more = len(rows) > limit
+        items = list(rows[:limit])
+
+        next_cursor: str | None = None
+        if has_more and items:
+            next_cursor = items[-1].created_at.isoformat()
+
+        return MessageListResponse(
+            items=[
+                MessageItem(
+                    id=str(msg.id),
+                    role=msg.role,
+                    content=msg.content,
+                    media_url=msg.media_url,
+                    metadata=msg.metadata_,
+                    created_at=msg.created_at,
+                )
+                for msg in items
+            ],
+            next_cursor=next_cursor,
+            has_more=has_more,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _get_active_character(self, character_id: uuid.UUID) -> Character:
+        """Look up an active character by id, raising 404 if not found."""
+        result = await self.db.execute(
+            select(Character).where(
+                Character.id == character_id,
+                Character.is_active == true(),
+            ),
+        )
+        character = result.scalar_one_or_none()
+        if character is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Character not found",
+            )
+        return character
+
+    async def _get_or_create_conversation(
+        self,
+        character_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> Conversation:
+        """Find the conversation for a character, auto-creating if missing."""
+        result = await self.db.execute(
+            select(Conversation).where(Conversation.character_id == character_id),
+        )
+        conversation = result.scalar_one_or_none()
+        if conversation is not None:
+            return conversation
+
+        # Defensive: auto-create if missing
+        conversation = Conversation(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            character_id=character_id,
+            last_message_at=None,
+        )
+        self.db.add(conversation)
+        await self.db.commit()
+        await self.db.refresh(conversation)
+        return conversation
+
+    async def _search_memories(
+        self,
+        query: str,
+        mem0_user_id: str,
+        agent_id: str | None,
+        limit: int = 5,
+    ) -> list[str]:
+        """Search Mem0 for relevant memories. Returns a list of memory text strings."""
+        try:
+            client = MemoryClient(api_key=settings.mem0_api_key)
+            kwargs: dict[str, Any] = {
+                "user_id": mem0_user_id,
+                "limit": limit,
+            }
+            if agent_id is not None:
+                kwargs["agent_id"] = agent_id
+
+            results = await asyncio.to_thread(
+                client.search,
+                query,
+                **kwargs,
+            )
+            return [r["memory"] for r in results]
+        except Exception:
+            logger.exception(
+                "Mem0 search failed (agent_id=%s)", agent_id,
+            )
+            return []
+
+    async def _get_recent_messages(
+        self,
+        conversation_id: uuid.UUID,
+    ) -> list[Message]:
+        """Fetch the last N messages for context, ordered by created_at ASC."""
+        stmt = (
+            select(Message)
+            .where(Message.conversation_id == conversation_id)
+            .order_by(Message.created_at.desc())
+            .limit(settings.max_context_messages)
+        )
+        result = await self.db.execute(stmt)
+        rows = result.scalars().all()
+        # Reverse to chronological order for the LLM prompt
+        return list(reversed(rows))
+
+    def _build_system_prompt(
+        self,
+        character_system_prompt: str,
+        global_memories: list[str],
+        character_memories: list[str],
+        profile: Profile,
+    ) -> str:
+        """Build the full system prompt from 3 blocks per docs/05-ai-bellek.md."""
+        blocks: list[str] = []
+
+        # Block 1: Character definition
+        blocks.append(character_system_prompt)
+
+        # Block 2: Learned knowledge (Mem0 memories)
+        all_memories = _deduplicate_memories(global_memories, character_memories)
+        if all_memories:
+            memory_lines = "\n".join(f"- {m}" for m in all_memories)
+            blocks.append(f"What you know about this user:\n{memory_lines}")
+
+        # Block 3: Daily context
+        try:
+            import zoneinfo
+            tz = zoneinfo.ZoneInfo(profile.timezone or "UTC")
+        except Exception:
+            import zoneinfo
+            tz = zoneinfo.ZoneInfo("UTC")
+
+        now = datetime.now(tz=tz)
+        date_str = now.strftime("%A, %Y-%m-%d %H:%M")
+        blocks.append(
+            f"Current date and time: {date_str}\n"
+            f"Timezone: {profile.timezone}\n"
+            f"User's preferred language: {profile.preferred_language}"
+        )
+
+        return "\n\n".join(blocks)
+
+    def _format_messages(
+        self,
+        recent_messages: list[Message],
+        new_content: str,
+    ) -> list[dict[str, str]]:
+        """Format message history + new user message for the Claude API."""
+        formatted: list[dict[str, str]] = []
+        for msg in recent_messages:
+            formatted.append({"role": msg.role, "content": msg.content})
+
+        # Append the new user message
+        formatted.append({"role": "user", "content": new_content})
+        return formatted
+
+    async def _extract_intent(
+        self,
+        assistant_response: str,
+        user_timezone: str,
+    ) -> dict[str, Any] | None:
+        """Extract device action intent from the assistant response via Claude Haiku."""
+        try:
+            now = datetime.now(tz=UTC)
+            prompt = _INTENT_EXTRACTION_PROMPT.format(
+                timezone=user_timezone,
+                current_date=now.strftime("%Y-%m-%d"),
+                assistant_response=assistant_response,
+            )
+
+            client = AsyncAnthropic(api_key=settings.anthropic_api_key)
+            response = await client.messages.create(
+                model=settings.claude_haiku_model,
+                max_tokens=256,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            raw_text = response.content[0].text.strip()
+
+            if raw_text.lower() == "none":
+                return None
+
+            parsed = json.loads(raw_text)
+            if (
+                isinstance(parsed, dict)
+                and "action" in parsed
+                and parsed["action"] in _SUPPORTED_ACTIONS
+            ):
+                return {
+                    "action": parsed["action"],
+                    "payload": parsed.get("payload", {}),
+                }
+
+            logger.debug("Haiku returned unsupported action: %s", raw_text)
+            return None
+
+        except json.JSONDecodeError:
+            logger.debug("Haiku returned non-JSON response: %s", raw_text)
+            return None
+        except Exception:
+            logger.exception("Intent extraction via Haiku failed")
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Background task (module-level function for testability)
+# ---------------------------------------------------------------------------
+
+
+async def _persist_exchange(
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    user_content: str,
+    user_media_url: str | None,
+    assistant_content: str,
+    assistant_message_id: uuid.UUID,
+    action_metadata: dict[str, Any] | None,
+    mem0_user_id: str,
+    mem0_agent_id: str,
+) -> None:
+    """Background task: persist messages, update timestamps, add to Mem0."""
+    try:
+        async with AsyncSessionLocal() as db:
+            # Save user message
+            user_msg = Message(
+                id=uuid.uuid4(),
+                conversation_id=conversation_id,
+                user_id=user_id,
+                role="user",
+                content=user_content,
+                media_url=user_media_url,
+            )
+            db.add(user_msg)
+
+            # Save assistant message
+            assistant_msg = Message(
+                id=assistant_message_id,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                role="assistant",
+                content=assistant_content,
+                metadata_=action_metadata,
+            )
+            db.add(assistant_msg)
+
+            # Update conversation timestamp
+            await db.execute(
+                update(Conversation)
+                .where(Conversation.id == conversation_id)
+                .values(last_message_at=datetime.now(tz=UTC)),
+            )
+
+            # Update user activity
+            await db.execute(
+                update(UserActivity)
+                .where(UserActivity.user_id == user_id)
+                .values(last_chat_at=datetime.now(tz=UTC)),
+            )
+
+            await db.commit()
+
+    except Exception:
+        logger.exception(
+            "Background persist failed for conversation_id=%s",
+            conversation_id,
+        )
+
+    # Mem0 add (outside DB transaction)
+    try:
+        client = MemoryClient(api_key=settings.mem0_api_key)
+        await asyncio.to_thread(
+            client.add,
+            [
+                {"role": "user", "content": user_content},
+                {"role": "assistant", "content": assistant_content},
+            ],
+            user_id=mem0_user_id,
+            agent_id=mem0_agent_id,
+        )
+    except Exception:
+        logger.exception("Mem0 add failed for agent_id=%s", mem0_agent_id)
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+
+def _deduplicate_memories(
+    global_memories: list[str],
+    character_memories: list[str],
+) -> list[str]:
+    """De-duplicate memories by exact string match, preserving order."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for memory in [*character_memories, *global_memories]:
+        if memory not in seen:
+            seen.add(memory)
+            result.append(memory)
+    return result

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -1,0 +1,659 @@
+"""Route-level integration tests for chat streaming endpoints.
+
+Uses the FastAPI test client with mocked ChatService and dependencies
+to test HTTP status codes, SSE stream format, and request validation.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import json  # noqa: E402
+import uuid  # noqa: E402
+from collections.abc import AsyncGenerator  # noqa: E402
+from datetime import UTC, datetime, timedelta  # noqa: E402
+from typing import Any  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from app.dependencies import get_current_user, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FAKE_USER_ID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+OTHER_USER_ID = uuid.UUID("770e8400-e29b-41d4-a716-446655440099")
+FAKE_CHARACTER_ID = uuid.UUID("660e8400-e29b-41d4-a716-446655440001")
+FAKE_CONVERSATION_ID = uuid.UUID("880e8400-e29b-41d4-a716-446655440002")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_profile(user_id: uuid.UUID = FAKE_USER_ID) -> MagicMock:
+    """Create a fake Profile-like object for auth dependency override."""
+    profile = MagicMock()
+    profile.id = user_id
+    profile.email = "test@ember.ai"
+    profile.name = "Alex"
+    profile.mem0_user_id = f"user_{user_id}"
+    profile.fcm_token = None
+    profile.timezone = "UTC"
+    profile.avatar_url = None
+    profile.preferred_language = "en"
+    profile.onboarding_completed = False
+    profile.subscription_tier = "free"
+    profile.subscription_expires_at = None
+    profile.created_at = datetime.now(tz=UTC)
+    profile.updated_at = datetime.now(tz=UTC)
+    return profile
+
+
+def _make_valid_context() -> dict[str, Any]:
+    """Create a valid context dict as returned by validate_send_message."""
+    mock_char = MagicMock()
+    mock_char.id = FAKE_CHARACTER_ID
+    mock_char.user_id = FAKE_USER_ID
+    mock_char.mem0_agent_id = f"english_teacher_{FAKE_USER_ID}"
+
+    mock_conv = MagicMock()
+    mock_conv.id = FAKE_CONVERSATION_ID
+
+    return {
+        "character": mock_char,
+        "conversation": mock_conv,
+        "system_prompt": "You are Sarah.",
+        "formatted_messages": [{"role": "user", "content": "Hello"}],
+    }
+
+
+def _parse_sse_events(text: str) -> list[dict[str, Any]]:
+    """Parse SSE text into a list of JSON event dicts."""
+    events = []
+    for line in text.split("\n"):
+        line = line.strip()
+        if line.startswith("data: "):
+            events.append(json.loads(line[6:]))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Mock streaming generator
+# ---------------------------------------------------------------------------
+
+
+async def _mock_stream_chunks(
+    chunks: list[str],
+    action: dict[str, Any] | None = None,
+) -> AsyncGenerator[str, None]:
+    """Create a mock SSE streaming generator."""
+    from app.schemas.chat import ActionEvent, ChunkEvent, DoneEvent
+
+    for chunk in chunks:
+        event = ChunkEvent(content=chunk)
+        yield f"data: {event.model_dump_json()}\n\n"
+
+    if action is not None:
+        action_event = ActionEvent(
+            action=action["action"],
+            payload=action["payload"],
+        )
+        yield f"data: {action_event.model_dump_json()}\n\n"
+
+    done_event = DoneEvent(message_id=str(uuid.uuid4()))
+    yield f"data: {done_event.model_dump_json()}\n\n"
+
+
+async def _mock_stream_error() -> AsyncGenerator[str, None]:
+    """Create a mock SSE streaming generator that emits an error event."""
+    from app.schemas.chat import ErrorEvent
+
+    error_event = ErrorEvent(message="AI service temporarily unavailable")
+    yield f"data: {error_event.model_dump_json()}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client with mocked DB and auth."""
+    fake_profile = _make_fake_profile()
+
+    async def override_user() -> MagicMock:
+        return fake_profile
+
+    async def override_db() -> AsyncGenerator[AsyncMock, None]:
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def unauthed_client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client without auth override (for 401/403 tests)."""
+    async def override_db() -> AsyncGenerator[AsyncMock, None]:
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/characters/:id/messages tests
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessage:
+    """Tests for POST /api/v1/characters/:id/messages (SSE streaming)."""
+
+    @pytest.mark.asyncio
+    async def test_valid_message_returns_sse_stream(self, client: AsyncClient) -> None:
+        """Valid message returns 200 with SSE stream containing chunk and done events."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_chunks(["Hello", ", ", "world!"]),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+        events = _parse_sse_events(resp.text)
+        assert len(events) >= 2
+
+        chunk_events = [e for e in events if e["type"] == "chunk"]
+        assert len(chunk_events) == 3
+
+        assert events[-1]["type"] == "done"
+        assert "message_id" in events[-1]
+
+    @pytest.mark.asyncio
+    async def test_message_to_other_users_character_returns_403(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Message to another user's character returns 403."""
+        from fastapi import HTTPException, status
+
+        with patch(
+            "app.services.chat_service.ChatService.validate_send_message",
+            side_effect=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Character does not belong to user",
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Character does not belong to user"
+
+    @pytest.mark.asyncio
+    async def test_message_to_nonexistent_character_returns_404(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Message to non-existent character returns 404."""
+        from fastapi import HTTPException, status
+
+        with patch(
+            "app.services.chat_service.ChatService.validate_send_message",
+            side_effect=HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Character not found",
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Character not found"
+
+    @pytest.mark.asyncio
+    async def test_message_to_inactive_character_returns_404(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Message to inactive character returns 404."""
+        from fastapi import HTTPException, status
+
+        with patch(
+            "app.services.chat_service.ChatService.validate_send_message",
+            side_effect=HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Character not found",
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_empty_content_returns_422(self, client: AsyncClient) -> None:
+        """Empty content (whitespace only) returns 422."""
+        resp = await client.post(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            json={"content": "   "},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_content_exceeds_max_length_returns_422(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Content exceeding 4000 chars returns 422."""
+        resp = await client.post(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            json={"content": "a" * 4001},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_missing_auth_returns_401_or_403(
+        self,
+        unauthed_client: AsyncClient,
+    ) -> None:
+        """Missing auth header returns 401 or 403."""
+        resp = await unauthed_client.post(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            json={"content": "Hello"},
+        )
+        assert resp.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_sse_event_order_chunk_then_done(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """SSE stream has chunk events first, then done event last."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_chunks(["Hi", " there"]),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        events = _parse_sse_events(resp.text)
+        types = [e["type"] for e in events]
+
+        assert all(t == "chunk" for t in types[:-1])
+        assert types[-1] == "done"
+
+    @pytest.mark.asyncio
+    async def test_claude_failure_emits_error_event(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Claude API failure during streaming emits error SSE event."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_error(),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        assert resp.status_code == 200
+        events = _parse_sse_events(resp.text)
+        assert any(e["type"] == "error" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_intent_detected_emits_action_event(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """When intent is detected, an action event appears before done."""
+        ctx = _make_valid_context()
+        action = {
+            "action": "SET_ALARM",
+            "payload": {"time": "2026-02-24T07:00:00", "label": "Wake up"},
+        }
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_chunks(
+                    ["I'll set an alarm for 7 AM."],
+                    action=action,
+                ),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Set an alarm for 7 AM"},
+            )
+
+        events = _parse_sse_events(resp.text)
+        types = [e["type"] for e in events]
+
+        assert "action" in types
+        assert types[-1] == "done"
+        action_idx = types.index("action")
+        done_idx = types.index("done")
+        assert action_idx < done_idx
+
+    @pytest.mark.asyncio
+    async def test_no_intent_no_action_event(self, client: AsyncClient) -> None:
+        """When no intent detected, no action event in stream."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_chunks(["Just a regular response."]),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        events = _parse_sse_events(resp.text)
+        types = [e["type"] for e in events]
+        assert "action" not in types
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/characters/:id/messages tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessages:
+    """Tests for GET /api/v1/characters/:id/messages (paginated)."""
+
+    @pytest.mark.asyncio
+    async def test_get_messages_first_page(self, client: AsyncClient) -> None:
+        """Returns 200 with messages on first page (no cursor)."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "items" in data
+        assert "next_cursor" in data
+        assert "has_more" in data
+
+    @pytest.mark.asyncio
+    async def test_get_messages_with_cursor(self, client: AsyncClient) -> None:
+        """Returns 200 with messages older than cursor."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+                "?cursor=2026-02-23T14:30:00%2B00:00",
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_get_messages_with_limit(self, client: AsyncClient) -> None:
+        """Returns 200 respecting custom limit."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=5",
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_get_messages_empty_conversation(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Empty conversation returns 200 with empty items."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"] == []
+        assert data["next_cursor"] is None
+        assert data["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_messages_other_users_character_returns_403(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Get messages for another user's character returns 403."""
+        from fastapi import HTTPException, status
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            side_effect=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Character does not belong to user",
+            ),
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            )
+
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_get_messages_nonexistent_character_returns_404(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Get messages for non-existent character returns 404."""
+        from fastapi import HTTPException, status
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            side_effect=HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Character not found",
+            ),
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_messages_without_auth_returns_401(
+        self,
+        unauthed_client: AsyncClient,
+    ) -> None:
+        """Missing auth header returns 401 or 403."""
+        resp = await unauthed_client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+        )
+        assert resp.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_get_messages_has_more_true(self, client: AsyncClient) -> None:
+        """has_more is true when more messages exist."""
+        from app.schemas.chat import MessageItem, MessageListResponse
+
+        now = datetime.now(tz=UTC)
+        items = [
+            MessageItem(
+                id=str(uuid.uuid4()),
+                role="user",
+                content=f"msg {i}",
+                media_url=None,
+                metadata=None,
+                created_at=now - timedelta(minutes=i),
+            )
+            for i in range(5)
+        ]
+        mock_response = MessageListResponse(
+            items=items,
+            next_cursor=(now - timedelta(minutes=4)).isoformat(),
+            has_more=True,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=5",
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["has_more"] is True
+        assert data["next_cursor"] is not None
+
+    @pytest.mark.asyncio
+    async def test_get_messages_has_more_false_on_last_page(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """has_more is false when all messages fit in one page."""
+        from app.schemas.chat import MessageItem, MessageListResponse
+
+        now = datetime.now(tz=UTC)
+        items = [
+            MessageItem(
+                id=str(uuid.uuid4()),
+                role="user",
+                content="hello",
+                media_url=None,
+                metadata=None,
+                created_at=now,
+            ),
+        ]
+        mock_response = MessageListResponse(
+            items=items,
+            next_cursor=None,
+            has_more=False,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=20",
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["has_more"] is False
+        assert data["next_cursor"] is None

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -657,3 +657,332 @@ class TestGetMessages:
         data = resp.json()
         assert data["has_more"] is False
         assert data["next_cursor"] is None
+
+
+# ---------------------------------------------------------------------------
+# Additional POST tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageAdditional:
+    """Additional tests for POST /api/v1/characters/:id/messages."""
+
+    @pytest.mark.asyncio
+    async def test_sse_response_headers(self, client: AsyncClient) -> None:
+        """SSE response includes Cache-Control and X-Accel-Buffering headers."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_chunks(["Hi"]),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        assert resp.headers.get("cache-control") == "no-cache"
+        assert resp.headers.get("x-accel-buffering") == "no"
+
+    @pytest.mark.asyncio
+    async def test_invalid_uuid_returns_422(self, client: AsyncClient) -> None:
+        """Invalid UUID in path parameter returns 422."""
+        resp = await client.post(
+            "/api/v1/characters/not-a-uuid/messages",
+            json={"content": "Hello"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_missing_content_field_returns_422(self, client: AsyncClient) -> None:
+        """Missing 'content' field in request body returns 422."""
+        resp = await client.post(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            json={},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_valid_media_url_accepted(self, client: AsyncClient) -> None:
+        """Valid media_url is accepted along with content."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_chunks(["Hello!"]),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={
+                    "content": "Look at this image",
+                    "media_url": "https://s3.amazonaws.com/bucket/photo.jpg",
+                },
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_action_event_payload_structure(self, client: AsyncClient) -> None:
+        """Action event has correct action and payload structure."""
+        ctx = _make_valid_context()
+        action = {
+            "action": "ADD_CALENDAR_EVENT",
+            "payload": {
+                "title": "Dentist",
+                "date": "2026-02-24",
+                "time": "15:00",
+                "duration_minutes": 60,
+            },
+        }
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_chunks(
+                    ["I've added the event."],
+                    action=action,
+                ),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Add a dentist appointment at 3pm"},
+            )
+
+        events = _parse_sse_events(resp.text)
+        action_events = [e for e in events if e["type"] == "action"]
+        assert len(action_events) == 1
+        assert action_events[0]["action"] == "ADD_CALENDAR_EVENT"
+        assert action_events[0]["payload"]["title"] == "Dentist"
+        assert action_events[0]["payload"]["duration_minutes"] == 60
+
+    @pytest.mark.asyncio
+    async def test_sse_chunk_content_accumulated(self, client: AsyncClient) -> None:
+        """Accumulated chunk content forms the full response text."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_chunks(["Hello", " ", "world", "!"]),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hi"},
+            )
+
+        events = _parse_sse_events(resp.text)
+        chunks = [e["content"] for e in events if e["type"] == "chunk"]
+        full_text = "".join(chunks)
+        assert full_text == "Hello world!"
+
+    @pytest.mark.asyncio
+    async def test_error_event_contains_message(self, client: AsyncClient) -> None:
+        """Error SSE event contains a user-friendly message."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_error(),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        events = _parse_sse_events(resp.text)
+        error_events = [e for e in events if e["type"] == "error"]
+        assert len(error_events) == 1
+        assert "message" in error_events[0]
+        assert error_events[0]["message"] == "AI service temporarily unavailable"
+
+    @pytest.mark.asyncio
+    async def test_error_event_no_done_event(self, client: AsyncClient) -> None:
+        """When error event is emitted, no done event follows."""
+        ctx = _make_valid_context()
+
+        with (
+            patch(
+                "app.services.chat_service.ChatService.validate_send_message",
+                return_value=ctx,
+            ),
+            patch(
+                "app.services.chat_service.ChatService.stream_response",
+                return_value=_mock_stream_error(),
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+                json={"content": "Hello"},
+            )
+
+        events = _parse_sse_events(resp.text)
+        types = [e["type"] for e in events]
+        assert "done" not in types
+
+
+# ---------------------------------------------------------------------------
+# Additional GET tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessagesAdditional:
+    """Additional tests for GET /api/v1/characters/:id/messages."""
+
+    @pytest.mark.asyncio
+    async def test_limit_below_min_returns_422(self, client: AsyncClient) -> None:
+        """limit=0 returns 422 (minimum is 1)."""
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=0",
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_limit_above_max_returns_422(self, client: AsyncClient) -> None:
+        """limit=101 returns 422 (maximum is 100)."""
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=101",
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_messages_invalid_uuid_returns_422(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Invalid UUID in path parameter returns 422."""
+        resp = await client.get("/api/v1/characters/not-a-uuid/messages")
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_messages_response_items_structure(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Each message item in the response has the required fields."""
+        from app.schemas.chat import MessageItem, MessageListResponse
+
+        now = datetime.now(tz=UTC)
+        msg_id = str(uuid.uuid4())
+        items = [
+            MessageItem(
+                id=msg_id,
+                role="user",
+                content="Hello",
+                media_url=None,
+                metadata=None,
+                created_at=now,
+            ),
+        ]
+        mock_response = MessageListResponse(
+            items=items,
+            next_cursor=None,
+            has_more=False,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        msg = data["items"][0]
+        assert "id" in msg
+        assert "role" in msg
+        assert "content" in msg
+        assert "media_url" in msg
+        assert "metadata" in msg
+        assert "created_at" in msg
+        assert msg["id"] == msg_id
+        assert msg["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_get_messages_next_cursor_format(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """next_cursor is a valid ISO 8601 string when has_more is true."""
+        from app.schemas.chat import MessageItem, MessageListResponse
+
+        now = datetime.now(tz=UTC)
+        cursor_value = (now - timedelta(minutes=10)).isoformat()
+        items = [
+            MessageItem(
+                id=str(uuid.uuid4()),
+                role="user",
+                content="Hello",
+                media_url=None,
+                metadata=None,
+                created_at=now,
+            ),
+        ]
+        mock_response = MessageListResponse(
+            items=items,
+            next_cursor=cursor_value,
+            has_more=True,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=1",
+            )
+
+        data = resp.json()
+        # Verify next_cursor is a parseable ISO 8601 string
+        datetime.fromisoformat(data["next_cursor"])
+
+    @pytest.mark.asyncio
+    async def test_get_messages_conversation_not_found_returns_404(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Conversation not found returns 404."""
+        from fastapi import HTTPException, status
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            side_effect=HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Conversation not found",
+            ),
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Conversation not found"

--- a/backend/tests/test_chat_schemas.py
+++ b/backend/tests/test_chat_schemas.py
@@ -1,0 +1,234 @@
+"""Unit tests for chat Pydantic schemas.
+
+Tests request validation (SendMessageRequest), response serialization
+(MessageItem, MessageListResponse), and SSE event models.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import uuid  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from app.schemas.chat import (  # noqa: E402
+    ActionEvent,
+    ChunkEvent,
+    DoneEvent,
+    ErrorEvent,
+    MessageItem,
+    MessageListResponse,
+    SendMessageRequest,
+)
+
+# ---------------------------------------------------------------------------
+# SendMessageRequest tests
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageRequest:
+    """Tests for the SendMessageRequest schema."""
+
+    def test_valid_content(self) -> None:
+        """Accept valid content string."""
+        req = SendMessageRequest(content="Hello, world!")
+        assert req.content == "Hello, world!"
+        assert req.media_url is None
+
+    def test_strips_whitespace_from_content(self) -> None:
+        """Content is whitespace-trimmed."""
+        req = SendMessageRequest(content="  Hello  ")
+        assert req.content == "Hello"
+
+    def test_rejects_empty_content_after_strip(self) -> None:
+        """Content that becomes empty after stripping raises ValidationError."""
+        with pytest.raises(ValidationError):
+            SendMessageRequest(content="   ")
+
+    def test_rejects_content_exceeding_max_length(self) -> None:
+        """Content exceeding 4000 chars raises ValidationError."""
+        with pytest.raises(ValidationError):
+            SendMessageRequest(content="a" * 4001)
+
+    def test_accepts_null_media_url(self) -> None:
+        """Null media_url is accepted."""
+        req = SendMessageRequest(content="Hello", media_url=None)
+        assert req.media_url is None
+
+    def test_accepts_valid_https_url(self) -> None:
+        """Valid HTTPS media_url is accepted."""
+        req = SendMessageRequest(
+            content="Hello",
+            media_url="https://s3.amazonaws.com/bucket/image.jpg",
+        )
+        assert req.media_url == "https://s3.amazonaws.com/bucket/image.jpg"
+
+    def test_accepts_valid_http_url(self) -> None:
+        """Valid HTTP media_url is accepted."""
+        req = SendMessageRequest(
+            content="Hello",
+            media_url="http://example.com/image.jpg",
+        )
+        assert req.media_url == "http://example.com/image.jpg"
+
+    def test_rejects_invalid_media_url(self) -> None:
+        """media_url without HTTP/HTTPS scheme raises ValidationError."""
+        with pytest.raises(ValidationError):
+            SendMessageRequest(content="Hello", media_url="ftp://invalid.com/file")
+
+    def test_media_url_strips_whitespace(self) -> None:
+        """media_url is whitespace-trimmed."""
+        req = SendMessageRequest(
+            content="Hello",
+            media_url="  https://example.com/image.jpg  ",
+        )
+        assert req.media_url == "https://example.com/image.jpg"
+
+
+# ---------------------------------------------------------------------------
+# MessageItem tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageItem:
+    """Tests for the MessageItem response schema."""
+
+    def test_coerces_uuid_id_to_string(self) -> None:
+        """UUID id is coerced to string."""
+        msg_id = uuid.uuid4()
+        item = MessageItem(
+            id=msg_id,  # type: ignore[arg-type]
+            role="user",
+            content="Hello",
+            media_url=None,
+            metadata=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert item.id == str(msg_id)
+
+    def test_string_id_passed_through(self) -> None:
+        """String id is kept as-is."""
+        item = MessageItem(
+            id="some-string-id",
+            role="assistant",
+            content="Hi there",
+            media_url=None,
+            metadata=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert item.id == "some-string-id"
+
+    def test_metadata_dict_accepted(self) -> None:
+        """dict metadata is passed through."""
+        meta = {"action": "SET_ALARM", "payload": {"time": "07:00"}}
+        item = MessageItem(
+            id="id1",
+            role="assistant",
+            content="OK",
+            media_url=None,
+            metadata=meta,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert item.metadata == meta
+
+    def test_metadata_none_accepted(self) -> None:
+        """None metadata is accepted."""
+        item = MessageItem(
+            id="id1",
+            role="user",
+            content="Hello",
+            media_url=None,
+            metadata=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert item.metadata is None
+
+
+# ---------------------------------------------------------------------------
+# MessageListResponse tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageListResponse:
+    """Tests for the MessageListResponse schema."""
+
+    def test_includes_pagination_fields(self) -> None:
+        """Response includes items, next_cursor, and has_more."""
+        resp = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+        assert resp.items == []
+        assert resp.next_cursor is None
+        assert resp.has_more is False
+
+    def test_with_items_and_cursor(self) -> None:
+        """Response with items and cursor is serialized correctly."""
+        item = MessageItem(
+            id="id1",
+            role="user",
+            content="Hello",
+            media_url=None,
+            metadata=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        resp = MessageListResponse(
+            items=[item],
+            next_cursor="2026-02-23T14:30:00+00:00",
+            has_more=True,
+        )
+        assert len(resp.items) == 1
+        assert resp.next_cursor == "2026-02-23T14:30:00+00:00"
+        assert resp.has_more is True
+
+
+# ---------------------------------------------------------------------------
+# SSE Event models tests
+# ---------------------------------------------------------------------------
+
+
+class TestSSEEventModels:
+    """Tests for SSE event serialization models."""
+
+    def test_chunk_event(self) -> None:
+        """ChunkEvent serializes correctly."""
+        event = ChunkEvent(content="Hello")
+        data = event.model_dump()
+        assert data == {"type": "chunk", "content": "Hello"}
+
+    def test_action_event(self) -> None:
+        """ActionEvent serializes correctly."""
+        event = ActionEvent(
+            action="SET_ALARM",
+            payload={"time": "2026-02-24T07:00:00", "label": "Wake up"},
+        )
+        data = event.model_dump()
+        assert data["type"] == "action"
+        assert data["action"] == "SET_ALARM"
+        assert data["payload"]["time"] == "2026-02-24T07:00:00"
+
+    def test_done_event(self) -> None:
+        """DoneEvent serializes correctly."""
+        msg_id = str(uuid.uuid4())
+        event = DoneEvent(message_id=msg_id)
+        data = event.model_dump()
+        assert data == {"type": "done", "message_id": msg_id}
+
+    def test_error_event(self) -> None:
+        """ErrorEvent serializes correctly."""
+        event = ErrorEvent(message="AI service temporarily unavailable")
+        data = event.model_dump()
+        assert data == {
+            "type": "error",
+            "message": "AI service temporarily unavailable",
+        }

--- a/backend/tests/test_chat_schemas.py
+++ b/backend/tests/test_chat_schemas.py
@@ -152,6 +152,54 @@ class TestMessageItem:
         )
         assert item.metadata is None
 
+    def test_metadata_non_dict_coerced_to_none(self) -> None:
+        """Non-dict, non-None metadata is coerced to None."""
+        item = MessageItem(
+            id="id1",
+            role="user",
+            content="Hello",
+            media_url=None,
+            metadata="invalid_string",  # type: ignore[arg-type]
+            created_at=datetime.now(tz=UTC),
+        )
+        assert item.metadata is None
+
+    def test_metadata_list_coerced_to_none(self) -> None:
+        """List metadata is coerced to None (not a dict)."""
+        item = MessageItem(
+            id="id1",
+            role="user",
+            content="Hello",
+            media_url=None,
+            metadata=["item1"],  # type: ignore[arg-type]
+            created_at=datetime.now(tz=UTC),
+        )
+        assert item.metadata is None
+
+    def test_integer_id_coerced_to_string(self) -> None:
+        """Integer id is coerced to string."""
+        item = MessageItem(
+            id=12345,  # type: ignore[arg-type]
+            role="user",
+            content="Hello",
+            media_url=None,
+            metadata=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert item.id == "12345"
+
+    def test_media_url_preserved(self) -> None:
+        """media_url is preserved in the response item."""
+        item = MessageItem(
+            id="id1",
+            role="user",
+            content="Hello",
+            media_url="https://s3.amazonaws.com/bucket/image.jpg",
+            metadata=None,
+            created_at=datetime.now(tz=UTC),
+        )
+        assert item.media_url == "https://s3.amazonaws.com/bucket/image.jpg"
+
 
 # ---------------------------------------------------------------------------
 # MessageListResponse tests
@@ -232,3 +280,86 @@ class TestSSEEventModels:
             "type": "error",
             "message": "AI service temporarily unavailable",
         }
+
+    def test_chunk_event_model_dump_json(self) -> None:
+        """ChunkEvent serializes to valid JSON string."""
+        import json as json_mod
+
+        event = ChunkEvent(content="token")
+        raw = event.model_dump_json()
+        parsed = json_mod.loads(raw)
+        assert parsed["type"] == "chunk"
+        assert parsed["content"] == "token"
+
+    def test_action_event_calendar(self) -> None:
+        """ActionEvent for ADD_CALENDAR_EVENT serializes correctly."""
+        event = ActionEvent(
+            action="ADD_CALENDAR_EVENT",
+            payload={
+                "title": "Dentist",
+                "date": "2026-02-24",
+                "time": "15:00",
+                "duration_minutes": 60,
+            },
+        )
+        data = event.model_dump()
+        assert data["action"] == "ADD_CALENDAR_EVENT"
+        assert data["payload"]["title"] == "Dentist"
+        assert data["payload"]["duration_minutes"] == 60
+
+    def test_done_event_model_dump_json(self) -> None:
+        """DoneEvent serializes to valid JSON string."""
+        import json as json_mod
+
+        msg_id = str(uuid.uuid4())
+        event = DoneEvent(message_id=msg_id)
+        raw = event.model_dump_json()
+        parsed = json_mod.loads(raw)
+        assert parsed["type"] == "done"
+        assert parsed["message_id"] == msg_id
+
+
+# ---------------------------------------------------------------------------
+# SendMessageRequest edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageRequestEdgeCases:
+    """Additional edge case tests for SendMessageRequest."""
+
+    def test_content_at_max_length_accepted(self) -> None:
+        """Content exactly at 4000 chars is accepted."""
+        req = SendMessageRequest(content="a" * 4000)
+        assert len(req.content) == 4000
+
+    def test_content_at_min_length_accepted(self) -> None:
+        """Content exactly at 1 char is accepted."""
+        req = SendMessageRequest(content="x")
+        assert req.content == "x"
+
+    def test_content_with_newlines_accepted(self) -> None:
+        """Content containing newlines is accepted."""
+        req = SendMessageRequest(content="line1\nline2\nline3")
+        assert "line1\nline2\nline3" == req.content
+
+    def test_content_with_unicode_accepted(self) -> None:
+        """Content with unicode characters is accepted."""
+        req = SendMessageRequest(content="Merhaba, nasilsiniz? Gunaydin!")
+        assert req.content == "Merhaba, nasilsiniz? Gunaydin!"
+
+    def test_media_url_at_max_length_accepted(self) -> None:
+        """media_url exactly at 2048 chars is accepted."""
+        url = "https://example.com/" + "a" * (2048 - len("https://example.com/"))
+        req = SendMessageRequest(content="Hello", media_url=url)
+        assert len(req.media_url) == 2048  # type: ignore[arg-type]
+
+    def test_media_url_exceeds_max_length_rejected(self) -> None:
+        """media_url over 2048 chars raises ValidationError."""
+        url = "https://example.com/" + "a" * 2050
+        with pytest.raises(ValidationError):
+            SendMessageRequest(content="Hello", media_url=url)
+
+    def test_missing_content_rejected(self) -> None:
+        """Missing content field raises ValidationError."""
+        with pytest.raises(ValidationError):
+            SendMessageRequest()  # type: ignore[call-arg]

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -902,3 +902,1045 @@ class TestDeduplicateMemories:
         """Empty input returns empty output."""
         result = _deduplicate_memories([], [])
         assert result == []
+
+    def test_all_duplicates(self) -> None:
+        """When all memories are duplicated, result has each only once."""
+        result = _deduplicate_memories(
+            global_memories=["likes pizza", "morning person"],
+            character_memories=["likes pizza", "morning person"],
+        )
+        assert result == ["likes pizza", "morning person"]
+        assert len(result) == 2
+
+    def test_only_global_memories(self) -> None:
+        """When only global memories exist, they are all returned."""
+        result = _deduplicate_memories(
+            global_memories=["fact1", "fact2"],
+            character_memories=[],
+        )
+        assert result == ["fact1", "fact2"]
+
+    def test_only_character_memories(self) -> None:
+        """When only character memories exist, they are all returned."""
+        result = _deduplicate_memories(
+            global_memories=[],
+            character_memories=["fact1", "fact2"],
+        )
+        assert result == ["fact1", "fact2"]
+
+
+# ---------------------------------------------------------------------------
+# Additional validate_send_message tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSendMessageAdditional:
+    """Additional tests for ChatService.validate_send_message()."""
+
+    @pytest.mark.asyncio
+    async def test_character_not_found_raises_404(self) -> None:
+        """validate_send_message raises 404 for non-existent character."""
+        from fastapi import HTTPException
+
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        with patch.object(
+            service,
+            "_get_active_character",
+            side_effect=HTTPException(status_code=404, detail="Character not found"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await service.validate_send_message(
+                    character_id=FAKE_CHARACTER_ID,
+                    user_id=FAKE_USER_ID,
+                    profile=_make_fake_profile(),
+                    content="Hello",
+                )
+            assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_ownership_check_raises_403(self) -> None:
+        """validate_send_message raises 403 when character belongs to another user."""
+        from fastapi import HTTPException
+
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_char.user_id = uuid.UUID("990e8400-e29b-41d4-a716-446655440099")
+
+        with patch.object(
+            service, "_get_active_character", return_value=mock_char,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await service.validate_send_message(
+                    character_id=FAKE_CHARACTER_ID,
+                    user_id=FAKE_USER_ID,
+                    profile=_make_fake_profile(),
+                    content="Hello",
+                )
+            assert exc_info.value.status_code == 403
+            assert exc_info.value.detail == "Character does not belong to user"
+
+    @pytest.mark.asyncio
+    async def test_recent_messages_failure_continues(self) -> None:
+        """DB fetch failure for recent messages continues with empty list."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        async def _failing_recent(*args: object, **kwargs: object) -> list[MagicMock]:
+            raise RuntimeError("DB down")
+
+        with (
+            patch.object(service, "_get_active_character", return_value=mock_char),
+            patch.object(
+                service, "_get_or_create_conversation", return_value=mock_conv,
+            ),
+            patch.object(service, "_search_memories", return_value=[]),
+            patch.object(
+                service, "_get_recent_messages", side_effect=_failing_recent,
+            ),
+        ):
+            ctx = await service.validate_send_message(
+                character_id=FAKE_CHARACTER_ID,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+            )
+
+        # Should still return a valid context
+        assert "system_prompt" in ctx
+        assert "formatted_messages" in ctx
+
+    @pytest.mark.asyncio
+    async def test_context_includes_character_and_conversation(self) -> None:
+        """Context dict includes all required keys with correct objects."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        with (
+            patch.object(service, "_get_active_character", return_value=mock_char),
+            patch.object(
+                service, "_get_or_create_conversation", return_value=mock_conv,
+            ),
+            patch.object(service, "_search_memories", return_value=[]),
+            patch.object(service, "_get_recent_messages", return_value=[]),
+        ):
+            ctx = await service.validate_send_message(
+                character_id=FAKE_CHARACTER_ID,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+            )
+
+        assert ctx["character"].id == FAKE_CHARACTER_ID
+        assert ctx["conversation"].id == FAKE_CONVERSATION_ID
+        assert isinstance(ctx["system_prompt"], str)
+        assert isinstance(ctx["formatted_messages"], list)
+
+
+# ---------------------------------------------------------------------------
+# Additional stream_response tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamResponseAdditional:
+    """Additional tests for ChatService.stream_response()."""
+
+    @pytest.mark.asyncio
+    async def test_action_event_before_done_event(self) -> None:
+        """Action event always comes before done event in the stream."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_iter() -> AsyncGenerator[str, None]:
+            yield "Setting alarm now."
+
+        mock_stream.text_stream = _text_iter()
+
+        with (
+            patch("app.services.chat_service.AsyncAnthropic") as mock_a,
+            patch.object(
+                service,
+                "_extract_intent",
+                return_value={
+                    "action": "ADD_CALENDAR_EVENT",
+                    "payload": {"title": "Meeting", "date": "2026-02-25"},
+                },
+            ),
+            patch("app.services.chat_service._persist_exchange"),
+        ):
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Add a meeting",
+                media_url=None,
+            ):
+                sse_lines.append(event)
+
+        events = _parse_sse_events(sse_lines)
+        types = [e["type"] for e in events]
+        assert "action" in types
+        assert "done" in types
+        assert types.index("action") < types.index("done")
+
+    @pytest.mark.asyncio
+    async def test_persist_exchange_called_with_correct_args(self) -> None:
+        """Background task receives correct arguments."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_iter() -> AsyncGenerator[str, None]:
+            yield "Response text"
+
+        mock_stream.text_stream = _text_iter()
+
+        with (
+            patch("app.services.chat_service.AsyncAnthropic") as mock_a,
+            patch.object(service, "_extract_intent", return_value=None),
+            patch("app.services.chat_service._persist_exchange") as mock_persist,
+            patch("app.services.chat_service.asyncio") as mock_asyncio_mod,
+        ):
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            mock_asyncio_mod.gather = asyncio.gather
+            mock_asyncio_mod.to_thread = asyncio.to_thread
+            mock_asyncio_mod.create_task = MagicMock()
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello there",
+                media_url="https://example.com/img.jpg",
+            ):
+                sse_lines.append(event)
+
+            mock_asyncio_mod.create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_multiple_chunks_streamed(self) -> None:
+        """Stream yields multiple chunk events with proper content."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_iter() -> AsyncGenerator[str, None]:
+            for token in ["I", " am", " Emma", ".", " How", " can", " I", " help", "?"]:
+                yield token
+
+        mock_stream.text_stream = _text_iter()
+
+        with (
+            patch("app.services.chat_service.AsyncAnthropic") as mock_a,
+            patch.object(service, "_extract_intent", return_value=None),
+            patch("app.services.chat_service._persist_exchange"),
+        ):
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+                media_url=None,
+            ):
+                sse_lines.append(event)
+
+        events = _parse_sse_events(sse_lines)
+        chunk_events = [e for e in events if e["type"] == "chunk"]
+        assert len(chunk_events) == 9
+        full_text = "".join(e["content"] for e in chunk_events)
+        assert full_text == "I am Emma. How can I help?"
+
+
+# ---------------------------------------------------------------------------
+# Additional get_messages tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessagesAdditional:
+    """Additional tests for ChatService.get_messages()."""
+
+    @pytest.mark.asyncio
+    async def test_ownership_check_raises_403(self) -> None:
+        """get_messages raises 403 when character belongs to another user."""
+        from fastapi import HTTPException
+
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_char.user_id = uuid.UUID("990e8400-e29b-41d4-a716-446655440099")
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.get_messages(
+                character_id=FAKE_CHARACTER_ID,
+                user_id=FAKE_USER_ID,
+                cursor=None,
+                limit=20,
+            )
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_cursor_filter_applied(self) -> None:
+        """get_messages applies cursor filter correctly."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        cursor_time = datetime.now(tz=UTC) - timedelta(hours=1)
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=cursor_time,
+            limit=20,
+        )
+
+        assert response.items == []
+        assert response.has_more is False
+        assert response.next_cursor is None
+
+    @pytest.mark.asyncio
+    async def test_empty_conversation_returns_empty_list(self) -> None:
+        """Empty conversation returns empty items list."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=20,
+        )
+
+        assert response.items == []
+        assert response.has_more is False
+        assert response.next_cursor is None
+
+    @pytest.mark.asyncio
+    async def test_next_cursor_matches_last_item(self) -> None:
+        """next_cursor equals the last item's created_at when has_more is true."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        now = datetime.now(tz=UTC)
+        messages = [
+            _make_fake_message(content=f"msg{i}", offset_minutes=i) for i in range(4)
+        ]
+        # Set explicit created_at for predictable cursor
+        for i, msg in enumerate(messages):
+            msg.created_at = now - timedelta(minutes=i)
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = messages
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=3,
+        )
+
+        assert response.has_more is True
+        assert len(response.items) == 3
+        # next_cursor should be the created_at of the last returned item
+        assert response.next_cursor == messages[2].created_at.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Additional _extract_intent tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractIntentAdditional:
+    """Additional tests for ChatService._extract_intent()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_calendar_event_action(self) -> None:
+        """Returns ADD_CALENDAR_EVENT action when Haiku detects it."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = json.dumps({
+            "action": "ADD_CALENDAR_EVENT",
+            "payload": {
+                "title": "Dentist",
+                "date": "2026-02-24",
+                "time": "15:00",
+                "duration_minutes": 60,
+            },
+        })
+        mock_response.content = [mock_content]
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(return_value=mock_response)
+            mock_a.return_value = mc
+
+            result = await service._extract_intent(
+                "I've added the dentist appointment.", "UTC",
+            )
+
+        assert result is not None
+        assert result["action"] == "ADD_CALENDAR_EVENT"
+        assert result["payload"]["title"] == "Dentist"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_invalid_json(self) -> None:
+        """Returns None when Haiku responds with invalid JSON."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = "this is not json {{{]]]"
+        mock_response.content = [mock_content]
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(return_value=mock_response)
+            mock_a.return_value = mc
+
+            result = await service._extract_intent("Some text.", "UTC")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_unsupported_action(self) -> None:
+        """Returns None when Haiku returns an unsupported action type."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = json.dumps({
+            "action": "UNSUPPORTED_ACTION",
+            "payload": {"data": "value"},
+        })
+        mock_response.content = [mock_content]
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(return_value=mock_response)
+            mock_a.return_value = mc
+
+            result = await service._extract_intent("Some text.", "UTC")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_json_without_action_key(self) -> None:
+        """Returns None when Haiku returns valid JSON but no 'action' key."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = json.dumps({"something": "else"})
+        mock_response.content = [mock_content]
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(return_value=mock_response)
+            mock_a.return_value = mc
+
+            result = await service._extract_intent("Some text.", "UTC")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_none_case_insensitive(self) -> None:
+        """Returns None when Haiku responds with 'None' (uppercase)."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = "None"
+        mock_response.content = [mock_content]
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(return_value=mock_response)
+            mock_a.return_value = mc
+
+            result = await service._extract_intent("Just a casual response.", "UTC")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_default_empty_payload_when_missing(self) -> None:
+        """Returns empty payload dict when Haiku omits payload key."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = json.dumps({"action": "SET_ALARM"})
+        mock_response.content = [mock_content]
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(return_value=mock_response)
+            mock_a.return_value = mc
+
+            result = await service._extract_intent("Set alarm.", "UTC")
+
+        assert result is not None
+        assert result["action"] == "SET_ALARM"
+        assert result["payload"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Additional _build_system_prompt tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSystemPromptAdditional:
+    """Additional tests for ChatService._build_system_prompt()."""
+
+    def test_invalid_timezone_falls_back_to_utc(self) -> None:
+        """Invalid timezone falls back to UTC without crashing."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        profile = _make_fake_profile()
+        profile.timezone = "Invalid/Timezone"
+
+        prompt = service._build_system_prompt(
+            character_system_prompt="You are Sarah.",
+            global_memories=[],
+            character_memories=[],
+            profile=profile,
+        )
+
+        # Should still contain date/time info (using UTC fallback)
+        assert "Current date and time:" in prompt
+
+    def test_none_timezone_falls_back_to_utc(self) -> None:
+        """None timezone falls back to UTC without crashing."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        profile = _make_fake_profile()
+        profile.timezone = None
+
+        prompt = service._build_system_prompt(
+            character_system_prompt="You are Sarah.",
+            global_memories=[],
+            character_memories=[],
+            profile=profile,
+        )
+
+        assert "Current date and time:" in prompt
+
+    def test_memory_deduplication_in_prompt(self) -> None:
+        """Duplicated memories between global and character appear only once."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        profile = _make_fake_profile()
+        prompt = service._build_system_prompt(
+            character_system_prompt="You are Sarah.",
+            global_memories=["Likes pizza", "Morning person"],
+            character_memories=["Likes pizza", "Struggles with grammar"],
+            profile=profile,
+        )
+
+        # "Likes pizza" should appear only once
+        assert prompt.count("Likes pizza") == 1
+        assert "Morning person" in prompt
+        assert "Struggles with grammar" in prompt
+
+    def test_max_ten_memories_in_prompt(self) -> None:
+        """Up to 10 memories (5 global + 5 character) can appear in prompt."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        profile = _make_fake_profile()
+        prompt = service._build_system_prompt(
+            character_system_prompt="You are Sarah.",
+            global_memories=[f"global_fact_{i}" for i in range(5)],
+            character_memories=[f"char_fact_{i}" for i in range(5)],
+            profile=profile,
+        )
+
+        assert "What you know about this user:" in prompt
+        # All 10 unique memories should be present
+        for i in range(5):
+            assert f"global_fact_{i}" in prompt
+            assert f"char_fact_{i}" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Additional _format_messages tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMessagesAdditional:
+    """Additional tests for ChatService._format_messages()."""
+
+    def test_formats_with_empty_history(self) -> None:
+        """Empty history produces only the new user message."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        formatted = service._format_messages([], "Hello!")
+
+        assert len(formatted) == 1
+        assert formatted[0] == {"role": "user", "content": "Hello!"}
+
+    def test_new_message_appended_last(self) -> None:
+        """New user message is always the last item."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        msg1 = _make_fake_message(role="user", content="First")
+        msg2 = _make_fake_message(role="assistant", content="Reply")
+
+        formatted = service._format_messages([msg1, msg2], "New message")
+
+        assert formatted[-1] == {"role": "user", "content": "New message"}
+        assert len(formatted) == 3
+
+
+# ---------------------------------------------------------------------------
+# Additional _persist_exchange tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistExchangeAdditional:
+    """Additional tests for the _persist_exchange background task."""
+
+    @pytest.mark.asyncio
+    async def test_persists_action_metadata(self) -> None:
+        """Background task stores action metadata on assistant message."""
+        mock_session = AsyncMock()
+        add_calls: list[Any] = []
+        mock_session.add = MagicMock(side_effect=lambda obj: add_calls.append(obj))
+        mock_session.commit = AsyncMock()
+
+        action_meta = {
+            "action": "SET_ALARM",
+            "payload": {"time": "07:00", "label": "Wake up"},
+        }
+
+        with (
+            patch("app.services.chat_service.AsyncSessionLocal") as mock_factory,
+            patch("app.services.chat_service.MemoryClient") as mock_mem0,
+        ):
+            mock_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session,
+            )
+            mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_mem0_inst = MagicMock()
+            mock_mem0.return_value = mock_mem0_inst
+
+            await _persist_exchange(
+                user_id=FAKE_USER_ID,
+                conversation_id=FAKE_CONVERSATION_ID,
+                user_content="Set alarm for 7am",
+                user_media_url=None,
+                assistant_content="I've set an alarm for 7:00 AM.",
+                assistant_message_id=uuid.uuid4(),
+                action_metadata=action_meta,
+                mem0_user_id=f"user_{FAKE_USER_ID}",
+                mem0_agent_id=f"english_teacher_{FAKE_USER_ID}",
+            )
+
+        # Verify 2 messages were added
+        assert mock_session.add.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_persists_media_url_on_user_message(self) -> None:
+        """Background task stores media_url on user message."""
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+
+        with (
+            patch("app.services.chat_service.AsyncSessionLocal") as mock_factory,
+            patch("app.services.chat_service.MemoryClient") as mock_mem0,
+        ):
+            mock_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session,
+            )
+            mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_mem0_inst = MagicMock()
+            mock_mem0.return_value = mock_mem0_inst
+
+            await _persist_exchange(
+                user_id=FAKE_USER_ID,
+                conversation_id=FAKE_CONVERSATION_ID,
+                user_content="Look at this",
+                user_media_url="https://s3.amazonaws.com/bucket/image.jpg",
+                assistant_content="Nice photo!",
+                assistant_message_id=uuid.uuid4(),
+                action_metadata=None,
+                mem0_user_id=f"user_{FAKE_USER_ID}",
+                mem0_agent_id=f"english_teacher_{FAKE_USER_ID}",
+            )
+
+        assert mock_session.add.call_count == 2
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mem0_add_called_with_message_pair(self) -> None:
+        """Background task passes correct user/assistant message pair to Mem0."""
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+
+        with (
+            patch("app.services.chat_service.AsyncSessionLocal") as mock_factory,
+            patch("app.services.chat_service.MemoryClient") as mock_mem0,
+            patch(
+                "app.services.chat_service.asyncio.to_thread",
+            ) as mock_to_thread,
+        ):
+            mock_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session,
+            )
+            mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_mem0_inst = MagicMock()
+            mock_mem0.return_value = mock_mem0_inst
+            mock_to_thread.return_value = None
+
+            await _persist_exchange(
+                user_id=FAKE_USER_ID,
+                conversation_id=FAKE_CONVERSATION_ID,
+                user_content="How are you?",
+                user_media_url=None,
+                assistant_content="I'm great!",
+                assistant_message_id=uuid.uuid4(),
+                action_metadata=None,
+                mem0_user_id=f"user_{FAKE_USER_ID}",
+                mem0_agent_id=f"english_teacher_{FAKE_USER_ID}",
+            )
+
+        # Verify the message pair passed to Mem0
+        mock_to_thread.assert_called_once()
+        call_args = mock_to_thread.call_args
+        messages_arg = call_args.args[1]  # Second positional arg
+        assert len(messages_arg) == 2
+        assert messages_arg[0]["role"] == "user"
+        assert messages_arg[0]["content"] == "How are you?"
+        assert messages_arg[1]["role"] == "assistant"
+        assert messages_arg[1]["content"] == "I'm great!"
+
+
+# ---------------------------------------------------------------------------
+# _get_active_character tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestGetActiveCharacter:
+    """Tests for ChatService._get_active_character()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_character_when_found(self) -> None:
+        """Returns the character when found and active."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_char
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        result = await service._get_active_character(FAKE_CHARACTER_ID)
+        assert result.id == FAKE_CHARACTER_ID
+
+    @pytest.mark.asyncio
+    async def test_raises_404_when_not_found(self) -> None:
+        """Raises 404 when character does not exist or is inactive."""
+        from fastapi import HTTPException
+
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service._get_active_character(FAKE_CHARACTER_ID)
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Character not found"
+
+
+# ---------------------------------------------------------------------------
+# _get_or_create_conversation tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestGetOrCreateConversation:
+    """Tests for ChatService._get_or_create_conversation()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_conversation(self) -> None:
+        """Returns existing conversation without creating a new one."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_conv = _make_fake_conversation()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_conv
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        result = await service._get_or_create_conversation(
+            FAKE_CHARACTER_ID, FAKE_USER_ID,
+        )
+
+        assert result.id == FAKE_CONVERSATION_ID
+        mock_db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_creates_conversation_when_missing(self) -> None:
+        """Auto-creates a conversation when none exists for the character."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        result = await service._get_or_create_conversation(
+            FAKE_CHARACTER_ID, FAKE_USER_ID,
+        )
+
+        # A new conversation was added and committed
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+        mock_db.refresh.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _search_memories tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchMemories:
+    """Tests for ChatService._search_memories()."""
+
+    @pytest.mark.asyncio
+    async def test_search_with_agent_id(self) -> None:
+        """Passes agent_id to Mem0 when provided."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        agent_id = f"english_teacher_{FAKE_USER_ID}"
+
+        with (
+            patch("app.services.chat_service.MemoryClient") as mock_mem0_cls,
+            patch("app.services.chat_service.asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_mem0_inst = MagicMock()
+            mock_mem0_cls.return_value = mock_mem0_inst
+            mock_to_thread.return_value = [
+                {"memory": "Likes reading"},
+                {"memory": "Prefers mornings"},
+            ]
+
+            result = await service._search_memories(
+                "Hello", f"user_{FAKE_USER_ID}", agent_id=agent_id,
+            )
+
+        assert result == ["Likes reading", "Prefers mornings"]
+        mock_to_thread.assert_called_once()
+        call_kwargs = mock_to_thread.call_args.kwargs
+        assert call_kwargs["agent_id"] == agent_id
+
+    @pytest.mark.asyncio
+    async def test_search_without_agent_id(self) -> None:
+        """Omits agent_id from Mem0 call when not provided (global search)."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        with (
+            patch("app.services.chat_service.MemoryClient") as mock_mem0_cls,
+            patch("app.services.chat_service.asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_mem0_inst = MagicMock()
+            mock_mem0_cls.return_value = mock_mem0_inst
+            mock_to_thread.return_value = [{"memory": "Global fact"}]
+
+            result = await service._search_memories(
+                "Hello", f"user_{FAKE_USER_ID}", agent_id=None,
+            )
+
+        assert result == ["Global fact"]
+        mock_to_thread.assert_called_once()
+        call_kwargs = mock_to_thread.call_args.kwargs
+        assert "agent_id" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_search_handles_exception(self) -> None:
+        """Returns empty list when Mem0 search raises an exception."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        with patch(
+            "app.services.chat_service.MemoryClient",
+            side_effect=Exception("Connection error"),
+        ):
+            result = await service._search_memories(
+                "Hello", f"user_{FAKE_USER_ID}", agent_id=None,
+            )
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _get_recent_messages tests (backend-tester)
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecentMessages:
+    """Tests for ChatService._get_recent_messages()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_messages_in_chronological_order(self) -> None:
+        """Recent messages are returned in chronological order (oldest first)."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        now = datetime.now(tz=UTC)
+        msg_old = _make_fake_message(content="older", offset_minutes=10)
+        msg_new = _make_fake_message(content="newer", offset_minutes=0)
+
+        # DB returns DESC order (newest first)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [msg_new, msg_old]
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        result = await service._get_recent_messages(FAKE_CONVERSATION_ID)
+
+        # After reversal, should be chronological: oldest first
+        assert result[0].content == "older"
+        assert result[1].content == "newer"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_new_conversation(self) -> None:
+        """Returns empty list when conversation has no messages."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        result = await service._get_recent_messages(FAKE_CONVERSATION_ID)
+
+        assert result == []

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -1,0 +1,904 @@
+"""Unit tests for ChatService.
+
+Tests service methods with mocked DB, Claude, and Mem0 dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import uuid  # noqa: E402
+from collections.abc import AsyncGenerator  # noqa: E402
+from datetime import UTC, datetime, timedelta  # noqa: E402
+from typing import Any  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+
+from app.services.chat_service import (  # noqa: E402
+    ChatService,
+    _deduplicate_memories,
+    _persist_exchange,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FAKE_USER_ID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+FAKE_CHARACTER_ID = uuid.UUID("660e8400-e29b-41d4-a716-446655440001")
+FAKE_CONVERSATION_ID = uuid.UUID("880e8400-e29b-41d4-a716-446655440002")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_profile() -> MagicMock:
+    """Create a fake Profile object."""
+    profile = MagicMock()
+    profile.id = FAKE_USER_ID
+    profile.name = "Alex"
+    profile.mem0_user_id = f"user_{FAKE_USER_ID}"
+    profile.timezone = "America/New_York"
+    profile.preferred_language = "en"
+    return profile
+
+
+def _make_fake_character() -> MagicMock:
+    """Create a fake Character object."""
+    char = MagicMock()
+    char.id = FAKE_CHARACTER_ID
+    char.user_id = FAKE_USER_ID
+    char.name = "Sarah"
+    char.template = "english_teacher"
+    char.system_prompt = "You are Sarah, an English teacher."
+    char.mem0_agent_id = f"english_teacher_{FAKE_USER_ID}"
+    char.is_active = True
+    return char
+
+
+def _make_fake_conversation() -> MagicMock:
+    """Create a fake Conversation object."""
+    conv = MagicMock()
+    conv.id = FAKE_CONVERSATION_ID
+    conv.user_id = FAKE_USER_ID
+    conv.character_id = FAKE_CHARACTER_ID
+    return conv
+
+
+def _make_fake_message(
+    role: str = "user",
+    content: str = "Hello",
+    offset_minutes: int = 0,
+) -> MagicMock:
+    """Create a fake Message object."""
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.conversation_id = FAKE_CONVERSATION_ID
+    msg.user_id = FAKE_USER_ID
+    msg.role = role
+    msg.content = content
+    msg.media_url = None
+    msg.metadata_ = None
+    msg.created_at = datetime.now(tz=UTC) - timedelta(minutes=offset_minutes)
+    return msg
+
+
+def _make_valid_context() -> dict[str, Any]:
+    """Create a valid context dict as returned by validate_send_message."""
+    return {
+        "character": _make_fake_character(),
+        "conversation": _make_fake_conversation(),
+        "system_prompt": "You are Sarah.",
+        "formatted_messages": [{"role": "user", "content": "Hello"}],
+    }
+
+
+def _parse_sse_events(sse_lines: list[str]) -> list[dict[str, Any]]:
+    """Parse collected SSE lines into event dicts."""
+    events = []
+    for line in sse_lines:
+        line = line.strip()
+        if line.startswith("data: "):
+            events.append(json.loads(line[6:]))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# validate_send_message tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSendMessage:
+    """Tests for ChatService.validate_send_message()."""
+
+    @pytest.mark.asyncio
+    async def test_parallel_fetch_mem0_and_db(self) -> None:
+        """validate_send_message calls search + recent messages in parallel."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        with (
+            patch.object(service, "_get_active_character", return_value=mock_char),
+            patch.object(
+                service, "_get_or_create_conversation", return_value=mock_conv,
+            ),
+            patch.object(service, "_search_memories", return_value=[]) as mock_sm,
+            patch.object(service, "_get_recent_messages", return_value=[]) as mock_rm,
+        ):
+            ctx = await service.validate_send_message(
+                character_id=FAKE_CHARACTER_ID,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+            )
+
+        # _search_memories called twice (global + character)
+        assert mock_sm.call_count == 2
+        # _get_recent_messages called once
+        assert mock_rm.call_count == 1
+        # Verify context has required keys
+        assert "character" in ctx
+        assert "conversation" in ctx
+        assert "system_prompt" in ctx
+        assert "formatted_messages" in ctx
+
+    @pytest.mark.asyncio
+    async def test_mem0_search_failure_continues(self) -> None:
+        """Mem0 search failure does not crash validate_send_message."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        async def _failing_search(*args: object, **kwargs: object) -> list[str]:
+            raise RuntimeError("Mem0 down")
+
+        with (
+            patch.object(service, "_get_active_character", return_value=mock_char),
+            patch.object(
+                service, "_get_or_create_conversation", return_value=mock_conv,
+            ),
+            patch.object(service, "_search_memories", side_effect=_failing_search),
+            patch.object(service, "_get_recent_messages", return_value=[]),
+        ):
+            ctx = await service.validate_send_message(
+                character_id=FAKE_CHARACTER_ID,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+            )
+
+        # Should still return a valid context
+        assert "system_prompt" in ctx
+
+
+# ---------------------------------------------------------------------------
+# stream_response tests
+# ---------------------------------------------------------------------------
+
+
+class TestStreamResponse:
+    """Tests for ChatService.stream_response()."""
+
+    @pytest.mark.asyncio
+    async def test_yields_chunk_events(self) -> None:
+        """stream_response yields chunk events from Claude stream."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_iter() -> AsyncGenerator[str, None]:
+            for chunk in ["Hello", ", ", "world!"]:
+                yield chunk
+
+        mock_stream.text_stream = _text_iter()
+
+        with (
+            patch("app.services.chat_service.AsyncAnthropic") as mock_a,
+            patch.object(service, "_extract_intent", return_value=None),
+            patch("app.services.chat_service._persist_exchange"),
+        ):
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+                media_url=None,
+            ):
+                sse_lines.append(event)
+
+        events = _parse_sse_events(sse_lines)
+        chunk_events = [e for e in events if e["type"] == "chunk"]
+        assert len(chunk_events) == 3
+        assert chunk_events[0]["content"] == "Hello"
+        assert chunk_events[1]["content"] == ", "
+        assert chunk_events[2]["content"] == "world!"
+
+    @pytest.mark.asyncio
+    async def test_yields_action_event_when_intent_detected(self) -> None:
+        """stream_response yields action event when intent is detected."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_iter() -> AsyncGenerator[str, None]:
+            yield "Setting alarm."
+
+        mock_stream.text_stream = _text_iter()
+
+        with (
+            patch("app.services.chat_service.AsyncAnthropic") as mock_a,
+            patch.object(
+                service,
+                "_extract_intent",
+                return_value={
+                    "action": "SET_ALARM",
+                    "payload": {"time": "07:00", "label": "Wake up"},
+                },
+            ),
+            patch("app.services.chat_service._persist_exchange"),
+        ):
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Set alarm",
+                media_url=None,
+            ):
+                sse_lines.append(event)
+
+        events = _parse_sse_events(sse_lines)
+        action_events = [e for e in events if e["type"] == "action"]
+        assert len(action_events) == 1
+        assert action_events[0]["action"] == "SET_ALARM"
+
+    @pytest.mark.asyncio
+    async def test_skips_action_when_haiku_returns_none(self) -> None:
+        """No action event when Haiku returns none."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_iter() -> AsyncGenerator[str, None]:
+            yield "Just chatting."
+
+        mock_stream.text_stream = _text_iter()
+
+        with (
+            patch("app.services.chat_service.AsyncAnthropic") as mock_a,
+            patch.object(service, "_extract_intent", return_value=None),
+            patch("app.services.chat_service._persist_exchange"),
+        ):
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+                media_url=None,
+            ):
+                sse_lines.append(event)
+
+        events = _parse_sse_events(sse_lines)
+        assert not any(e["type"] == "action" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_yields_done_event_with_uuid(self) -> None:
+        """stream_response yields done event with valid UUID message_id."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_iter() -> AsyncGenerator[str, None]:
+            yield "Hi"
+
+        mock_stream.text_stream = _text_iter()
+
+        with (
+            patch("app.services.chat_service.AsyncAnthropic") as mock_a,
+            patch.object(service, "_extract_intent", return_value=None),
+            patch("app.services.chat_service._persist_exchange"),
+        ):
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+                media_url=None,
+            ):
+                sse_lines.append(event)
+
+        events = _parse_sse_events(sse_lines)
+        done_events = [e for e in events if e["type"] == "done"]
+        assert len(done_events) == 1
+        uuid.UUID(done_events[0]["message_id"])
+
+    @pytest.mark.asyncio
+    async def test_fires_background_task_for_persistence(self) -> None:
+        """stream_response fires asyncio.create_task for persistence."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_iter() -> AsyncGenerator[str, None]:
+            yield "Hi"
+
+        mock_stream.text_stream = _text_iter()
+
+        with (
+            patch("app.services.chat_service.AsyncAnthropic") as mock_a,
+            patch.object(service, "_extract_intent", return_value=None),
+            patch("app.services.chat_service._persist_exchange"),
+            patch("app.services.chat_service.asyncio") as mock_asyncio,
+        ):
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            mock_asyncio.gather = asyncio.gather
+            mock_asyncio.to_thread = asyncio.to_thread
+            mock_asyncio.create_task = MagicMock()
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+                media_url=None,
+            ):
+                sse_lines.append(event)
+
+            mock_asyncio.create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_claude_error_emits_error_event(self) -> None:
+        """stream_response emits error event when Claude fails."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+        ctx = _make_valid_context()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(side_effect=Exception("API error"))
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.stream = MagicMock(return_value=mock_stream)
+            mock_a.return_value = mc
+
+            sse_lines = []
+            async for event in service.stream_response(
+                context=ctx,
+                user_id=FAKE_USER_ID,
+                profile=profile,
+                content="Hello",
+                media_url=None,
+            ):
+                sse_lines.append(event)
+
+        events = _parse_sse_events(sse_lines)
+        assert events[-1]["type"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# System prompt and message formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptBuilder:
+    """Tests for ChatService._build_system_prompt() and _format_messages()."""
+
+    def test_builds_system_prompt_with_three_blocks(self) -> None:
+        """System prompt contains character prompt, memories, and date/time."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        prompt = service._build_system_prompt(
+            character_system_prompt="You are Sarah.",
+            global_memories=["Likes pizza"],
+            character_memories=["Struggles with grammar"],
+            profile=profile,
+        )
+
+        assert "You are Sarah." in prompt
+        assert "- Likes pizza" in prompt
+        assert "- Struggles with grammar" in prompt
+        assert "What you know about this user:" in prompt
+        assert "Current date and time:" in prompt
+        assert "Timezone: America/New_York" in prompt
+        assert "User's preferred language: en" in prompt
+
+    def test_system_prompt_omits_memory_block_when_empty(self) -> None:
+        """System prompt omits Block 2 when no memories exist."""
+        profile = _make_fake_profile()
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        prompt = service._build_system_prompt(
+            character_system_prompt="You are Sarah.",
+            global_memories=[],
+            character_memories=[],
+            profile=profile,
+        )
+
+        assert "What you know about this user:" not in prompt
+        assert "You are Sarah." in prompt
+        assert "Current date and time:" in prompt
+
+    def test_system_prompt_includes_timezone_and_language(self) -> None:
+        """System prompt Block 3 includes user timezone and language."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        profile = _make_fake_profile()
+        profile.timezone = "Europe/Istanbul"
+        profile.preferred_language = "tr"
+
+        prompt = service._build_system_prompt(
+            character_system_prompt="You are a companion.",
+            global_memories=[],
+            character_memories=[],
+            profile=profile,
+        )
+
+        assert "Timezone: Europe/Istanbul" in prompt
+        assert "User's preferred language: tr" in prompt
+
+    def test_formats_messages_with_history(self) -> None:
+        """Message history + new content are formatted for Claude API."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        msg1 = _make_fake_message(role="user", content="Hi")
+        msg2 = _make_fake_message(role="assistant", content="Hello!")
+
+        formatted = service._format_messages([msg1, msg2], "How are you?")
+
+        assert len(formatted) == 3
+        assert formatted[0] == {"role": "user", "content": "Hi"}
+        assert formatted[1] == {"role": "assistant", "content": "Hello!"}
+        assert formatted[2] == {"role": "user", "content": "How are you?"}
+
+
+# ---------------------------------------------------------------------------
+# get_messages tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessages:
+    """Tests for ChatService.get_messages()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_messages_in_desc_order(self) -> None:
+        """get_messages returns messages newest-first."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        msg1 = _make_fake_message(content="older", offset_minutes=10)
+        msg2 = _make_fake_message(content="newer", offset_minutes=0)
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = [msg2, msg1]
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=20,
+        )
+
+        assert len(response.items) == 2
+        assert response.items[0].content == "newer"
+        assert response.items[1].content == "older"
+        assert response.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_has_more_and_next_cursor(self) -> None:
+        """get_messages sets has_more=True and next_cursor when more exist."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        messages = [
+            _make_fake_message(content=f"msg{i}", offset_minutes=i) for i in range(3)
+        ]
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = messages
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=2,
+        )
+
+        assert len(response.items) == 2
+        assert response.has_more is True
+        assert response.next_cursor is not None
+
+    @pytest.mark.asyncio
+    async def test_missing_conversation_raises_404(self) -> None:
+        """get_messages raises 404 for missing conversation."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            else:
+                result.scalar_one_or_none.return_value = None
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.get_messages(
+                character_id=FAKE_CHARACTER_ID,
+                user_id=FAKE_USER_ID,
+                cursor=None,
+                limit=20,
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Intent extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractIntent:
+    """Tests for ChatService._extract_intent()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_action_when_intent_detected(self) -> None:
+        """Returns action dict when Haiku finds an intent."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = json.dumps({
+            "action": "SET_ALARM",
+            "payload": {"time": "2026-02-24T07:00:00", "label": "Wake up"},
+        })
+        mock_response.content = [mock_content]
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(return_value=mock_response)
+            mock_a.return_value = mc
+
+            result = await service._extract_intent("I'll set an alarm.", "UTC")
+
+        assert result is not None
+        assert result["action"] == "SET_ALARM"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_haiku_says_none(self) -> None:
+        """Returns None when Haiku responds with 'none'."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = "none"
+        mock_response.content = [mock_content]
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(return_value=mock_response)
+            mock_a.return_value = mc
+
+            result = await service._extract_intent("Just chatting.", "UTC")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_haiku_fails(self) -> None:
+        """Returns None when Haiku call fails (no crash)."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        with patch("app.services.chat_service.AsyncAnthropic") as mock_a:
+            mc = AsyncMock()
+            mc.messages.create = AsyncMock(side_effect=Exception("API error"))
+            mock_a.return_value = mc
+
+            result = await service._extract_intent("Some text.", "UTC")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Background task tests
+# ---------------------------------------------------------------------------
+
+
+class TestPersistExchange:
+    """Tests for the _persist_exchange background task."""
+
+    @pytest.mark.asyncio
+    async def test_persists_user_and_assistant_messages(self) -> None:
+        """Background task inserts two messages."""
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+
+        with (
+            patch("app.services.chat_service.AsyncSessionLocal") as mock_factory,
+            patch("app.services.chat_service.MemoryClient") as mock_mem0,
+        ):
+            mock_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session,
+            )
+            mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_mem0_inst = MagicMock()
+            mock_mem0.return_value = mock_mem0_inst
+
+            await _persist_exchange(
+                user_id=FAKE_USER_ID,
+                conversation_id=FAKE_CONVERSATION_ID,
+                user_content="Hello",
+                user_media_url=None,
+                assistant_content="Hi there!",
+                assistant_message_id=uuid.uuid4(),
+                action_metadata=None,
+                mem0_user_id=f"user_{FAKE_USER_ID}",
+                mem0_agent_id=f"english_teacher_{FAKE_USER_ID}",
+            )
+
+        assert mock_session.add.call_count == 2
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_db_error_gracefully(self) -> None:
+        """Background task handles DB error without crash."""
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock(side_effect=Exception("DB error"))
+
+        with (
+            patch("app.services.chat_service.AsyncSessionLocal") as mock_factory,
+            patch("app.services.chat_service.MemoryClient") as mock_mem0,
+        ):
+            mock_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session,
+            )
+            mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_mem0_inst = MagicMock()
+            mock_mem0.return_value = mock_mem0_inst
+
+            await _persist_exchange(
+                user_id=FAKE_USER_ID,
+                conversation_id=FAKE_CONVERSATION_ID,
+                user_content="Hello",
+                user_media_url=None,
+                assistant_content="Hi there!",
+                assistant_message_id=uuid.uuid4(),
+                action_metadata=None,
+                mem0_user_id=f"user_{FAKE_USER_ID}",
+                mem0_agent_id=f"english_teacher_{FAKE_USER_ID}",
+            )
+
+    @pytest.mark.asyncio
+    async def test_handles_mem0_error_gracefully(self) -> None:
+        """Background task handles Mem0 error without crash."""
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+
+        with (
+            patch("app.services.chat_service.AsyncSessionLocal") as mock_factory,
+            patch("app.services.chat_service.MemoryClient") as mock_mem0,
+            patch("app.services.chat_service.asyncio") as mock_asyncio_mod,
+        ):
+            mock_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session,
+            )
+            mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_mem0_inst = MagicMock()
+            mock_mem0.return_value = mock_mem0_inst
+
+            async def _failing_to_thread(
+                fn: object, *args: object, **kwargs: object
+            ) -> None:
+                raise RuntimeError("Mem0 error")
+
+            mock_asyncio_mod.to_thread = _failing_to_thread
+
+            await _persist_exchange(
+                user_id=FAKE_USER_ID,
+                conversation_id=FAKE_CONVERSATION_ID,
+                user_content="Hello",
+                user_media_url=None,
+                assistant_content="Hi there!",
+                assistant_message_id=uuid.uuid4(),
+                action_metadata=None,
+                mem0_user_id=f"user_{FAKE_USER_ID}",
+                mem0_agent_id=f"english_teacher_{FAKE_USER_ID}",
+            )
+
+    @pytest.mark.asyncio
+    async def test_calls_mem0_add_with_correct_agent_id(self) -> None:
+        """Background task calls Mem0 add with correct parameters."""
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+
+        agent_id = f"english_teacher_{FAKE_USER_ID}"
+        mem0_user_id = f"user_{FAKE_USER_ID}"
+
+        with (
+            patch("app.services.chat_service.AsyncSessionLocal") as mock_factory,
+            patch("app.services.chat_service.MemoryClient") as mock_mem0,
+            patch(
+                "app.services.chat_service.asyncio.to_thread",
+            ) as mock_to_thread,
+        ):
+            mock_factory.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session,
+            )
+            mock_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_mem0_inst = MagicMock()
+            mock_mem0.return_value = mock_mem0_inst
+            mock_to_thread.return_value = None
+
+            await _persist_exchange(
+                user_id=FAKE_USER_ID,
+                conversation_id=FAKE_CONVERSATION_ID,
+                user_content="Hello",
+                user_media_url=None,
+                assistant_content="Hi!",
+                assistant_message_id=uuid.uuid4(),
+                action_metadata=None,
+                mem0_user_id=mem0_user_id,
+                mem0_agent_id=agent_id,
+            )
+
+        mock_to_thread.assert_called_once()
+        call_args = mock_to_thread.call_args
+        assert call_args.kwargs.get("user_id") == mem0_user_id
+        assert call_args.kwargs.get("agent_id") == agent_id
+
+
+# ---------------------------------------------------------------------------
+# Utility tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplicateMemories:
+    """Tests for _deduplicate_memories."""
+
+    def test_deduplicates_by_exact_match(self) -> None:
+        """Identical memories are de-duplicated."""
+        global_mems = ["Likes pizza", "Prefers mornings"]
+        char_mems = ["Likes pizza", "Struggles with grammar"]
+
+        result = _deduplicate_memories(global_mems, char_mems)
+
+        assert "Likes pizza" in result
+        assert result.count("Likes pizza") == 1
+        assert "Struggles with grammar" in result
+        assert "Prefers mornings" in result
+
+    def test_preserves_order_character_first(self) -> None:
+        """Character-specific memories come before global."""
+        result = _deduplicate_memories(
+            global_memories=["global1"],
+            character_memories=["char1"],
+        )
+        assert result[0] == "char1"
+        assert result[1] == "global1"
+
+    def test_empty_lists(self) -> None:
+        """Empty input returns empty output."""
+        result = _deduplicate_memories([], [])
+        assert result == []

--- a/docs/features/chat-streaming.md
+++ b/docs/features/chat-streaming.md
@@ -1,0 +1,430 @@
+# Chat Streaming
+
+> Sends a user message to an AI character and streams the response in real time via Server-Sent Events, integrating Mem0 long-term memory and device action intent detection.
+
+**Status**: Released
+**Added in**: Phase 1 (P01-06)
+**Platforms**: Backend
+**GitHub Issue**: #8
+
+---
+
+## Overview
+
+Chat streaming is the core interaction endpoint of Ember. It powers every conversation between a user and their AI characters. When a user sends a message, the backend gathers context from two sources in parallel -- recent conversation history from PostgreSQL and long-term memories from Mem0 -- then streams the AI response token-by-token via Server-Sent Events (SSE). This gives the user a responsive experience where text appears incrementally rather than after a multi-second wait.
+
+Beyond basic chat, the endpoint performs post-stream intent extraction using Claude Haiku. If the assistant's response contains a device action intent (such as setting an alarm or adding a calendar event), the backend emits an `action` SSE event that the mobile client can act on. This is the foundation for Ember's device integration capabilities.
+
+A second endpoint provides cursor-based paginated retrieval of message history, enabling infinite-scroll message loading on mobile clients. Messages are persisted asynchronously as background tasks after the stream completes, keeping time-to-first-token low.
+
+---
+
+## Architecture
+
+### How It Works (Data Flow)
+
+**Streaming a message (POST):**
+
+1. The mobile client sends `POST /api/v1/characters/{character_id}/messages` with the user's message text and a Bearer JWT.
+2. The route handler extracts `user_id` from the JWT via the `get_current_user` dependency.
+3. `ChatService.validate_send_message()` runs **before** the `StreamingResponse` is created, so any validation failures (403, 404) return proper JSON error responses.
+4. The character is looked up by ID (must be active); ownership is verified against the JWT user.
+5. The character's conversation is looked up (or auto-created defensively if missing).
+6. Three parallel fetches run via `asyncio.gather(return_exceptions=True)`:
+   - Mem0 global memory search (up to 5 results, no `agent_id` filter)
+   - Mem0 character-specific memory search (up to 5 results, filtered by `agent_id`)
+   - Last 50 messages from PostgreSQL (configurable via `settings.max_context_messages`)
+7. The system prompt is constructed from three blocks: character definition, Mem0 memories, and daily context (date/time/timezone/language).
+8. Message history is formatted in chronological order with the new user message appended last.
+9. A `StreamingResponse` is returned with `Content-Type: text/event-stream`.
+10. Claude Sonnet streams the response; each text chunk is yielded as an SSE `chunk` event.
+11. After the full response is assembled, Claude Haiku analyzes it for device action intents.
+12. If an intent is detected, an SSE `action` event is emitted before the final `done` event.
+13. The `done` event includes the UUID of the persisted assistant message.
+14. A background task fires via `asyncio.create_task()` to persist both messages, update timestamps, and add the exchange to Mem0.
+
+**Retrieving message history (GET):**
+
+1. The client sends `GET /api/v1/characters/{character_id}/messages` with optional `cursor` and `limit` query parameters.
+2. Character ownership is verified.
+3. The conversation is looked up; if not found, a 404 is returned.
+4. Messages are queried with cursor-based pagination (`WHERE created_at < $cursor ORDER BY created_at DESC LIMIT $limit + 1`).
+5. The extra row determines `has_more`. The response includes `items`, `next_cursor`, and `has_more`.
+
+### Mem0 Memory Integration
+
+- **Global memories**: Searched without an `agent_id`, returning memories visible across all characters for the user.
+- **Character-specific memories**: Searched with `agent_id = character.mem0_agent_id`, returning memories isolated to this character.
+- **Search query**: The user's message text is used as the search query.
+- **Memory limit**: Up to 5 global + 5 character-specific = 10 total memories. De-duplicated by exact string match, with character-specific memories taking priority.
+- **Memory storage**: After the stream completes, the user-assistant message pair is added to Mem0 via `mem0_client.add()` as a background task.
+- **Failure resilience**: Mem0 search failures are caught and logged; the stream continues with empty memories. Mem0 add failures are caught and logged; message persistence is unaffected.
+
+### System Prompt Construction
+
+The system message sent to Claude is built from three blocks, following the architecture in `docs/05-ai-bellek.md`:
+
+| Block | Source | Content |
+|-------|--------|---------|
+| 1 -- Character Definition | `characters.system_prompt` | The stored system prompt generated during character creation (P01-05) |
+| 2 -- Learned Knowledge | Mem0 search results | `"What you know about this user:\n- {memory_1}\n- {memory_2}\n..."` (omitted if no memories) |
+| 3 -- Daily Context | Profile + server time | Current date/time in user's timezone, timezone name, preferred language |
+
+### Intent Extraction via Claude Haiku
+
+After the full Sonnet response is assembled, a separate non-streaming call to Claude Haiku determines whether the response contains a device action intent. Supported actions:
+
+| Action | Payload Fields | Description |
+|--------|---------------|-------------|
+| `SET_ALARM` | `time` (ISO 8601), `label` (string) | The assistant is setting an alarm or reminder |
+| `ADD_CALENDAR_EVENT` | `title`, `date` (YYYY-MM-DD), `time` (ISO 8601), `duration_minutes` (integer) | The assistant is adding a calendar event |
+
+If Haiku returns valid JSON with a supported action, the `action` SSE event is emitted. If Haiku returns `"none"`, returns invalid JSON, or fails entirely, the action event is skipped silently.
+
+### Background Task Persistence
+
+Background tasks run via `asyncio.create_task()` after the SSE stream completes. They use a **separate database session** (via `AsyncSessionLocal()`) because the request-scoped session is closed when the `StreamingResponse` finishes.
+
+The background task performs these operations:
+
+1. Insert the user message (`role="user"`, with `media_url` if provided)
+2. Insert the assistant message (`role="assistant"`, with `metadata_` containing action data if detected)
+3. Update `conversations.last_message_at`
+4. Update `user_activity.last_chat_at`
+5. Commit the database transaction
+6. Call `mem0_client.add()` with the user-assistant message pair (outside the DB transaction)
+
+Database and Mem0 failures are logged but do not crash the application.
+
+### Database Tables Involved
+
+| Table | Operation | Notes |
+|-------|-----------|-------|
+| `characters` | SELECT | Look up character, read `system_prompt` and `mem0_agent_id` |
+| `conversations` | SELECT, INSERT, UPDATE | Look up/auto-create conversation; update `last_message_at` |
+| `messages` | SELECT, INSERT | Fetch recent messages for context; persist user + assistant messages |
+| `profiles` | SELECT | Read via `get_current_user` for timezone, language, name, `mem0_user_id` |
+| `user_activity` | UPDATE | Update `last_chat_at` in background task |
+
+---
+
+## API Reference
+
+For the full API contract, see [`docs/04-veri-api.md`](../04-veri-api.md). All endpoints below are under `/api/v1/characters` and require `Authorization: Bearer <jwt>`.
+
+### POST /api/v1/characters/{character_id}/messages
+
+**Auth**: Bearer JWT required
+**Content-Type**: `application/json`
+**Success Status**: `200 OK` (SSE stream)
+
+Sends a message to a character and streams the AI response via Server-Sent Events.
+
+**Request Body**:
+
+```json
+{
+  "content": "I want to practice English today!",
+  "media_url": null
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `content` | string | yes | 1-4000 chars, whitespace-trimmed, rejected if empty after trim |
+| `media_url` | string or null | no | Must be a valid HTTP/HTTPS URL if provided, max 2048 chars |
+
+**Response**: `text/event-stream` with `Cache-Control: no-cache` and `X-Accel-Buffering: no`.
+
+**SSE Event Sequence**:
+
+```
+data: {"type":"chunk","content":"Great"}
+
+data: {"type":"chunk","content":"! Let's"}
+
+data: {"type":"chunk","content":" start with some conversation practice."}
+
+data: {"type":"action","action":"SET_ALARM","payload":{"time":"2026-02-24T07:00:00","label":"Morning practice"}}
+
+data: {"type":"done","message_id":"550e8400-e29b-41d4-a716-446655440099"}
+
+```
+
+Each SSE line is prefixed with `data: ` and followed by two newlines (`\n\n`). The JSON payload is a single line.
+
+**SSE Event Types**:
+
+| Event Type | Fields | Description |
+|------------|--------|-------------|
+| `chunk` | `type`, `content` | A text fragment of the streaming AI response |
+| `action` | `type`, `action`, `payload` | A device action intent detected in the response. Zero or one per response. Sent after streaming, before `done`. |
+| `done` | `type`, `message_id` | Signals the stream is complete. `message_id` is the UUID of the persisted assistant message. Always the last event. |
+| `error` | `type`, `message` | Signals an error occurred mid-stream. Sent instead of `done`. |
+
+**Error Responses (before SSE starts)**:
+
+| Status | Detail | When |
+|--------|--------|------|
+| 400 | `"Message content must be between 1 and 4000 characters"` | Content empty or exceeds 4000 chars |
+| 401 | `"Invalid or expired token"` | Missing or invalid JWT |
+| 403 | `"Character does not belong to user"` | Ownership mismatch |
+| 404 | `"Character not found"` | Non-existent or inactive character |
+| 422 | Standard FastAPI validation error | Pydantic validation failure |
+
+**Error during streaming (after SSE has started)**:
+
+If the Claude API fails mid-stream, an `error` event is emitted and the connection is closed. The HTTP status remains 200 (SSE protocol constraint). No messages are persisted.
+
+```
+data: {"type":"error","message":"AI service temporarily unavailable"}
+
+```
+
+**Notes**:
+
+- The `message_id` in the `done` event is the assistant message UUID. The user message UUID is not returned; the client generates a local UUID for the user message bubble.
+- The `media_url` is stored on the user message but is not processed in this feature. Photo analysis is a separate future feature.
+- If the character has no existing conversation (edge case), the endpoint auto-creates one.
+
+### GET /api/v1/characters/{character_id}/messages
+
+**Auth**: Bearer JWT required
+**Success Status**: `200 OK`
+
+Retrieves paginated message history for a character's conversation using cursor-based pagination.
+
+**Query Parameters**:
+
+| Param | Type | Required | Default | Constraints |
+|-------|------|----------|---------|-------------|
+| `cursor` | string (ISO 8601) | no | none | Messages older than this timestamp are returned |
+| `limit` | integer | no | 20 | Min 1, max 100 |
+
+**Response Body**:
+
+```json
+{
+  "items": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440088",
+      "role": "assistant",
+      "content": "Great! Let's start with some conversation practice.",
+      "media_url": null,
+      "metadata": null,
+      "created_at": "2026-02-23T14:30:05Z"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440087",
+      "role": "user",
+      "content": "I want to practice English today!",
+      "media_url": null,
+      "metadata": null,
+      "created_at": "2026-02-23T14:30:00Z"
+    }
+  ],
+  "next_cursor": "2026-02-23T14:25:00Z",
+  "has_more": true
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `items` | array | Messages in reverse chronological order (newest first) |
+| `items[].id` | string (UUID) | Message primary key |
+| `items[].role` | string | `"user"` or `"assistant"` |
+| `items[].content` | string | Message text |
+| `items[].media_url` | string or null | S3 URL for attached media |
+| `items[].metadata` | object or null | Intent action data or other metadata |
+| `items[].created_at` | string (ISO 8601) | Message creation timestamp |
+| `next_cursor` | string or null | Timestamp for the next page. Null when no more messages. |
+| `has_more` | boolean | True if older messages exist beyond this page |
+
+**Error Responses**:
+
+| Status | Detail | When |
+|--------|--------|------|
+| 401 | `"Invalid or expired token"` | Missing or invalid JWT |
+| 403 | `"Character does not belong to user"` | Ownership mismatch |
+| 404 | `"Character not found"` | Non-existent or inactive character |
+| 404 | `"Conversation not found"` | Character has no conversation (edge case) |
+| 422 | Standard FastAPI validation error | Invalid limit range, invalid UUID |
+
+---
+
+## Pydantic Schemas
+
+All schemas are defined in `backend/app/schemas/chat.py`.
+
+**Request schemas**:
+
+- `SendMessageRequest` -- validates `content` (1-4000 chars, whitespace-trimmed), `media_url` (optional, must be HTTP/HTTPS URL)
+
+**Response schemas**:
+
+- `MessageItem` -- a single message with `id` (UUID coerced to string), `role`, `content`, `media_url`, `metadata` (handles ORM `metadata_` mapping), `created_at`
+- `MessageListResponse` -- wrapper containing `items`, `next_cursor`, `has_more`
+
+**SSE event models** (used for serialization via `model_dump_json()`, not as FastAPI response models):
+
+- `ChunkEvent` -- `{"type": "chunk", "content": "..."}`
+- `ActionEvent` -- `{"type": "action", "action": "...", "payload": {...}}`
+- `DoneEvent` -- `{"type": "done", "message_id": "..."}`
+- `ErrorEvent` -- `{"type": "error", "message": "..."}`
+
+---
+
+## Configuration
+
+One new configuration field was added to `backend/app/config.py`:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `max_context_messages` | int | 50 | Number of recent messages to include as context for the Claude API call |
+
+Existing settings used by this feature:
+
+| Variable | Purpose |
+|----------|---------|
+| `anthropic_api_key` | API key for both Claude Sonnet (streaming) and Claude Haiku (intent extraction) |
+| `claude_model` | Model identifier for the main conversation (Claude Sonnet) |
+| `claude_haiku_model` | Model identifier for intent extraction (Claude Haiku) |
+| `mem0_api_key` | API key for Mem0 memory search and add operations |
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `backend/app/routes/chat.py` | Route handlers: `send_message` (POST, returns `StreamingResponse`) and `get_messages` (GET, returns `MessageListResponse`). Delegates all logic to `ChatService`. |
+| `backend/app/services/chat_service.py` | `ChatService` class with 2 public methods (`validate_send_message`, `stream_response`, `get_messages`) and 6 private helpers. Module-level `_persist_exchange` background task and `_deduplicate_memories` utility. |
+| `backend/app/schemas/chat.py` | 7 Pydantic schemas: `SendMessageRequest`, `MessageItem`, `MessageListResponse`, `ChunkEvent`, `ActionEvent`, `DoneEvent`, `ErrorEvent`. |
+| `backend/app/config.py` | Modified: added `max_context_messages: int = 50`. |
+| `backend/app/main.py` | Modified: registered chat router at `/api/v1/characters` with `tags=["chat"]`. |
+
+### Service Layer
+
+`ChatService` is instantiated per-request with the database session: `ChatService(db)`. Route handlers create the service and delegate entirely -- they contain no business logic.
+
+The streaming flow is split into two methods for a deliberate reason:
+
+- `validate_send_message()` runs before the `StreamingResponse` is created, allowing `HTTPException` to propagate as proper JSON error responses.
+- `stream_response()` is the async generator that runs inside the `StreamingResponse`. At this point, the HTTP status is already 200 and errors can only be communicated via SSE `error` events.
+
+Key private helpers:
+
+- `_get_active_character(character_id)` -- queries for an active character, raises 404 if not found
+- `_get_or_create_conversation(character_id, user_id)` -- finds the conversation, auto-creates if missing
+- `_search_memories(query, mem0_user_id, agent_id, limit)` -- searches Mem0 via `asyncio.to_thread()`, returns empty list on failure
+- `_get_recent_messages(conversation_id)` -- fetches the last N messages in DESC order, reverses to chronological
+- `_build_system_prompt(...)` -- constructs the 3-block system prompt
+- `_format_messages(recent_messages, new_content)` -- formats message history for the Claude API
+- `_extract_intent(assistant_response, user_timezone)` -- calls Claude Haiku for intent extraction
+
+---
+
+## Testing
+
+### Coverage Summary
+
+| File | Tests | Line Coverage | Branch Coverage |
+|------|-------|---------------|-----------------|
+| `test_chat_routes.py` | 34 | 100% | 100% |
+| `test_chat_service.py` | 65 | 100% | 100% |
+| `test_chat_schemas.py` | 31 | 100% | 100% |
+| **Total** | **130** | **100%** (274/274 lines) | **100%** (50/50 branches) |
+
+Target was >= 80% line coverage. Both line and branch coverage are at 100%.
+
+### Running Tests
+
+Chat tests only:
+
+```bash
+cd backend && python -m pytest tests/test_chat_routes.py tests/test_chat_service.py tests/test_chat_schemas.py -v
+```
+
+Full backend suite:
+
+```bash
+cd backend && python -m pytest tests/ -v --ignore=tests/test_migration.py
+```
+
+### Test Approach
+
+- **Route tests**: Use `httpx.AsyncClient`. The `get_current_user` dependency is overridden. SSE response body is consumed as text and parsed line-by-line.
+- **Service tests**: Unit-test `ChatService` directly with mock database session, mock Anthropic client, and mock Mem0 client.
+- **Schema tests**: Validate Pydantic schemas directly -- content trimming, length boundaries, URL validation, UUID-to-string coercion, SSE event serialization.
+- **Mocking**: All external services (Claude Sonnet streaming, Claude Haiku non-streaming, Mem0 search/add) are mocked. No real API calls are made.
+
+---
+
+## Known Limitations
+
+- **No offline support**: Messages require network connectivity. There is no local queue or retry mechanism for failed sends.
+- **Maximum 4000 characters per message**: Longer messages are rejected with a 422 validation error.
+- **No media processing**: The `media_url` field is accepted and stored but not processed. Photo analysis is a separate future feature.
+- **No TTS integration**: The `tts_url` field exists in the database but is not populated. Voice features are Phase 3+.
+- **No subscription-tier enforcement**: Any authenticated user can send unlimited messages. Free-tier message limits are a Phase 2 feature.
+- **Background task failure risk**: If the background persistence task fails, messages are lost (the user saw the streamed response but it is not saved to the database). This is an accepted trade-off for Phase 1 to keep time-to-first-token low. A retry mechanism can be added later.
+- **No streaming retry**: If the Claude API fails mid-stream, an error event is emitted and the conversation stops. The client must retry the message manually.
+- **Mem0 SDK is synchronous**: All Mem0 calls are wrapped in `asyncio.to_thread()`. This uses a thread from the default executor pool, which could become a bottleneck under high concurrency.
+
+---
+
+## Design Decisions
+
+### Why SSE instead of WebSocket
+
+SSE is a simpler protocol for server-to-client streaming. Ember's chat is request-response (user sends, server streams a reply) -- not bidirectional. SSE works over standard HTTP, is easier to test, and is well-supported by FastAPI's `StreamingResponse`. WebSocket is reserved for real-time voice calls (Phase 5+ via LiveKit).
+
+### Why background tasks for persistence instead of inline writes
+
+Writing messages to the database before or during the stream would add latency to the first-token time. The performance target from `docs/08-guvenlik-performans.md` is TTFT under 1 second. By deferring persistence to background tasks, the stream starts as soon as Claude begins generating tokens.
+
+### Why 50 messages of context
+
+`docs/05-ai-bellek.md` mentions 20 messages for cost optimization, but `CLAUDE.md` specifies "last 30-50 messages." The implementation uses 50 as a configurable upper bound via `settings.max_context_messages`. More context produces better conversation quality, and the cost difference is manageable for Phase 1.
+
+### Why a separate Haiku call for intent extraction
+
+Separating intent extraction from conversation keeps the main response natural. Sonnet writes human-friendly text, not structured JSON. Haiku is cheaper and faster for structured extraction. The latency (~200-400ms) is acceptable because it runs after the full response is streamed -- the user is already reading the response.
+
+### Why the user message ID is not in the SSE stream
+
+The mobile client generates a local UUID for the user message bubble immediately on send. Only the assistant message ID is returned (for correlating the streamed response with the persisted message). This keeps the SSE protocol simpler.
+
+### Why background tasks use a separate DB session
+
+The request-scoped database session is closed when the `StreamingResponse` finishes. Background tasks create their own session via `AsyncSessionLocal()` to avoid using a closed session.
+
+### Why validation runs before StreamingResponse
+
+The route handler calls `validate_send_message()` before creating the `StreamingResponse`. This ensures that `HTTPException` (403, 404) produces proper JSON error responses with correct HTTP status codes. Once inside the streaming generator, the HTTP status is already 200 and errors can only be communicated via SSE events.
+
+---
+
+## Extending This Feature
+
+**Adding a new device action type** (e.g., `SEND_REMINDER`): Add the action name to the `_SUPPORTED_ACTIONS` frozenset in `backend/app/services/chat_service.py`. Update the `_INTENT_EXTRACTION_PROMPT` template to describe the new action and its expected payload fields. No schema changes are needed because `ActionEvent.payload` is a generic `dict`. Update mobile clients to handle the new action type.
+
+**Changing the context window size**: Modify `max_context_messages` in `backend/app/config.py` or set the `MAX_CONTEXT_MESSAGES` environment variable. No code changes required.
+
+**Adding subscription-tier message limits**: Add a count check at the beginning of `ChatService.validate_send_message()` that queries the number of messages sent by the user today and compares it against the tier limit. Return 429 if the limit is exceeded.
+
+**Adding prompt caching**: Pass the system prompt as a list of content blocks with `cache_control: {"type": "ephemeral"}` on the first block (character definition). This leverages Anthropic's prompt caching to reduce cost and latency for repeated conversations with the same character.
+
+**Adding media/image analysis**: Process the `media_url` field in `validate_send_message()` by downloading the image and including it as a vision content block in the Claude API call.
+
+---
+
+## Related Documentation
+
+- [Character CRUD](./character-crud.md) -- character creation and the `system_prompt` / `mem0_agent_id` that this feature uses
+- [Database Schema](./database-schema.md) -- the `messages`, `conversations`, `characters`, `profiles`, and `user_activity` tables
+- [Cognito Auth Middleware](./cognito-auth-middleware.md) -- JWT verification used by both endpoints
+- [Database Schema and API Endpoints](../04-veri-api.md) -- authoritative source for table definitions and API contracts
+- [AI Memory System](../05-ai-bellek.md) -- Mem0 integration patterns, prompt architecture, and memory isolation
+- [Security and Performance](../08-guvenlik-performans.md) -- TTFT performance target and rate limiting
+- [Multi-Character System](../16-karakterler.md) -- character templates and memory isolation design

--- a/docs/pipeline/chat-streaming-architect.handoff.md
+++ b/docs/pipeline/chat-streaming-architect.handoff.md
@@ -1,0 +1,70 @@
+# Architect Handoff: Chat Streaming
+
+**Date**: 2026-02-23
+**Agent**: architect
+**Status**: COMPLETE
+
+## What Was Designed
+
+Two backend API endpoints for the core chat functionality: `POST /api/v1/characters/:id/messages` (SSE streaming endpoint that receives a user message, gathers Mem0 memories + recent conversation history in parallel, streams Claude Sonnet's response as SSE chunk events, extracts device action intents via Claude Haiku, and persists everything as background tasks) and `GET /api/v1/characters/:id/messages` (cursor-based paginated message history retrieval).
+
+## Key Decisions
+
+- **SSE over WebSocket**: Chat is request-response, not bidirectional. SSE is simpler, works over standard HTTP, and is well-supported by FastAPI's `StreamingResponse`. WebSocket is reserved for real-time voice (Phase 5+).
+- **Background task persistence**: User and assistant messages are persisted AFTER the stream completes, not inline. This minimizes time-to-first-token (target: <1s per `docs/08-guvenlik-performans.md`). Trade-off: messages could be lost if the background task fails. Acceptable for Phase 1.
+- **Separate Haiku intent extraction**: Device action intents (SET_ALARM, ADD_CALENDAR_EVENT) are detected by a post-stream Haiku call, not by instructing Sonnet to embed structured JSON in the response. Keeps conversation natural, cheaper, and independently evolvable.
+- **50 messages of context**: Configurable via `settings.max_context_messages`. CLAUDE.md says 30-50; `docs/05-ai-bellek.md` mentions 20. Using 50 for better quality in Phase 1, tunable later.
+- **3 parallel fetches**: Global Mem0 search + character Mem0 search + DB last 50 messages all run via `asyncio.gather()`, following the architecture in `docs/05-ai-bellek.md`.
+- **Background tasks use separate DB session**: The request-scoped session closes when the StreamingResponse finishes. Background tasks create their own session via `AsyncSessionLocal()`.
+- **Mem0 SDK wrapped in asyncio.to_thread()**: The `mem0ai` package is synchronous. All calls are wrapped to avoid blocking the event loop.
+- **New config field**: `max_context_messages: int = 50` added to Settings.
+- **Auto-create conversation if missing**: Defensive handling for edge case where conversation row is absent despite P01-05 creating it.
+
+## Spec Location
+
+`shared/feature-specs/chat-streaming.md`
+
+## Assumptions Made
+
+- The `anthropic` package supports `client.messages.stream()` as an async context manager with `.text_stream` and `.get_final_message()`.
+- The `mem0ai` package provides `MemoryClient` with synchronous `.search()` and `.add()` methods. The `.search()` accepts `user_id`, `agent_id`, and `limit` parameters.
+- The existing `idx_messages_conv_time` index on `(conversation_id, created_at DESC)` from P01-02 is sufficient for the message history query and cursor pagination.
+- The `user_activity` table has a row for every registered user (created during registration in P01-04). If not, the UPDATE query will silently affect 0 rows.
+- Subscription tier enforcement (message limits per day) is deferred to Phase 2.
+
+## Dependencies
+
+- Requires: P01-01 (project-setup), P01-02 (database-schema), P01-03 (cognito-auth-middleware), P01-04 (auth-endpoints), P01-05 (character-crud)
+- Blocks: backend-dev (implements the endpoints), backend-tester (writes tests)
+
+## File Manifest
+
+```
+Backend:
+  CREATE  backend/app/routes/chat.py
+  CREATE  backend/app/services/chat_service.py
+  CREATE  backend/app/schemas/chat.py
+  MODIFY  backend/app/main.py
+  MODIFY  backend/app/config.py
+  CREATE  backend/tests/test_chat_routes.py
+  CREATE  backend/tests/test_chat_service.py
+  CREATE  backend/tests/test_chat_schemas.py
+
+Shared:
+  CREATE  shared/feature-specs/chat-streaming.md
+  CREATE  docs/pipeline/chat-streaming-architect.handoff.md
+```
+
+## Notes for Developers
+
+- **Router prefix**: Register the chat router with `prefix="/api/v1/characters"` and route decorators use `"/{character_id}/messages"`. This does NOT conflict with the existing characters router.
+- **SSE format**: `data: {json}\n\n` (two newlines, no `event:` header). Use the `type` field in JSON instead.
+- **Claude streaming**: Use `client.messages.stream()`, not `client.messages.create(stream=True)`.
+- **Mem0 is synchronous**: Wrap all `MemoryClient` calls in `asyncio.to_thread()`.
+- **Background task session**: Create new `AsyncSessionLocal()` inside background tasks, do NOT reuse the request session.
+- **Reverse message order**: DB query returns DESC; reverse to chronological before passing to Claude.
+- **Error mid-stream**: Emit `{"type":"error"}` SSE event; HTTP status stays 200 (SSE protocol constraint).
+
+## Next Steps
+
+backend-dev should read the spec at `shared/feature-specs/chat-streaming.md` and implement the endpoints. backend-tester follows with test coverage.

--- a/docs/pipeline/chat-streaming-backend-dev.handoff.md
+++ b/docs/pipeline/chat-streaming-backend-dev.handoff.md
@@ -1,0 +1,79 @@
+# Backend Dev Handoff: Chat Streaming (P01-06)
+
+**Date**: 2026-02-23
+**Agent**: backend-dev
+**Status**: COMPLETE
+
+## Implemented Files
+
+- `backend/app/routes/chat.py` -- 2 endpoints (POST streaming, GET paginated)
+- `backend/app/services/chat_service.py` -- ChatService class (9 methods) + 2 module-level functions
+- `backend/app/schemas/chat.py` -- 8 schemas (1 request, 3 response, 4 SSE events)
+- `backend/app/main.py` -- Modified: added chat router registration
+- `backend/app/config.py` -- Modified: added `max_context_messages: int = 50`
+
+## Endpoints Implemented
+
+- `POST /api/v1/characters/{character_id}/messages` -- Send message, returns SSE stream
+- `GET /api/v1/characters/{character_id}/messages` -- Cursor-based paginated message history
+
+## SSE Event Format
+
+All SSE events follow the spec format:
+
+```
+data: {"type": "chunk", "content": "partial text here"}
+data: {"type": "action", "action": "SET_ALARM", "payload": {"time": "07:00"}}
+data: {"type": "done", "message_id": "uuid-here"}
+data: {"type": "error", "message": "AI service temporarily unavailable"}
+```
+
+## Architecture Decisions
+
+1. **Validation-before-streaming pattern**: `validate_send_message()` runs BEFORE the
+   `StreamingResponse` is created, so HTTPExceptions (403, 404) produce proper JSON
+   error responses. The `stream_response()` async generator only runs inside the
+   StreamingResponse after validation succeeds.
+
+2. **Background persistence**: Messages are persisted via `asyncio.create_task()` calling
+   the module-level `_persist_exchange()` function. This function creates its own DB
+   session via `AsyncSessionLocal()` because the request-scoped session closes when the
+   StreamingResponse finishes.
+
+3. **Mem0 resilience**: `asyncio.gather(..., return_exceptions=True)` is used for parallel
+   Mem0 + DB operations. Mem0 failures are caught and logged; the chat continues with
+   empty memories rather than failing.
+
+4. **Intent extraction**: Claude Haiku extracts device action intents (SET_ALARM,
+   ADD_CALENDAR_EVENT) from the assistant response. Failures are silently handled.
+
+## Test Results
+
+- pytest: 64 passed (19 schema, 20 route, 25 service), 0 failed
+- ruff: clean (all new/modified files)
+- Full suite: 824 passed, 13 skipped, 0 failed
+
+## Test Files
+
+- `backend/tests/test_chat_schemas.py` -- 19 tests: request validation, response serialization, SSE events
+- `backend/tests/test_chat_routes.py` -- 20 tests: 11 POST streaming, 9 GET pagination
+- `backend/tests/test_chat_service.py` -- 25 tests: validation, streaming, system prompt, pagination, intent, persist, dedup
+
+## Known Issues / Deviations from Spec
+
+- None. Implementation follows the architect spec exactly.
+
+## Notes for Backend Tester
+
+- Mock `app.services.chat_service.MemoryClient` for all Mem0 tests
+- Mock `app.services.chat_service.AsyncAnthropic` for Claude API tests
+- SSE streaming tests: mock `validate_send_message` (returns context dict) and
+  `stream_response` (returns async generator) separately
+- Route tests use `httpx.AsyncClient` -- SSE response body is consumed as text
+- The `_persist_exchange` function uses `AsyncSessionLocal` directly (not the
+  request-scoped `db` session) -- mock `app.services.chat_service.AsyncSessionLocal`
+- `_extract_intent` has multiple code paths (valid JSON, "none", invalid JSON,
+  exception) -- ensure coverage of all branches
+- `_build_system_prompt` conditionally includes memory block -- test with and without
+  memories
+- `_deduplicate_memories` prioritizes character memories over global -- verify order

--- a/docs/pipeline/chat-streaming-backend-test.handoff.md
+++ b/docs/pipeline/chat-streaming-backend-test.handoff.md
@@ -1,0 +1,174 @@
+# Backend Test Handoff: Chat Streaming (P01-06)
+
+**Date**: 2026-02-24
+**Agent**: backend-tester
+**Status**: COMPLETE
+
+## Test Files Written
+- `backend/tests/test_chat_routes.py` -- 34 tests (20 existing + 14 new)
+- `backend/tests/test_chat_service.py` -- 65 tests (25 existing + 40 new)
+- `backend/tests/test_chat_schemas.py` -- 31 tests (19 existing + 12 new)
+
+## Coverage Results
+
+| File | Lines | Lines Covered | Branch | Branch Covered | Coverage |
+|------|-------|--------------|--------|---------------|----------|
+| `app/routes/chat.py` | 23 | 23 | 2 | 2 | **100%** |
+| `app/schemas/chat.py` | 62 | 62 | 10 | 10 | **100%** |
+| `app/services/chat_service.py` | 189 | 189 | 38 | 38 | **100%** |
+| **TOTAL** | **274** | **274** | **50** | **50** | **100%** |
+
+- Lines: 100% (target: >= 80%) -- EXCEEDS
+- Branches: 100% (target: >= 70%) -- EXCEEDS
+
+## Test Run Results
+- Passed: 130 (chat tests only)
+- Failed: 0
+- Skipped: 0
+- Full suite: 890 passed, 0 failed, 4 warnings (none related to chat tests)
+
+## What Was Tested (by category)
+
+### Route Tests (test_chat_routes.py)
+**POST /api/v1/characters/:id/messages (SSE streaming):**
+- Valid message returns 200 with SSE stream (chunk + done events)
+- Character belonging to another user returns 403
+- Non-existent / inactive character returns 404
+- Empty content (whitespace only) returns 422
+- Content exceeding 4000 chars returns 422
+- Missing auth returns 401/403
+- SSE event order: chunks first, done last
+- Claude failure emits error event
+- Intent detected emits action event before done
+- No intent means no action event in stream
+- SSE response headers (Cache-Control, X-Accel-Buffering)
+- Invalid UUID path parameter returns 422
+- Missing content field returns 422
+- Valid media_url accepted
+- ADD_CALENDAR_EVENT action payload structure
+- Accumulated chunk content forms full response
+- Error event contains user-friendly message
+- Error event has no done event following it
+
+**GET /api/v1/characters/:id/messages (paginated):**
+- First page returns 200 with items/next_cursor/has_more
+- Cursor parameter filters older messages
+- Custom limit respected
+- Empty conversation returns empty items
+- Other user's character returns 403
+- Non-existent character returns 404
+- Missing auth returns 401/403
+- has_more=true when more messages exist
+- has_more=false on last page
+- limit=0 returns 422 (minimum is 1)
+- limit=101 returns 422 (maximum is 100)
+- Invalid UUID path parameter returns 422
+- Response items have all required fields
+- next_cursor is valid ISO 8601 string
+- Conversation not found returns 404
+
+### Service Tests (test_chat_service.py)
+**validate_send_message:**
+- Parallel fetch of Mem0 + DB via asyncio.gather
+- Mem0 search failure continues gracefully
+- Character not found raises 404
+- Ownership check raises 403
+- Recent messages fetch failure continues
+- Context includes correct character and conversation
+
+**stream_response:**
+- Yields chunk events from Claude stream
+- Yields action event when intent detected
+- Skips action when Haiku returns "none"
+- Yields done event with valid UUID
+- Fires background task for persistence
+- Claude error emits error event
+- Action event always before done event
+- Persist exchange called with correct args
+- Multiple chunks streamed correctly
+
+**_build_system_prompt:**
+- Builds prompt with 3 blocks (character, memories, date/time)
+- Omits memory block when no memories
+- Includes timezone and language
+- Invalid timezone falls back to UTC
+- None timezone falls back to UTC
+- Memory deduplication in prompt
+- Up to 10 memories in prompt
+
+**_format_messages:**
+- Formats with message history
+- Formats with empty history (only new message)
+- New message appended last
+
+**get_messages:**
+- Returns messages in DESC order
+- has_more and next_cursor set correctly
+- Missing conversation raises 404
+- Ownership check raises 403
+- Cursor filter applied
+- Empty conversation returns empty list
+- next_cursor matches last item's created_at
+
+**_extract_intent:**
+- Returns SET_ALARM action when detected
+- Returns ADD_CALENDAR_EVENT action when detected
+- Returns None when Haiku says "none" (case insensitive)
+- Returns None when Haiku fails
+- Returns None for invalid JSON from Haiku
+- Returns None for unsupported action type
+- Returns None for JSON without "action" key
+- Returns default empty payload when payload missing
+
+**_persist_exchange (background task):**
+- Persists user and assistant messages
+- Handles DB error gracefully
+- Handles Mem0 error gracefully
+- Calls Mem0 add with correct agent_id
+- Stores action metadata on assistant message
+- Stores media_url on user message
+- Passes correct user/assistant message pair to Mem0
+
+**_get_active_character:**
+- Returns character when found and active
+- Raises 404 when not found
+
+**_get_or_create_conversation:**
+- Returns existing conversation
+- Auto-creates conversation when missing
+
+**_search_memories:**
+- Search with agent_id passes it to Mem0
+- Search without agent_id omits it (global)
+- Handles Mem0 exception gracefully
+
+**_get_recent_messages:**
+- Returns messages in chronological order (reversed from DB DESC)
+- Returns empty list for new conversation
+
+**_deduplicate_memories:**
+- Deduplicates by exact string match
+- Preserves order (character first)
+- Empty lists return empty output
+- All-duplicate input returns unique items only
+- Only global memories
+- Only character memories
+
+### Schema Tests (test_chat_schemas.py)
+- SendMessageRequest: valid content, whitespace trimming, empty after strip, max length
+- SendMessageRequest: null/valid/invalid media_url, whitespace trimming
+- SendMessageRequest edge cases: boundary lengths, newlines, unicode, missing field
+- MessageItem: UUID/string/integer id coercion, metadata dict/None/non-dict coercion
+- MessageListResponse: pagination fields
+- SSE events: ChunkEvent, ActionEvent, DoneEvent, ErrorEvent serialization
+- SSE events: JSON serialization, calendar action variant
+
+## Issues Found During Testing
+- None. Implementation follows the architect spec exactly.
+
+## Notes for Reviewer
+- All 130 chat tests achieve 100% line and branch coverage on routes, schemas, and service.
+- The full backend suite (890 tests) passes with zero failures.
+- Runtime warnings about unawaited coroutines are from `unittest.mock.AsyncMock` internals and are not test failures.
+- Tests mock all external services (Claude, Mem0) and never make real API calls.
+- Background task (`_persist_exchange`) is tested both via `asyncio.create_task` mocking and by direct invocation of the function.

--- a/docs/pipeline/chat-streaming-doc.handoff.md
+++ b/docs/pipeline/chat-streaming-doc.handoff.md
@@ -1,0 +1,15 @@
+# Doc Writer Handoff: Chat Streaming
+
+**Date**: 2026-02-24
+**Agent**: doc-writer
+**Status**: COMPLETE
+
+## Documents Written
+- `docs/features/chat-streaming.md` -- main feature documentation
+- `CHANGELOG.md` -- added entry under [Unreleased]
+
+## Summary
+Documented the chat streaming feature (P01-06), covering the SSE streaming endpoint (POST), cursor-based message history endpoint (GET), Mem0 memory integration, Claude Haiku intent extraction for device actions, background task persistence, system prompt construction, and all Pydantic schemas. Documentation was written from the architect spec, backend-dev handoff, backend-tester handoff, and verified against the actual implementation files.
+
+## Notes
+- None. The implementation matches the architect spec exactly, as confirmed by both the backend-dev and backend-tester handoff files.

--- a/docs/pipeline/chat-streaming-review.handoff.md
+++ b/docs/pipeline/chat-streaming-review.handoff.md
@@ -1,0 +1,121 @@
+# Reviewer Handoff: Chat Streaming (P01-06)
+
+**Date**: 2026-02-24
+**Agent**: reviewer
+**Status**: APPROVED
+
+## Review Summary
+
+| Category | Passed | Warnings | Issues |
+|----------|--------|----------|--------|
+| Architecture | 9 | 0 | 0 |
+| Backend Code Quality | 8 | 0 | 0 |
+| Testing | 7 | 0 | 0 |
+| Security | 4 | 0 | 0 |
+| **Total** | **28** | **0** | **0** |
+
+## Architecture Compliance
+
+- [x] **Single conversation per character** -- PASS. No `/conversations` path segment in any mobile-facing endpoint. `POST /api/v1/characters/{character_id}/messages` and `GET /api/v1/characters/{character_id}/messages` are the only endpoints. Conversation is looked up internally via `character_id`.
+- [x] **Correct endpoint path** -- PASS. `POST /{character_id}/messages` and `GET /{character_id}/messages` on `chat.router`, registered at prefix `/api/v1/characters` in `main.py` (line 57).
+- [x] **agent_id format: "{template}_{user_id}"** -- PASS. The `character.mem0_agent_id` field is passed to all Mem0 calls (`_search_memories` at line 347, `_persist_exchange` at line 548). The model field `mem0_agent_id` is set during character creation (P01-05) using the `f"{template}_{user_id}"` format. Tests verify this with `f"english_teacher_{FAKE_USER_ID}"`.
+- [x] **user_id from JWT only** -- PASS. Route handlers extract user identity via `current_user: Profile = Depends(get_current_user)`. `current_user.id` is passed to the service layer. No `user_id` in request body or query params.
+- [x] **asyncio.gather for parallel Mem0+DB calls** -- PASS. `validate_send_message()` at line 107 uses `asyncio.gather()` with `return_exceptions=True` for global Mem0 search, character Mem0 search, and recent DB messages -- all three run in parallel.
+- [x] **Cursor pagination -- no OFFSET** -- PASS. `get_messages()` at line 252 uses `WHERE Message.created_at < cursor ORDER BY created_at DESC LIMIT limit+1`. No `OFFSET` keyword found anywhere in `backend/app/`.
+- [x] **SSE format matches spec** -- PASS. Events follow the spec: `data: {"type":"chunk","content":"..."}\n\n`, then optionally `data: {"type":"action",...}\n\n`, then `data: {"type":"done","message_id":"..."}\n\n`. On error: `data: {"type":"error","message":"..."}\n\n` with no `done` event following.
+- [x] **Background task persistence** -- PASS. `_persist_exchange()` is called via `asyncio.create_task()` at line 206. It creates its own DB session via `AsyncSessionLocal()` (line 493), not the request-scoped session. Persists user message, assistant message, updates `conversations.last_message_at`, updates `user_activity.last_chat_at`, and adds exchange to Mem0.
+- [x] **Intent extraction via Claude Haiku** -- PASS. `_extract_intent()` at line 428 calls Claude Haiku (`settings.claude_haiku_model`) with the structured extraction prompt. Supported actions: `SET_ALARM`, `ADD_CALENDAR_EVENT`. Failure is gracefully handled (returns `None`, error logged).
+
+## Backend Code Quality
+
+- [x] **All route handlers are async** -- PASS. Both `send_message` (line 26) and `get_messages` (line 69) use `async def`. Grep for `^def ` in routes returned zero matches.
+- [x] **Validation-before-streaming pattern** -- PASS. `validate_send_message()` runs BEFORE `StreamingResponse` is created (line 42), so HTTPExceptions (403, 404) return proper JSON error responses. The generator only starts after validation succeeds.
+- [x] **Proper error responses** -- PASS. 403 returns `"Character does not belong to user"` (line 97), 404 returns `"Character not found"` (line 303) and `"Conversation not found"` (line 248). Error events use user-friendly message `"AI service temporarily unavailable"` (line 185).
+- [x] **SSE headers** -- PASS. `StreamingResponse` sets `Cache-Control: no-cache` and `X-Accel-Buffering: no` (lines 59-60). Media type is `text/event-stream`.
+- [x] **Input validation** -- PASS. `SendMessageRequest` uses `Field(..., min_length=1, max_length=4000)` for content, `Field(default=None, max_length=2048)` for `media_url`, with whitespace stripping and URL scheme validation. Route `limit` parameter uses `Query(default=20, ge=1, le=100)`.
+- [x] **Ownership checks** -- PASS. Both `validate_send_message()` (line 94) and `get_messages()` (line 234) check `character.user_id != user_id` and raise 403.
+- [x] **No print() in production code** -- PASS. Grep for `print(` in `backend/app/` returned zero matches. All logging uses `logger.error`, `logger.exception`, `logger.debug`.
+- [x] **No TODO/FIXME** -- PASS. Grep for `TODO|FIXME` in all three implementation files returned zero matches.
+
+## Test Quality
+
+- [x] **Coverage >= 80%** -- PASS. Backend-tester handoff reports 100% line coverage and 100% branch coverage across all three files (`routes/chat.py`, `schemas/chat.py`, `services/chat_service.py`). Exceeds the 80% threshold.
+- [x] **Edge cases covered** -- PASS. Tests cover: auth failure (401/403), not found (404), validation errors (422 for empty content, content >4000 chars, limit out of bounds, invalid UUID), empty conversation, conversation not found, inactive character.
+- [x] **External services mocked** -- PASS. All tests mock `AsyncAnthropic` (Claude Sonnet + Haiku), `MemoryClient` (Mem0), and `AsyncSessionLocal` (background task DB). No real API calls in tests.
+- [x] **Cursor pagination tested** -- PASS. Service test `test_has_more_and_next_cursor` verifies pagination logic. Route tests verify `has_more`, `next_cursor`, limit bounds. `test_next_cursor_matches_last_item` verifies cursor value matches the last item's `created_at`.
+- [x] **SSE sequence verified** -- PASS. Route test `test_sse_event_order_chunk_then_done` verifies chunks come before done. `test_error_event_no_done_event` verifies no done event after error. `test_intent_detected_emits_action_event` verifies action comes before done. Service test `test_action_event_before_done_event` verifies ordering.
+- [x] **Ownership tested** -- PASS. Route tests `test_message_to_other_users_character_returns_403` and `test_get_messages_other_users_character_returns_403`. Service tests `TestValidateSendMessageAdditional.test_ownership_check_raises_403` and `TestGetMessagesAdditional.test_ownership_check_raises_403`.
+- [x] **130 tests total, 0 failures** -- PASS. Backend-tester handoff reports 130 chat-specific tests passing, full suite 890 passed with 0 failures.
+
+## Security
+
+- [x] **No credentials in code** -- PASS. Grep for `api_key\s*=\s*['\"]` and `secret\s*=\s*['\"]` returned zero matches. API keys are loaded from `settings` (env/Secrets Manager).
+- [x] **No user_id in request body** -- PASS. Grep for `user_id.*body|body.*user_id` in routes returned zero matches. `user_id` is always derived from JWT via `get_current_user` dependency.
+- [x] **SQL injection prevention** -- PASS. All DB queries use SQLAlchemy parameterized statements (`select(Character).where(...)`, `update(Conversation).where(...).values(...)`). No raw string concatenation in SQL.
+- [x] **No internal IDs exposed** -- PASS. Error messages are user-friendly strings. No stack traces, internal DB IDs, or system paths in error responses.
+
+## Files Reviewed
+
+**Implementation:**
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/routes/chat.py` -- PASS (94 lines, 2 endpoints)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/services/chat_service.py` -- PASS (571 lines, 9 methods + 2 module-level functions)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/schemas/chat.py` -- PASS (122 lines, 7 schema classes)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/main.py` -- PASS (chat router registered at line 57)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/config.py` -- PASS (`max_context_messages: int = 50` at line 65)
+
+**Tests:**
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/tests/test_chat_routes.py` -- PASS (989 lines, 34 tests)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/tests/test_chat_service.py` -- PASS (1947 lines, 65 tests)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/tests/test_chat_schemas.py` -- PASS (366 lines, 31 tests)
+
+**Supporting files verified:**
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/models/character.py` -- Fields match service usage (`user_id`, `system_prompt`, `mem0_agent_id`, `template`, `is_active`)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/models/conversation.py` -- Fields match service usage (`character_id`, `last_message_at`)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/models/message.py` -- Fields match service usage (`conversation_id`, `user_id`, `role`, `content`, `media_url`, `metadata_`, `created_at`)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/models/profile.py` -- Fields match service usage (`mem0_user_id`, `timezone`, `preferred_language`)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/models/user_activity.py` -- Fields match service usage (`user_id`, `last_chat_at`)
+- `/Users/atakan/Documents/GitHub/atknatk/ember/backend/app/dependencies.py` -- `get_current_user` returns `Profile`, `get_db` yields `AsyncSession`
+
+**Pipeline handoffs verified:**
+- `/Users/atakan/Documents/GitHub/atknatk/ember/docs/pipeline/chat-streaming-architect.handoff.md` -- COMPLETE
+- `/Users/atakan/Documents/GitHub/atknatk/ember/docs/pipeline/chat-streaming-backend-dev.handoff.md` -- COMPLETE
+- `/Users/atakan/Documents/GitHub/atknatk/ember/docs/pipeline/chat-streaming-backend-test.handoff.md` -- COMPLETE
+
+**Feature spec verified:**
+- `/Users/atakan/Documents/GitHub/atknatk/ember/shared/feature-specs/chat-streaming.md` -- All endpoints implemented, all file manifest items present
+
+## Grep Check Results
+
+| Pattern | Target | Result |
+|---------|--------|--------|
+| `OFFSET` | `backend/app/` (*.py) | 0 matches |
+| `user_id.*body\|body.*user_id` | `backend/app/routes/` (*.py) | 0 matches |
+| `api_key\s*=\s*['"]` | `backend/app/` (*.py) | 0 matches |
+| `secret\s*=\s*['"]` | `backend/app/` (*.py) | 0 matches |
+| `^def ` (sync handlers) | `backend/app/routes/` (*.py) | 0 matches |
+| `/conversations` | `backend/app/routes/` (*.py) | 0 matches |
+| `print(` | `backend/app/` (*.py) | 0 matches |
+| `TODO\|FIXME` | Implementation files | 0 matches |
+
+## Issues Resolved During Review
+- None (first-pass clean)
+
+## Warnings (Not Blocking)
+- None
+
+## Spec Compliance Verification
+
+All items from the feature spec file manifest are accounted for:
+
+| Spec Item | Status |
+|-----------|--------|
+| `CREATE backend/app/routes/chat.py` | Present |
+| `CREATE backend/app/services/chat_service.py` | Present |
+| `CREATE backend/app/schemas/chat.py` | Present |
+| `MODIFY backend/app/main.py` (chat router) | Verified (line 57) |
+| `MODIFY backend/app/config.py` (max_context_messages) | Verified (line 65) |
+| `CREATE backend/tests/test_chat_routes.py` | Present |
+| `CREATE backend/tests/test_chat_service.py` | Present |
+| `CREATE backend/tests/test_chat_schemas.py` | Present |
+
+All 23 acceptance criteria from the spec are addressed by the implementation and test suite.

--- a/shared/feature-specs/chat-streaming.md
+++ b/shared/feature-specs/chat-streaming.md
@@ -1,0 +1,1164 @@
+# Feature Spec: P01-06 -- Chat Streaming
+
+**Feature ID**: P01-06
+**Phase**: 1
+**Layer**: backend
+**GitHub Issue**: #8
+**Date**: 2026-02-23
+**Author**: architect
+
+---
+
+## 1. Overview
+
+### What This Feature Does
+
+This feature implements the core messaging endpoint for Ember: `POST /api/v1/characters/:id/messages`. It is the single most important endpoint in the application -- it receives a user's message, retrieves context (recent messages + Mem0 memories), streams the AI response via Server-Sent Events (SSE), and persists both messages as background tasks after the stream completes.
+
+Additionally, the feature implements `GET /api/v1/characters/:id/messages` for cursor-based retrieval of message history, enabling the mobile clients to load conversation history with infinite scroll.
+
+**The streaming endpoint performs these steps in order:**
+
+1. Validate the character belongs to the authenticated user and is active.
+2. Look up (or auto-create) the character's single conversation.
+3. Run `asyncio.gather()` to fetch Mem0 memories and recent DB messages in parallel.
+4. Build the full LLM prompt: system prompt (character template) + Mem0 memories + date/time context + last 50 messages + the new user message.
+5. Open an Anthropic Claude Sonnet streaming session and yield SSE `chunk` events as tokens arrive.
+6. After the full response is assembled, run Claude Haiku intent extraction on the complete assistant response to detect device action intents (SET_ALARM, ADD_CALENDAR_EVENT). If an intent is found, yield an SSE `action` event.
+7. Yield a final SSE `done` event with the assistant message's UUID.
+8. Fire-and-forget background tasks: save user message + assistant message to DB, update `conversations.last_message_at`, add the exchange to Mem0, update `user_activity.last_chat_at`.
+
+### Why It Exists
+
+Without this endpoint, users cannot converse with their AI characters. Chat is the primary interaction mode in Ember. Streaming provides a responsive UX (the user sees tokens appear in real-time rather than waiting for the full response). Mem0 integration makes the AI remember past conversations, which is Ember's core differentiator.
+
+### Dependencies
+
+- **Requires**: P01-01 (project-setup -- FastAPI scaffold, config, logging)
+- **Requires**: P01-02 (database-schema -- Message, Conversation, Character, Profile, UserActivity models)
+- **Requires**: P01-03 (cognito-auth-middleware -- `get_current_user` dependency)
+- **Requires**: P01-04 (auth-endpoints -- user can register and obtain a JWT)
+- **Requires**: P01-05 (character-crud -- user can create characters, conversation auto-created)
+- **Blocks**: All mobile chat UI features, voice features, notification features that depend on message data
+
+### What This Feature Does NOT Do
+
+- It does not implement media upload or image analysis. The `media_url` field is accepted in the request and stored, but no vision processing occurs in this feature.
+- It does not implement TTS (text-to-speech). The `tts_url` field on messages remains null.
+- It does not implement the memory display endpoints (`GET /characters/:id/memories`). That is a separate feature.
+- It does not implement proactive notifications. That is a Phase 3+ feature.
+- It does not enforce subscription-tier message limits. That is a Phase 2 feature.
+
+---
+
+## 2. Data Models
+
+### No New Tables
+
+This feature does not create any new database tables. It reads from and writes to existing tables defined in P01-02 (documented in `docs/04-veri-api.md`):
+
+- **messages** -- User and assistant messages are inserted here after stream completion.
+- **conversations** -- The `last_message_at` column is updated after each exchange. The conversation row is looked up by `character_id`.
+- **characters** -- Read to obtain `system_prompt`, `mem0_agent_id`, `template`, and `name` for prompt building.
+- **profiles** -- Read via `get_current_user` for `timezone`, `preferred_language`, `name`, and `mem0_user_id`.
+- **user_activity** -- `last_chat_at` is updated as a background task.
+
+### Key Column References
+
+| Table | Column | Usage in This Feature |
+|-------|--------|----------------------|
+| `messages.id` | UUID PK | Generated server-side for both user and assistant messages |
+| `messages.conversation_id` | UUID FK | Links message to the character's conversation |
+| `messages.user_id` | UUID FK | Set from JWT user_id |
+| `messages.role` | TEXT | `"user"` for the incoming message, `"assistant"` for the AI response |
+| `messages.content` | TEXT | User message text from request, or accumulated streamed AI text |
+| `messages.media_url` | TEXT / NULL | Passed through from request for user message, null for assistant |
+| `messages.metadata_` | JSONB / NULL | Stores intent action data on the assistant message if detected |
+| `messages.created_at` | TIMESTAMPTZ | Server-default `now()` |
+| `conversations.character_id` | UUID UNIQUE FK | Used to find the conversation for a given character |
+| `conversations.last_message_at` | TIMESTAMPTZ | Updated to `now()` after the exchange |
+| `characters.system_prompt` | TEXT | Included as Block 1 of the LLM prompt |
+| `characters.mem0_agent_id` | TEXT | Passed to Mem0 search and add calls |
+| `characters.template` | TEXT | Used for mem0_agent_id validation |
+| `profiles.timezone` | TEXT | Included in Block 3 (daily context) of the LLM prompt |
+| `profiles.preferred_language` | TEXT | Included in Block 3 for language context |
+| `profiles.name` | TEXT | Included in Block 3 for personalization |
+| `profiles.mem0_user_id` | TEXT | Passed to all Mem0 API calls as `user_id` |
+| `user_activity.last_chat_at` | TIMESTAMPTZ | Updated as background task |
+
+### Mem0 Operations
+
+This feature makes the following Mem0 API calls:
+
+**Search (before streaming, parallel with DB query):**
+
+Two searches run in parallel via `asyncio.gather()`:
+
+1. **Global memories** -- memories visible to all characters:
+   ```
+   mem0.search(query=user_message_content, user_id=profile.mem0_user_id)
+   ```
+   No `agent_id` filter. Returns up to 5 results.
+
+2. **Character-specific memories** -- memories isolated to this character:
+   ```
+   mem0.search(query=user_message_content, user_id=profile.mem0_user_id, agent_id=character.mem0_agent_id)
+   ```
+   Returns up to 5 results.
+
+Combined: up to 10 memories injected into Block 2 of the prompt.
+
+**Add (background task after stream completion):**
+
+```
+mem0.add(
+    messages=[user_message_content, assistant_response_content],
+    user_id=profile.mem0_user_id,
+    agent_id=character.mem0_agent_id
+)
+```
+
+This runs as a background task. Failure is logged but does not affect the user-facing response.
+
+---
+
+## 3. API Endpoints
+
+All endpoints are under the `/api/v1` prefix. Both require `Authorization: Bearer <jwt>`.
+
+---
+
+### POST /api/v1/characters/:id/messages
+
+Sends a message to a character and streams the AI response via Server-Sent Events.
+
+```
+Auth: Bearer JWT required
+Content-Type: application/json
+Accept: text/event-stream
+```
+
+**Path Parameters:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `id` | UUID string | Character ID |
+
+**Request Body:**
+
+```json
+{
+  "content": "I want to practice English today!",
+  "media_url": null
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `content` | string | yes | Min 1 char, max 4000 chars, whitespace-trimmed |
+| `media_url` | string or null | no | Valid URL format if provided, max 2048 chars |
+
+**Response: `text/event-stream` (SSE)**
+
+The response uses `Transfer-Encoding: chunked` with `Content-Type: text/event-stream; charset=utf-8` and `Cache-Control: no-cache`. The connection stays open until the `done` event is sent.
+
+**SSE Event Sequence:**
+
+```
+data: {"type":"chunk","content":"Great"}
+
+data: {"type":"chunk","content":"! Let's"}
+
+data: {"type":"chunk","content":" start"}
+
+data: {"type":"chunk","content":" with some"}
+
+data: {"type":"chunk","content":" conversation practice."}
+
+data: {"type":"action","action":"SET_ALARM","payload":{"time":"2026-02-24T07:00:00","label":"Morning practice"}}
+
+data: {"type":"done","message_id":"550e8400-e29b-41d4-a716-446655440099"}
+
+```
+
+Each SSE line is prefixed with `data: ` and followed by two newlines (`\n\n`). The JSON payload is a single line (no pretty-printing).
+
+**SSE Event Types:**
+
+| Event Type | Fields | Description |
+|------------|--------|-------------|
+| `chunk` | `type`, `content` | A text fragment of the streaming AI response. `content` is a string (may be a single token or a few tokens). |
+| `action` | `type`, `action`, `payload` | A device action intent detected in the response. Sent after streaming completes but before `done`. Zero or one per response. |
+| `done` | `type`, `message_id` | Signals the stream is complete. `message_id` is the UUID of the persisted assistant message. Always the last event. |
+| `error` | `type`, `message` | Signals an error occurred mid-stream. Sent instead of `done` if an unrecoverable error occurs during streaming. |
+
+**Action Event Payloads:**
+
+| Action | Payload Fields | Example |
+|--------|---------------|---------|
+| `SET_ALARM` | `time` (ISO 8601), `label` (string) | `{"time":"2026-02-24T07:00:00","label":"Wake up"}` |
+| `ADD_CALENDAR_EVENT` | `title` (string), `date` (ISO 8601 date), `time` (ISO 8601 time), `duration_minutes` (integer) | `{"title":"Dentist","date":"2026-02-24","time":"15:00","duration_minutes":60}` |
+
+**Error Responses (non-streaming, before SSE starts):**
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| 400 | Content is empty or exceeds 4000 chars | `{"detail": "Message content must be between 1 and 4000 characters"}` |
+| 401 | Missing or invalid JWT | `{"detail": "Invalid or expired token"}` |
+| 403 | Character does not belong to the authenticated user | `{"detail": "Character does not belong to user"}` |
+| 404 | Character not found or inactive | `{"detail": "Character not found"}` |
+| 422 | Pydantic validation failure | Standard FastAPI 422 response |
+
+**Error during streaming (after SSE has started):**
+
+If the Claude API fails mid-stream, an `error` event is sent and the connection is closed:
+
+```
+data: {"type":"error","message":"AI service temporarily unavailable"}
+
+```
+
+The user message is NOT persisted if the stream fails before producing any content. If the stream fails after producing partial content, neither the user message nor the partial assistant message is persisted.
+
+**Notes:**
+
+- The HTTP response status is always 200 once the SSE stream starts, even if an error occurs mid-stream. This is a constraint of the SSE protocol. Errors before streaming begins (validation, auth, not found) return standard HTTP error codes.
+- The `message_id` in the `done` event is the UUID of the assistant message that was saved to the database. The mobile client uses this to correlate the streamed response with the persisted message.
+- The user message is also saved to the database (as a background task), but its `id` is not returned in the SSE stream. The client generates a local UUID for the user message displayed in the UI.
+- If the character has no existing conversation (edge case -- should not happen since P01-05 auto-creates one), the endpoint auto-creates a conversation row before proceeding.
+- The `media_url` is stored on the user message but is NOT processed in this feature. Photo analysis is a separate future feature.
+
+---
+
+### GET /api/v1/characters/:id/messages
+
+Retrieves the message history for a character's conversation, using cursor-based pagination.
+
+```
+Auth: Bearer JWT required
+Content-Type: application/json
+```
+
+**Path Parameters:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `id` | UUID string | Character ID |
+
+**Query Parameters:**
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `cursor` | string (ISO 8601 timestamp) | no | none | The `created_at` of the last loaded message. Messages older than this are returned. |
+| `limit` | integer | no | 20 | Number of messages to return. Min 1, max 100. |
+
+**Response 200 OK:**
+
+```json
+{
+  "items": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440088",
+      "role": "assistant",
+      "content": "Great! Let's start with some conversation practice.",
+      "media_url": null,
+      "metadata": null,
+      "created_at": "2026-02-23T14:30:05Z"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440087",
+      "role": "user",
+      "content": "I want to practice English today!",
+      "media_url": null,
+      "metadata": null,
+      "created_at": "2026-02-23T14:30:00Z"
+    }
+  ],
+  "next_cursor": "2026-02-23T14:25:00Z",
+  "has_more": true
+}
+```
+
+| Response Field | Type | Notes |
+|----------------|------|-------|
+| `items` | array | Messages in reverse chronological order (newest first) |
+| `items[].id` | string (UUID) | Message primary key |
+| `items[].role` | string | `"user"` or `"assistant"` |
+| `items[].content` | string | Message text |
+| `items[].media_url` | string or null | S3 URL for attached media |
+| `items[].metadata` | object or null | Intent action data or other metadata |
+| `items[].created_at` | string (ISO 8601) | Message creation timestamp |
+| `next_cursor` | string or null | Timestamp to use as `cursor` for the next page. Null when no more messages. |
+| `has_more` | boolean | True if there are older messages beyond this page |
+
+**SQL pattern for cursor pagination:**
+
+```sql
+SELECT id, role, content, media_url, metadata, created_at
+FROM messages
+WHERE conversation_id = $1
+  AND ($cursor IS NULL OR created_at < $cursor)
+ORDER BY created_at DESC
+LIMIT $limit + 1;
+```
+
+Fetching `limit + 1` rows allows determining `has_more` without an extra count query. If `limit + 1` rows are returned, `has_more = true` and the extra row is discarded. The `next_cursor` is the `created_at` of the last returned item.
+
+**Error Responses:**
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| 401 | Missing or invalid JWT | `{"detail": "Invalid or expired token"}` |
+| 403 | Character does not belong to the authenticated user | `{"detail": "Character does not belong to user"}` |
+| 404 | Character not found or inactive | `{"detail": "Character not found"}` |
+| 404 | Character has no conversation (edge case) | `{"detail": "Conversation not found"}` |
+
+**Notes:**
+
+- Messages are returned newest-first (reverse chronological). The mobile client displays them bottom-up (newest at the bottom).
+- The `tts_url` field exists in the DB but is NOT included in this response. It will be added in the voice feature (Phase 3+).
+- The existing composite index `idx_messages_conv_time` on `(conversation_id, created_at DESC)` supports this query efficiently.
+
+---
+
+## 4. Backend Logic
+
+### ChatService Class
+
+The `ChatService` class in `backend/app/services/chat_service.py` encapsulates all messaging business logic. Route handlers delegate to this service.
+
+```
+class ChatService:
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def send_message_stream(
+        self,
+        character_id: uuid.UUID,
+        user_id: uuid.UUID,
+        profile: Profile,
+        content: str,
+        media_url: str | None,
+    ) -> AsyncGenerator[str, None]:
+        """Stream an AI response for a user message via SSE events.
+
+        Yields SSE-formatted strings: 'data: {"type":"chunk","content":"..."}\n\n'
+        """
+
+    async def get_messages(
+        self,
+        character_id: uuid.UUID,
+        user_id: uuid.UUID,
+        cursor: datetime | None,
+        limit: int,
+    ) -> MessageListResponse:
+        """Retrieve paginated message history for a character's conversation."""
+```
+
+### Send Message Flow (Streaming)
+
+```
+Client sends: POST /api/v1/characters/:id/messages
+    { content, media_url }
+    |
+    v
+1. Validate request body (Pydantic)
+   - content: 1-4000 chars, whitespace-trimmed
+   - media_url: optional, valid URL format
+    |
+    v
+2. Look up character by id:
+   SELECT * FROM characters WHERE id = $id AND is_active = true
+    |
+    +--> Not found --> 404 "Character not found"
+    |
+    v
+3. Ownership check: character.user_id == jwt_user_id
+    |
+    +--> Mismatch --> 403 "Character does not belong to user"
+    |
+    v
+4. Look up conversation:
+   SELECT * FROM conversations WHERE character_id = $character_id
+    |
+    +--> Not found --> Auto-create conversation row
+    |    (defensive: should exist from P01-05 character creation)
+    |
+    v
+5. Parallel fetch via asyncio.gather():
+   a) Mem0 global memory search (top 5)
+   b) Mem0 character-specific memory search (top 5)
+   c) DB: last 50 messages for this conversation
+      ORDER BY created_at DESC LIMIT 50
+      Then reverse to chronological order for the prompt
+    |
+    v
+6. Build the LLM prompt:
+   [system message] = Block 1 (character system_prompt)
+                    + Block 2 (Mem0 memories, max 10)
+                    + Block 3 (current date/time/timezone)
+   [messages] = last 50 messages (alternating user/assistant)
+              + the new user message
+    |
+    v
+7. Open Claude Sonnet streaming session:
+   client.messages.stream(
+       model=settings.claude_model,  # claude-sonnet-4-6
+       system=system_message,
+       messages=message_history,
+       max_tokens=2048,
+   )
+    |
+    v
+8. Yield SSE chunk events as tokens arrive:
+   Accumulate the full response text as chunks stream.
+   Each chunk: data: {"type":"chunk","content":"<token>"}\n\n
+    |
+    +--> Claude API error mid-stream -->
+    |    yield: data: {"type":"error","message":"AI service temporarily unavailable"}\n\n
+    |    return (do not persist anything)
+    |
+    v
+9. Intent extraction (after full response is assembled):
+   Call Claude Haiku with the complete assistant response:
+   "Does this response contain a device action intent?
+    Respond with JSON or 'none'."
+    |
+    +--> Intent detected -->
+    |    yield: data: {"type":"action","action":"SET_ALARM","payload":{...}}\n\n
+    +--> No intent / Haiku error --> skip (log error if Haiku fails)
+    |
+    v
+10. Generate assistant message UUID
+    yield: data: {"type":"done","message_id":"<uuid>"}\n\n
+    |
+    v
+11. Background tasks (fire-and-forget via asyncio.create_task):
+    a) Save user message to DB (role="user")
+    b) Save assistant message to DB (role="assistant", metadata=action if any)
+    c) UPDATE conversations SET last_message_at = now() WHERE character_id = $id
+    d) Mem0 add: [user_content, assistant_content] with agent_id
+    e) UPSERT user_activity SET last_chat_at = now() WHERE user_id = $id
+```
+
+### System Prompt Construction
+
+The system message sent to Claude is constructed from three blocks, following the architecture in `docs/05-ai-bellek.md`:
+
+**Block 1 -- Character Definition (from `characters.system_prompt`):**
+
+This is the stored system prompt generated by Claude Haiku during character creation (P01-05). It is passed as the first segment. Per `docs/05-ai-bellek.md`, this block is relatively static and benefits from Anthropic prompt caching.
+
+**Block 2 -- Learned Knowledge (from Mem0 search results):**
+
+```
+What you know about this user:
+- {memory_1}
+- {memory_2}
+- ...
+- {memory_N}
+```
+
+Up to 10 memories (5 global + 5 character-specific). Each memory is a single line of text. If no memories are found, this block is omitted. Memories from the global search and character-specific search are de-duplicated by content similarity (exact string match is sufficient for Phase 1).
+
+**Block 3 -- Daily Context (dynamic):**
+
+```
+Current date and time: {weekday}, {date} {time}
+Timezone: {profile.timezone}
+User's preferred language: {profile.preferred_language}
+```
+
+The date/time is computed server-side at request time using the user's timezone from their profile.
+
+**Message history:**
+
+The last 50 messages from the conversation are passed as the `messages` array to Claude, in chronological order (oldest first). Each message has `role` (`"user"` or `"assistant"`) and `content`. The new user message is appended as the final entry.
+
+Per `docs/05-ai-bellek.md`, the doc mentions "last 20 messages" for cost optimization, but CLAUDE.md says "last 30-50 messages." This spec uses 50 as the upper bound, configurable. The service should read this from a constant or config value, not a hardcoded literal.
+
+### Intent Extraction via Claude Haiku
+
+After the Claude Sonnet response is fully streamed and assembled, the service calls Claude Haiku to determine if the response contains a device action intent. This is a separate, non-streaming call.
+
+**Haiku Intent Extraction Prompt:**
+
+```
+Analyze the following AI assistant response and determine if it contains an intent to perform a device action.
+
+Supported actions:
+- SET_ALARM: The assistant is setting an alarm or reminder. Extract time and label.
+- ADD_CALENDAR_EVENT: The assistant is adding a calendar event. Extract title, date, time, duration.
+
+If the response contains a device action intent, respond with ONLY this JSON:
+{"action": "<ACTION_NAME>", "payload": {<relevant fields>}}
+
+If the response does NOT contain any device action intent, respond with ONLY:
+none
+
+The "time" field must be in ISO 8601 format. The "date" field must be YYYY-MM-DD format.
+
+User's timezone: {profile.timezone}
+Current date: {current_date}
+
+Assistant response to analyze:
+{assistant_response_content}
+```
+
+**Processing the Haiku response:**
+
+1. If the response is `"none"` or cannot be parsed as JSON: no action event is emitted.
+2. If the response is valid JSON with an `action` field that matches a supported action: emit the `action` SSE event.
+3. If the Haiku call fails (network error, rate limit): log the error and skip the action event. Do not fail the entire message flow.
+
+**Why a separate Haiku call instead of instructing Sonnet to include actions in-stream:**
+
+- Separating intent extraction from conversation keeps the main conversation natural. Sonnet should write a human-friendly response, not JSON-structured output.
+- Haiku is cheaper and faster for structured extraction tasks.
+- Intent extraction can evolve independently (new actions, better prompts) without affecting the conversation quality.
+- Per `docs/05-ai-bellek.md`: Haiku is the designated model for "intent classification" tasks.
+
+### Get Messages Flow (Paginated)
+
+```
+Client sends: GET /api/v1/characters/:id/messages?cursor=2026-02-23T14:30:00Z&limit=20
+    |
+    v
+1. Look up character by id (active, ownership check)
+    |
+    v
+2. Look up conversation by character_id
+    |
+    +--> Not found --> 404 "Conversation not found"
+    |
+    v
+3. Query messages with cursor pagination:
+   SELECT id, role, content, media_url, metadata, created_at
+   FROM messages
+   WHERE conversation_id = $conversation_id
+     AND ($cursor IS NULL OR created_at < $cursor)
+   ORDER BY created_at DESC
+   LIMIT $limit + 1
+    |
+    v
+4. Determine pagination:
+   - If result count > limit: has_more=true, drop last row
+   - next_cursor = last returned row's created_at (as ISO 8601 string)
+   - If result count <= limit: has_more=false, next_cursor=null
+    |
+    v
+5. Return 200 { items, next_cursor, has_more }
+```
+
+### Background Task Execution
+
+Background tasks are fired after the SSE stream completes using `asyncio.create_task()`. They run within the same event loop but do not block the response.
+
+**Critical design decision**: Background tasks use a NEW database session (not the request-scoped session). The request-scoped session is closed when the SSE response finishes. The background task creates its own session via `AsyncSessionLocal()`.
+
+```
+async def _persist_exchange(
+    user_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    user_content: str,
+    user_media_url: str | None,
+    assistant_content: str,
+    assistant_message_id: uuid.UUID,
+    action_metadata: dict | None,
+    mem0_user_id: str,
+    mem0_agent_id: str,
+) -> None:
+    """Background task: persist messages, update timestamps, add to Mem0."""
+    async with AsyncSessionLocal() as db:
+        # Save user message
+        user_msg = Message(
+            id=uuid.uuid4(),
+            conversation_id=conversation_id,
+            user_id=user_id,
+            role="user",
+            content=user_content,
+            media_url=user_media_url,
+        )
+        db.add(user_msg)
+
+        # Save assistant message
+        assistant_msg = Message(
+            id=assistant_message_id,
+            conversation_id=conversation_id,
+            user_id=user_id,
+            role="assistant",
+            content=assistant_content,
+            metadata_=action_metadata,
+        )
+        db.add(assistant_msg)
+
+        # Update conversation timestamp
+        await db.execute(
+            update(Conversation)
+            .where(Conversation.id == conversation_id)
+            .values(last_message_at=func.now())
+        )
+
+        # Update user activity
+        await db.execute(
+            update(UserActivity)
+            .where(UserActivity.user_id == user_id)
+            .values(last_chat_at=func.now())
+        )
+
+        await db.commit()
+
+    # Mem0 add (outside DB transaction)
+    try:
+        mem0_client = MemoryClient(api_key=settings.mem0_api_key)
+        await asyncio.to_thread(
+            mem0_client.add,
+            [
+                {"role": "user", "content": user_content},
+                {"role": "assistant", "content": assistant_content},
+            ],
+            user_id=mem0_user_id,
+            agent_id=mem0_agent_id,
+        )
+    except Exception:
+        logger.exception("Mem0 add failed for agent_id=%s", mem0_agent_id)
+```
+
+**Error handling in background tasks:**
+
+- DB persistence failure: logged at ERROR level. The user will not see the messages in history, but the streamed response was already delivered. This is an acceptable trade-off for Phase 1. A retry mechanism can be added later.
+- Mem0 add failure: logged at ERROR level. Memory will not be updated for this exchange. This is non-critical.
+- User activity update failure: logged at WARNING level. Non-critical.
+
+### Mem0 Client Integration
+
+The Mem0 Python SDK (`mem0ai` package, already in `requirements.txt`) provides a `MemoryClient` class. Since the SDK is synchronous, all calls are wrapped with `asyncio.to_thread()` to avoid blocking the event loop.
+
+```python
+from mem0 import MemoryClient
+
+async def _search_memories(
+    query: str,
+    mem0_user_id: str,
+    agent_id: str | None,
+    limit: int = 5,
+) -> list[str]:
+    """Search Mem0 for relevant memories. Returns a list of memory text strings."""
+    client = MemoryClient(api_key=settings.mem0_api_key)
+
+    filters = {"user_id": mem0_user_id}
+    if agent_id is not None:
+        filters["agent_id"] = agent_id
+
+    results = await asyncio.to_thread(
+        client.search,
+        query,
+        user_id=mem0_user_id,
+        agent_id=agent_id,
+        limit=limit,
+    )
+    return [r["memory"] for r in results]
+```
+
+The two Mem0 searches (global + character-specific) are run in parallel:
+
+```python
+global_memories, character_memories = await asyncio.gather(
+    _search_memories(content, profile.mem0_user_id, agent_id=None, limit=5),
+    _search_memories(content, profile.mem0_user_id, agent_id=character.mem0_agent_id, limit=5),
+)
+```
+
+### Anthropic Streaming Client
+
+The streaming call uses the `anthropic` SDK's async streaming interface:
+
+```python
+client = AsyncAnthropic(api_key=settings.anthropic_api_key)
+
+async with client.messages.stream(
+    model=settings.claude_model,  # claude-sonnet-4-6
+    system=system_prompt_text,
+    messages=formatted_messages,
+    max_tokens=2048,
+) as stream:
+    async for text in stream.text_stream:
+        yield f'data: {json.dumps({"type": "chunk", "content": text})}\n\n'
+    # After stream completes, get the full message
+    response = await stream.get_final_message()
+    full_response_text = response.content[0].text
+```
+
+### Config Changes
+
+The `config.py` Settings class needs one new constant. Note that `claude_model` and `claude_haiku_model` already exist from P01-05.
+
+```
+max_context_messages: int = 50
+```
+
+This makes the message history depth configurable.
+
+No changes to `requirements.txt` are needed. All required packages (`anthropic`, `mem0ai`, `fastapi`) are already listed.
+
+---
+
+## 5. Pydantic Schemas
+
+All new schemas are defined in `backend/app/schemas/chat.py`.
+
+### Request Schemas
+
+```
+class SendMessageRequest(BaseModel):
+    content: str = Field(..., min_length=1, max_length=4000)
+    media_url: str | None = Field(default=None, max_length=2048)
+
+    @field_validator("content")
+    @classmethod
+    def strip_content(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Message content must not be empty after trimming whitespace")
+        return stripped
+
+    @field_validator("media_url")
+    @classmethod
+    def validate_media_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        v = v.strip()
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("media_url must be a valid HTTP or HTTPS URL")
+        return v
+```
+
+### Response Schemas
+
+```
+class MessageItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    role: str
+    content: str
+    media_url: str | None
+    metadata: dict | None
+    created_at: datetime
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def coerce_id_to_str(cls, v: object) -> str:
+        return str(v)
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def coerce_metadata(cls, v: object) -> dict | None:
+        """Handle the ORM column name metadata_ -> metadata."""
+        return v
+```
+
+```
+class MessageListResponse(BaseModel):
+    items: list[MessageItem]
+    next_cursor: str | None
+    has_more: bool
+```
+
+**SSE Event Models (used for serialization, not as response_model):**
+
+```
+class ChunkEvent(BaseModel):
+    type: str = "chunk"
+    content: str
+
+class ActionEvent(BaseModel):
+    type: str = "action"
+    action: str
+    payload: dict
+
+class DoneEvent(BaseModel):
+    type: str = "done"
+    message_id: str
+
+class ErrorEvent(BaseModel):
+    type: str = "error"
+    message: str
+```
+
+These are used internally by `ChatService` to serialize SSE payloads via `model.model_dump_json()`. They are NOT FastAPI response models.
+
+---
+
+## 6. Test Requirements
+
+### Route Tests (`backend/tests/test_chat_routes.py`)
+
+These tests use the FastAPI test client. The `get_current_user` dependency is overridden to return a fake Profile. Claude and Mem0 are mocked.
+
+#### POST /characters/:id/messages
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Valid message to own character | 200, SSE stream with chunk events, done event with message_id |
+| 2 | Message to character belonging to another user | 403, "Character does not belong to user" |
+| 3 | Message to non-existent character | 404, "Character not found" |
+| 4 | Message to inactive character | 404, "Character not found" |
+| 5 | Empty content (whitespace only) | 422, validation error |
+| 6 | Content exceeds 4000 chars | 422, validation error |
+| 7 | Missing Authorization header | 401 |
+| 8 | SSE stream contains chunk, done events in correct order | Verify first events are chunks, last event is done |
+| 9 | Claude API failure before streaming starts | 200 then error SSE event |
+| 10 | Intent action detected in response | SSE stream includes action event before done |
+| 11 | No intent detected | SSE stream has chunks and done, no action event |
+
+#### GET /characters/:id/messages
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 12 | Get messages without cursor (first page) | 200, items array, newest messages first |
+| 13 | Get messages with cursor | 200, only messages older than cursor |
+| 14 | Get messages with limit=5 | 200, at most 5 items |
+| 15 | Get messages when conversation is empty | 200, `{"items": [], "next_cursor": null, "has_more": false}` |
+| 16 | Get messages for character belonging to another user | 403 |
+| 17 | Get messages for non-existent character | 404 |
+| 18 | Get messages without auth | 401 |
+| 19 | has_more is true when more messages exist | Verify by inserting more messages than limit |
+| 20 | has_more is false on last page | Verify when all messages fit in one page |
+| 21 | next_cursor value matches last item's created_at | Verify cursor format |
+
+### Service Tests (`backend/tests/test_chat_service.py`)
+
+Unit tests for `ChatService` with mocked DB, Claude, and Mem0.
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 22 | `send_message_stream()` calls asyncio.gather for Mem0 + DB in parallel | Mock verify gather called with 3 coroutines |
+| 23 | `send_message_stream()` builds system prompt with 3 blocks | Verify system prompt contains character prompt, memories, date/time |
+| 24 | `send_message_stream()` passes last 50 messages to Claude | Verify message count in Claude call |
+| 25 | `send_message_stream()` yields chunk events from Claude stream | Verify SSE format per chunk |
+| 26 | `send_message_stream()` calls Haiku for intent extraction after stream | Verify Haiku called with assistant response |
+| 27 | `send_message_stream()` yields action event when intent detected | Verify action SSE event emitted |
+| 28 | `send_message_stream()` skips action when Haiku returns "none" | No action event in stream |
+| 29 | `send_message_stream()` skips action when Haiku call fails | No action event, error logged |
+| 30 | `send_message_stream()` yields done event with UUID | Verify done event format |
+| 31 | `send_message_stream()` fires background task for persistence | Verify asyncio.create_task called |
+| 32 | Background task persists user and assistant messages | Verify 2 Message inserts |
+| 33 | Background task updates conversation.last_message_at | Verify UPDATE query |
+| 34 | Background task calls Mem0 add with correct agent_id | Verify Mem0 add params |
+| 35 | Background task handles DB error gracefully | Error logged, no crash |
+| 36 | Background task handles Mem0 error gracefully | Error logged, no crash |
+| 37 | `get_messages()` returns messages in DESC order | Verify ordering |
+| 38 | `get_messages()` applies cursor filter correctly | Only messages before cursor |
+| 39 | `get_messages()` calculates has_more and next_cursor | Verify pagination logic |
+| 40 | `get_messages()` raises 404 for missing conversation | HTTPException(404) |
+| 41 | Mem0 search failure does not crash send_message_stream | Stream continues with empty memories |
+| 42 | System prompt includes user timezone and language | Verify Block 3 content |
+
+### Schema Tests (`backend/tests/test_chat_schemas.py`)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 43 | `SendMessageRequest` strips whitespace from content | Trimmed correctly |
+| 44 | `SendMessageRequest` rejects empty content after strip | ValidationError |
+| 45 | `SendMessageRequest` rejects content > 4000 chars | ValidationError |
+| 46 | `SendMessageRequest` accepts null media_url | Passes |
+| 47 | `SendMessageRequest` rejects invalid media_url | ValidationError |
+| 48 | `MessageItem` coerces UUID id to string | UUID -> string |
+| 49 | `MessageListResponse` includes pagination fields | next_cursor, has_more present |
+
+### How to Mock Claude Streaming
+
+```python
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Mock the streaming context manager
+mock_stream = AsyncMock()
+mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+# Mock text_stream as an async iterator
+async def mock_text_iter():
+    for chunk in ["Hello", ", ", "world", "!"]:
+        yield chunk
+
+mock_stream.text_stream = mock_text_iter()
+
+# Mock get_final_message
+mock_final = MagicMock()
+mock_final.content = [MagicMock(text="Hello, world!")]
+mock_stream.get_final_message = AsyncMock(return_value=mock_final)
+
+with patch("app.services.chat_service.AsyncAnthropic") as mock_cls:
+    mock_client = AsyncMock()
+    mock_client.messages.stream = MagicMock(return_value=mock_stream)
+    mock_cls.return_value = mock_client
+    # ... run test
+```
+
+### How to Mock Mem0
+
+```python
+from unittest.mock import patch, MagicMock
+
+mock_mem0 = MagicMock()
+mock_mem0.search.return_value = [
+    {"memory": "Prefers morning workouts"},
+    {"memory": "Left knee is sensitive"},
+]
+mock_mem0.add.return_value = None
+
+with patch("app.services.chat_service.MemoryClient", return_value=mock_mem0):
+    # ... run test
+```
+
+Since Mem0 calls are wrapped in `asyncio.to_thread()`, the mock must work with synchronous calls.
+
+### How to Test SSE Streaming
+
+Use `httpx.AsyncClient` with `stream=True` to consume SSE events:
+
+```python
+async with httpx.AsyncClient(app=app) as client:
+    async with client.stream(
+        "POST",
+        f"/api/v1/characters/{char_id}/messages",
+        json={"content": "Hello"},
+        headers={"Authorization": f"Bearer {token}"},
+    ) as response:
+        events = []
+        async for line in response.aiter_lines():
+            if line.startswith("data: "):
+                events.append(json.loads(line[6:]))
+
+        assert events[-1]["type"] == "done"
+        assert "message_id" in events[-1]
+        assert all(e["type"] == "chunk" for e in events[:-1])
+```
+
+---
+
+## 7. File Manifest
+
+Every file to be created or modified, grouped by purpose.
+
+### Route Handler
+
+```
+Backend:
+  CREATE  backend/app/routes/chat.py
+```
+
+Contains two route functions: `send_message` (POST, returns `StreamingResponse`) and `get_messages` (GET, returns `MessageListResponse`). Each delegates to `ChatService`.
+
+### Service Layer
+
+```
+Backend:
+  CREATE  backend/app/services/chat_service.py
+```
+
+Contains the `ChatService` class with `send_message_stream()` and `get_messages()` methods. Contains the system prompt builder, Mem0 search wrapper, Haiku intent extractor, and the `_persist_exchange()` background task function.
+
+### Pydantic Schemas
+
+```
+Backend:
+  CREATE  backend/app/schemas/chat.py
+```
+
+Contains `SendMessageRequest`, `MessageItem`, `MessageListResponse`, `ChunkEvent`, `ActionEvent`, `DoneEvent`, `ErrorEvent`.
+
+### Application Wiring
+
+```
+Backend:
+  MODIFY  backend/app/main.py
+```
+
+Add `from app.routes import chat` and register the chat router:
+
+```python
+app.include_router(chat.router, prefix="/api/v1/characters", tags=["chat"])
+```
+
+Note: The chat router is registered under the `/api/v1/characters` prefix because the endpoints are `/{character_id}/messages`. This does NOT conflict with the existing characters router because the path patterns are distinct: the characters router handles `""`, `"/{character_id}"` while the chat router handles `"/{character_id}/messages"`.
+
+### Configuration
+
+```
+Backend:
+  MODIFY  backend/app/config.py
+```
+
+Add `max_context_messages: int = 50` to the `Settings` class.
+
+### Tests
+
+```
+Backend:
+  CREATE  backend/tests/test_chat_routes.py
+  CREATE  backend/tests/test_chat_service.py
+  CREATE  backend/tests/test_chat_schemas.py
+```
+
+### Documentation (Pipeline)
+
+```
+Shared:
+  CREATE  shared/feature-specs/chat-streaming.md          (this file)
+  CREATE  docs/pipeline/chat-streaming-architect.handoff.md
+```
+
+### Summary
+
+| Action | Count |
+|--------|-------|
+| CREATE | 6 |
+| MODIFY | 2 |
+| DELETE | 0 |
+| **Total** | **8** |
+
+### Files NOT Modified
+
+- `backend/app/dependencies.py` -- Uses the existing `get_current_user` and `get_db`. No changes needed.
+- `backend/app/core/auth.py` -- JWT verification is handled by the existing middleware. No changes needed.
+- `backend/app/models/` -- No model changes. Existing Message, Conversation, Character, Profile, UserActivity models from P01-02 are used as-is.
+- `backend/app/schemas/__init__.py` -- Not modified (follow direct import pattern from route files).
+- `backend/app/services/__init__.py` -- Not modified (follow direct import pattern).
+- `backend/requirements.txt` -- Already includes `anthropic>=0.43.0,<1.0.0` and `mem0ai>=0.1.0`. No new dependencies needed.
+- `backend/.env.example` -- Already has `ANTHROPIC_API_KEY` and `MEM0_API_KEY`. No changes needed.
+
+---
+
+## 8. Acceptance Criteria
+
+1. Given an authenticated user with a character, when the client sends `POST /api/v1/characters/:id/messages` with valid content, then the response is HTTP 200 with `Content-Type: text/event-stream` and the stream contains at least one `chunk` event followed by a `done` event.
+
+2. Given a streaming response in progress, when each SSE event is parsed, then every event is valid JSON with a `type` field that is one of `chunk`, `action`, `done`, or `error`.
+
+3. Given a successful streaming response, when the `done` event is received, then it contains a `message_id` field that is a valid UUID string.
+
+4. Given a successful streaming response, when the background tasks complete, then both a `user` message and an `assistant` message exist in the `messages` table with the correct `conversation_id`, `user_id`, `role`, and `content`.
+
+5. Given a successful streaming response, when the background tasks complete, then `conversations.last_message_at` is updated to approximately the current time.
+
+6. Given a successful streaming response, when the background tasks complete, then `user_activity.last_chat_at` is updated to approximately the current time.
+
+7. Given a successful streaming response, when the background tasks complete, then `mem0.add()` is called with the user message content, assistant response content, the profile's `mem0_user_id`, and the character's `mem0_agent_id`.
+
+8. Given a character whose conversation has existing messages, when `POST /characters/:id/messages` is called, then the Claude API receives the last 50 messages from the conversation as context.
+
+9. Given a character with Mem0 memories, when `POST /characters/:id/messages` is called, then the system prompt sent to Claude includes the Mem0 memory content (up to 10 memories).
+
+10. Given the system prompt sent to Claude, when a developer inspects the prompt, then it contains the character's `system_prompt` (Block 1), Mem0 memories (Block 2), and current date/time/timezone (Block 3).
+
+11. Given an assistant response that includes an intent to set an alarm (e.g., "I've set an alarm for 7 AM tomorrow"), when the intent extraction completes, then the SSE stream includes an `action` event with `action: "SET_ALARM"` and a valid payload before the `done` event.
+
+12. Given an assistant response with no device action intent, when the intent extraction completes, then the SSE stream contains only `chunk` events and a `done` event (no `action` event).
+
+13. Given the Claude API failing mid-stream, when the error occurs, then the SSE stream emits an `error` event with a user-friendly message and no messages are persisted to the database.
+
+14. Given Mem0 search failing during context gathering, when the error occurs, then the stream proceeds normally with an empty memory block and the error is logged.
+
+15. Given the Mem0 add call failing in the background task, when the error occurs, then the error is logged but the user and assistant messages are still persisted to the database.
+
+16. Given a character belonging to another user, when the client sends `POST /characters/:id/messages`, then the response is HTTP 403 with detail "Character does not belong to user".
+
+17. Given a non-existent or inactive character ID, when the client sends `POST /characters/:id/messages`, then the response is HTTP 404 with detail "Character not found".
+
+18. Given a message with content that is only whitespace, when the client sends `POST /characters/:id/messages`, then the response is HTTP 422 with a validation error.
+
+19. Given an authenticated user with a character that has messages, when the client sends `GET /api/v1/characters/:id/messages`, then the response is HTTP 200 with `items` containing messages in reverse chronological order, plus `next_cursor` and `has_more` fields.
+
+20. Given a `cursor` query parameter, when `GET /characters/:id/messages` is called, then only messages with `created_at` strictly less than the cursor are returned.
+
+21. Given more messages exist than the requested `limit`, when `GET /characters/:id/messages` is called, then `has_more` is `true` and `next_cursor` contains the `created_at` of the last returned message.
+
+22. Given all messages fit within the `limit`, when `GET /characters/:id/messages` is called, then `has_more` is `false` and `next_cursor` is `null`.
+
+23. Given an empty conversation, when `GET /characters/:id/messages` is called, then the response is HTTP 200 with `{"items": [], "next_cursor": null, "has_more": false}`.
+
+24. Given the backend test suite, when a developer runs `pytest` on the new test files, then all tests pass with exit code 0.
+
+25. Given the route handler code, when a developer inspects it, then all business logic is in `ChatService` and route handlers only call service methods, validate input (Pydantic), and return responses.
+
+---
+
+## 9. Design Decisions and Rationale
+
+### Why SSE instead of WebSocket
+
+SSE (Server-Sent Events) is a simpler protocol for server-to-client streaming. Ember's chat is request-response (user sends a message, server streams a reply) -- not bidirectional real-time communication. SSE works over standard HTTP, is easier to test, and is well-supported by FastAPI's `StreamingResponse`. WebSocket would add complexity with no benefit for this use case. Real-time voice calls (Phase 5+) will use WebSocket via LiveKit.
+
+### Why background tasks for persistence instead of inline writes
+
+Writing messages to the database before or during the stream would add latency to the first-token time. Per `docs/08-guvenlik-performans.md`, the target TTFT (time to first token) is under 1 second. By deferring persistence to background tasks, the stream starts as soon as Claude begins generating tokens. The trade-off is that messages may be lost if the background task fails, but this is acceptable for Phase 1 -- the user already saw the response in real-time.
+
+### Why 50 messages of context instead of 20
+
+`docs/05-ai-bellek.md` mentions 20 messages for cost optimization, but `CLAUDE.md` specifies "last 30-50 messages." This spec uses 50 as a configurable upper bound via `settings.max_context_messages`. The cost difference is manageable for Phase 1, and more context produces better conversation quality. This can be tuned down later based on token usage data.
+
+### Why a separate Haiku call for intent extraction
+
+As detailed in Section 4, separating intent extraction from conversation keeps the main response natural and allows independent evolution of the intent system. Haiku is significantly cheaper than Sonnet for this structured extraction task. The latency cost (~200-400ms) is acceptable because it happens after the full response is streamed -- the user is already reading the response while intent extraction runs.
+
+### Why the user message ID is not returned in the SSE stream
+
+The mobile client generates a local UUID for the user message bubble immediately when the user taps "send." The actual DB-generated UUID for the user message is not needed by the client. Only the assistant message ID is useful (for correlating the streamed response with the persisted message for features like reply, copy, etc.). This keeps the SSE protocol simpler.
+
+### Why auto-create conversation if missing
+
+Although P01-05 creates a conversation when a character is created, defensive programming handles the edge case where the conversation row is missing (e.g., manual DB edit, data migration issue). Rather than returning a 500 error for what should be an invisible implementation detail, the endpoint auto-creates the missing conversation.
+
+### Why metadata is stored on the assistant message
+
+When an intent action is detected, the `metadata` JSONB column on the assistant message stores the full action payload. This allows the mobile client to re-display the action (e.g., "Alarm set for 7:00 AM") when loading message history, without needing to re-run intent extraction.
+
+### Why Mem0 searches are parallel but not with DB query
+
+Actually, all three fetches (global Mem0, character Mem0, DB last 50 messages) ARE parallel via a single `asyncio.gather()`. This is the approach specified in the issue description and follows the pattern from `docs/05-ai-bellek.md`.
+
+---
+
+## 10. Notes for Developers
+
+### For backend-dev
+
+- **Start with schemas** (`app/schemas/chat.py`), then the service (`app/services/chat_service.py`), then the route (`app/routes/chat.py`), then wire up in `main.py`.
+
+- **StreamingResponse usage**: The POST endpoint returns `StreamingResponse(generator(), media_type="text/event-stream")`. FastAPI handles the chunked transfer encoding. Set headers: `Cache-Control: no-cache`, `X-Accel-Buffering: no` (prevents nginx from buffering SSE).
+
+- **Router registration path**: Register the chat router with `prefix="/api/v1/characters"`. The route decorators use relative paths: `@router.post("/{character_id}/messages")` and `@router.get("/{character_id}/messages")`. This does NOT conflict with the characters router (which handles `""` and `"/{character_id}"`) because FastAPI matches by full path pattern.
+
+- **Anthropic streaming API**: Use `client.messages.stream()` (async context manager), not `client.messages.create(stream=True)`. The `.stream()` method provides a cleaner async iterator via `stream.text_stream` and a `get_final_message()` method to retrieve the complete response object.
+
+- **Mem0 SDK is synchronous**: The `mem0ai` package's `MemoryClient` is blocking. Wrap all calls in `asyncio.to_thread()`. Do NOT call Mem0 methods directly in async functions.
+
+- **Background task session management**: Do NOT use the request-scoped `db` session in background tasks. Create a new session via `AsyncSessionLocal()` inside the background task. The request session is closed when the StreamingResponse finishes.
+
+- **SSE format**: Each event is `data: {json}\n\n` (note: TWO newlines). Do not add event type headers (`event:`) -- we use the `type` field inside the JSON payload instead. This simplifies client parsing.
+
+- **Config change**: Add `max_context_messages: int = 50` to `Settings`. Use `settings.max_context_messages` in the service for the message history query limit.
+
+- **Prompt caching**: Per `docs/05-ai-bellek.md`, Block 1 (character system prompt) can use Anthropic's `cache_control` parameter. For Phase 1, this is optional but recommended. To enable it, pass the system prompt as a list of content blocks with `cache_control: {"type": "ephemeral"}` on the first block.
+
+- **Error handling during streaming**: Once the first SSE event has been sent, you cannot change the HTTP status code. If Claude fails mid-stream, emit `data: {"type":"error","message":"..."}\n\n` and return from the generator. The HTTP status remains 200.
+
+- **Intent extraction confidence**: The Haiku prompt asks for structured JSON. If the response cannot be parsed as JSON or the action is not in the supported set, treat it as "no intent" and skip the action event. Log the raw Haiku response for debugging.
+
+- **Message ordering in DB query for context**: The DB query fetches the last 50 messages in DESC order. You MUST reverse them to chronological order before sending to Claude (Claude expects messages in chronological order).
+
+### For backend-tester
+
+- **SSE testing**: Use `httpx.AsyncClient` with `stream=True`. Parse SSE events line by line. The test client must consume the entire stream before asserting.
+
+- **Mock all external services**: Claude (both Sonnet streaming and Haiku non-streaming), Mem0 (search and add), and the background task database session.
+
+- **Test SSE event ordering**: The correct order is: N chunk events, 0 or 1 action event, exactly 1 done event. Verify this ordering in integration tests.
+
+- **Test background task execution**: Use `asyncio.create_task` with a mock. Verify that the task was created and that its arguments are correct. For deeper testing, run the background task function directly with mocked dependencies.
+
+- **Test Mem0 failure resilience**: Mock Mem0 search to raise an exception. Verify that the stream still works with empty memories.
+
+- **Test cursor pagination**: Seed the database with N messages with known `created_at` values. Verify that cursor correctly filters, that `has_more` is accurate, and that `next_cursor` matches the last item.


### PR DESCRIPTION
## chat-streaming

POST /characters/:id/messages SSE streaming endpoint with Claude AI integration, Mem0 memory context, and device action intent extraction.

Closes #8

---

## Pipeline Summary

| Stage | Agent | Status |
|-------|-------|--------|
| Architecture | architect | ✅ |
| Backend Implementation | backend-dev | ✅ |
| Backend Tests | backend-tester | ✅ |
| Documentation | doc-writer | ✅ |
| Code Review | reviewer | ✅ Approved |

## Spec
`shared/feature-specs/chat-streaming.md`

## Test Coverage
- **130 chat-streaming tests** — 100% line & branch coverage
- **890 total tests** passing (0 failures)

## Key Features
- SSE streaming with chunk/action/done/error events
- Parallel Mem0 + DB context fetching via asyncio.gather()
- Claude Sonnet for chat responses, Haiku for intent extraction
- Background task persistence (messages + Mem0 memory)
- Cursor-based message pagination
- Device action intents (SET_ALARM, ADD_CALENDAR_EVENT)

🤖 Generated via `/pipeline-run P01-06`