### PR TITLE
feat(messages-pagination): messages-pagination [P01-07]

### DIFF
--- a/.claude/agent-memory/architect/MEMORY.md
+++ b/.claude/agent-memory/architect/MEMORY.md
@@ -89,6 +89,27 @@
 - P01-06: Action metadata stored on assistant message's JSONB metadata_ column.
 - P01-06: SSE format: data: {json}\n\n with type field in JSON (no event: header).
 
+## Key Decisions Log (P01-07)
+
+- P01-07: Composite cursor (created_at, id) over plain ISO timestamp -- fixes correctness bug with same-timestamp messages.
+- P01-07: Base64 URL-safe JSON cursor encoding per docs/standards/common.md Section 6.
+- P01-07: No backward compatibility for old plain-ISO cursors -- no mobile client has shipped yet.
+- P01-07: No index changes needed -- existing idx_messages_conv_time is sufficient, id tiebreaker operates on small result set.
+- P01-07: SQLAlchemy tuple_() for row-value comparison: (created_at, id) < ($ts, $id).
+- P01-07: Default limit stays at 20 (matches issue description; common.md says 30 but issue takes precedence).
+- P01-07: Single HTTPException(400) for all cursor parse failures -- do not expose internal error details.
+- P01-07: MODIFY-only feature -- no new files created in backend, only updates to 4 existing files.
+
+## Implementation State After P01-06
+
+- `backend/app/config.py` now has `claude_haiku_model`, `claude_model`, `max_context_messages: int = 50`.
+- `backend/app/routes/` has `__init__.py` + `health.py` + `auth.py` + `characters.py` + `chat.py`.
+- `backend/app/services/` has `__init__.py` (empty) + `auth_service.py` + `character_service.py` + `chat_service.py`.
+- `backend/app/schemas/` has `__init__.py` (empty) + `health.py` + `auth.py` + `character.py` + `chat.py`.
+- `backend/app/main.py` registers health, auth, characters, and chat routers.
+- `backend/app/db/session.py` has AsyncSessionLocal (used by background tasks).
+- Tests: `test_chat_routes.py` (989 lines) and `test_chat_service.py` (1947 lines) with comprehensive coverage.
+
 ## Implementation State After P01-05
 
 - `backend/app/config.py` now has `claude_haiku_model: str = "claude-haiku-4-5"`.
@@ -96,3 +117,9 @@
 - `backend/app/services/` has `__init__.py` (empty) + `auth_service.py` + `character_service.py`.
 - `backend/app/schemas/` has `__init__.py` (empty) + `health.py` + `auth.py` + `character.py`.
 - `backend/app/main.py` registers health, auth, and characters routers.
+
+## Spec Writing Patterns (P01-07 lesson)
+
+- When a feature mostly enhances an existing implementation, clearly document "What Already Exists" vs "What Changes" in a comparison table.
+- For MODIFY-only features with no new files, the file manifest is small. Still list every modified file explicitly.
+- When docs/standards/common.md and the issue description conflict on specifics (e.g., default limit 30 vs 20), note the discrepancy and state which takes precedence and why.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [P01-04] Auth endpoints: register, login, refresh with Cognito integration
 - [P01-05] Character CRUD endpoints with Claude Haiku prompt generation
 - [P01-06] SSE streaming chat endpoint with Claude AI integration, Mem0 memory, and device action intents
+- [P01-07] Composite cursor-based message pagination with (created_at, id) tiebreaker
 
 ---
 

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -8,7 +8,6 @@ authentication. Business logic is delegated to ChatService.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
@@ -17,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_current_user, get_db
 from app.models.profile import Profile
 from app.schemas.chat import MessageListResponse, SendMessageRequest
-from app.services.chat_service import ChatService
+from app.services.chat_service import ChatService, MessageCursor, _decode_cursor
 
 router = APIRouter()
 
@@ -75,14 +74,15 @@ async def get_messages(
 ) -> MessageListResponse:
     """Retrieve paginated message history for a character's conversation.
 
-    Uses cursor-based pagination. Messages are returned newest-first.
+    Uses cursor-based pagination with composite (created_at, id) cursors
+    encoded as base64 URL-safe JSON. Messages are returned newest-first.
     Pass the ``next_cursor`` from a previous response as the ``cursor``
     query parameter to load the next page.
     """
-    # Parse cursor from ISO 8601 string to datetime
-    parsed_cursor: datetime | None = None
+    # Decode composite cursor from base64 JSON — raises 400 on invalid format
+    parsed_cursor: MessageCursor | None = None
     if cursor is not None:
-        parsed_cursor = datetime.fromisoformat(cursor)
+        parsed_cursor = _decode_cursor(cursor)
 
     service = ChatService(db)
     return await service.get_messages(

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -8,16 +8,18 @@ message history retrieval.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
 from anthropic import AsyncAnthropic
 from fastapi import HTTPException, status
 from mem0 import MemoryClient
-from sqlalchemy import select, true, update
+from sqlalchemy import select, true, tuple_, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -62,6 +64,46 @@ Assistant response to analyze:
 {assistant_response}"""
 
 _SUPPORTED_ACTIONS = frozenset({"SET_ALARM", "ADD_CALENDAR_EVENT"})
+
+
+# ---------------------------------------------------------------------------
+# Cursor helpers for composite (created_at, id) pagination
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MessageCursor:
+    """Decoded composite cursor for keyset pagination."""
+
+    ts: datetime
+    id: uuid.UUID
+
+
+def _encode_cursor(ts: datetime, msg_id: uuid.UUID) -> str:
+    """Encode a (created_at, id) pair into an opaque base64 URL-safe cursor string."""
+    payload = {"ts": ts.isoformat(), "id": str(msg_id)}
+    raw = json.dumps(payload).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _decode_cursor(cursor: str) -> MessageCursor:
+    """Decode a base64 URL-safe cursor string into a MessageCursor.
+
+    Raises HTTPException(400) for any malformed input.
+    """
+    try:
+        # Restore base64 padding
+        padded = cursor + "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(padded)
+        payload = json.loads(raw)
+        ts = datetime.fromisoformat(payload["ts"])
+        msg_id = uuid.UUID(payload["id"])
+        return MessageCursor(ts=ts, id=msg_id)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid cursor format",
+        )
 
 
 class ChatService:
@@ -225,7 +267,7 @@ class ChatService:
         self,
         character_id: uuid.UUID,
         user_id: uuid.UUID,
-        cursor: datetime | None,
+        cursor: MessageCursor | None,
         limit: int,
     ) -> MessageListResponse:
         """Retrieve paginated message history for a character's conversation."""
@@ -248,7 +290,7 @@ class ChatService:
                 detail="Conversation not found",
             )
 
-        # Cursor-based query
+        # Cursor-based query with composite (created_at, id) cursor
         stmt = (
             select(Message)
             .where(Message.conversation_id == conversation.id)
@@ -256,7 +298,10 @@ class ChatService:
             .limit(limit + 1)
         )
         if cursor is not None:
-            stmt = stmt.where(Message.created_at < cursor)
+            stmt = stmt.where(
+                tuple_(Message.created_at, Message.id)
+                < tuple_(cursor.ts, cursor.id),
+            )
 
         result = await self.db.execute(stmt)
         rows = result.scalars().all()
@@ -266,7 +311,7 @@ class ChatService:
 
         next_cursor: str | None = None
         if has_more and items:
-            next_cursor = items[-1].created_at.isoformat()
+            next_cursor = _encode_cursor(items[-1].created_at, items[-1].id)
 
         return MessageListResponse(
             items=[

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -14,6 +14,7 @@ os.environ.setdefault(
     "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
 )
 
+import base64  # noqa: E402
 import json  # noqa: E402
 import uuid  # noqa: E402
 from collections.abc import AsyncGenerator  # noqa: E402
@@ -27,6 +28,7 @@ from httpx import ASGITransport, AsyncClient  # noqa: E402
 
 from app.dependencies import get_current_user, get_db  # noqa: E402
 from app.main import app  # noqa: E402
+from app.services.chat_service import _encode_cursor  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -462,7 +464,7 @@ class TestGetMessages:
 
     @pytest.mark.asyncio
     async def test_get_messages_with_cursor(self, client: AsyncClient) -> None:
-        """Returns 200 with messages older than cursor."""
+        """Returns 200 with messages older than cursor (base64 composite cursor)."""
         from app.schemas.chat import MessageListResponse
 
         mock_response = MessageListResponse(
@@ -471,13 +473,17 @@ class TestGetMessages:
             has_more=False,
         )
 
+        cursor_ts = datetime(2026, 2, 23, 14, 30, 0, tzinfo=UTC)
+        cursor_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440088")
+        encoded_cursor = _encode_cursor(cursor_ts, cursor_id)
+
         with patch(
             "app.services.chat_service.ChatService.get_messages",
             return_value=mock_response,
         ):
             resp = await client.get(
                 f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
-                "?cursor=2026-02-23T14:30:00%2B00:00",
+                f"?cursor={encoded_cursor}",
             )
 
         assert resp.status_code == 200
@@ -590,6 +596,7 @@ class TestGetMessages:
         from app.schemas.chat import MessageItem, MessageListResponse
 
         now = datetime.now(tz=UTC)
+        last_item_id = uuid.uuid4()
         items = [
             MessageItem(
                 id=str(uuid.uuid4()),
@@ -599,11 +606,21 @@ class TestGetMessages:
                 metadata=None,
                 created_at=now - timedelta(minutes=i),
             )
-            for i in range(5)
+            for i in range(4)
         ]
+        items.append(
+            MessageItem(
+                id=str(last_item_id),
+                role="user",
+                content="msg 4",
+                media_url=None,
+                metadata=None,
+                created_at=now - timedelta(minutes=4),
+            ),
+        )
         mock_response = MessageListResponse(
             items=items,
-            next_cursor=(now - timedelta(minutes=4)).isoformat(),
+            next_cursor=_encode_cursor(now - timedelta(minutes=4), last_item_id),
             has_more=True,
         )
 
@@ -932,11 +949,12 @@ class TestGetMessagesAdditional:
         self,
         client: AsyncClient,
     ) -> None:
-        """next_cursor is a valid ISO 8601 string when has_more is true."""
+        """next_cursor is a valid base64 JSON string with ts and id when has_more is true."""
         from app.schemas.chat import MessageItem, MessageListResponse
 
         now = datetime.now(tz=UTC)
-        cursor_value = (now - timedelta(minutes=10)).isoformat()
+        last_id = uuid.uuid4()
+        cursor_value = _encode_cursor(now - timedelta(minutes=10), last_id)
         items = [
             MessageItem(
                 id=str(uuid.uuid4()),
@@ -962,8 +980,14 @@ class TestGetMessagesAdditional:
             )
 
         data = resp.json()
-        # Verify next_cursor is a parseable ISO 8601 string
-        datetime.fromisoformat(data["next_cursor"])
+        # Verify next_cursor is a valid base64 JSON with ts and id
+        raw_cursor = data["next_cursor"]
+        padded = raw_cursor + "=" * (-len(raw_cursor) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(padded))
+        assert "ts" in decoded
+        assert "id" in decoded
+        datetime.fromisoformat(decoded["ts"])
+        uuid.UUID(decoded["id"])
 
     @pytest.mark.asyncio
     async def test_get_messages_conversation_not_found_returns_404(
@@ -986,3 +1010,214 @@ class TestGetMessagesAdditional:
 
         assert resp.status_code == 404
         assert resp.json()["detail"] == "Conversation not found"
+
+    # --- R1: Invalid cursor (not base64) returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_invalid_cursor_not_base64_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor that is not valid base64 returns 400."""
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            "?cursor=!!!not-base64!!!",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- R2: Invalid cursor (valid base64, invalid JSON) returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_invalid_cursor_base64_not_json_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor with valid base64 but not valid JSON returns 400."""
+        encoded = base64.urlsafe_b64encode(b"not json at all").decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- R3: Invalid cursor (valid JSON, missing ts) returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_invalid_cursor_missing_ts_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON missing 'ts' field returns 400."""
+        payload = json.dumps({"id": str(uuid.uuid4())}).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- R4: Invalid cursor (valid JSON, missing id) returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_invalid_cursor_missing_id_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON missing 'id' field returns 400."""
+        payload = json.dumps({"ts": "2026-02-23T14:30:00+00:00"}).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- R5: Invalid cursor (valid JSON, ts not ISO 8601) returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_invalid_cursor_bad_ts_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON with non-ISO 'ts' field returns 400."""
+        payload = json.dumps(
+            {"ts": "not-a-timestamp", "id": str(uuid.uuid4())},
+        ).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- R6: Invalid cursor (valid JSON, id not UUID) returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_invalid_cursor_bad_id_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON with non-UUID 'id' field returns 400."""
+        payload = json.dumps(
+            {"ts": "2026-02-23T14:30:00+00:00", "id": "not-a-uuid"},
+        ).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- R7: Valid base64 cursor is accepted ---
+
+    @pytest.mark.asyncio
+    async def test_valid_base64_cursor_accepted(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Valid base64 composite cursor is accepted and returns 200."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        cursor_ts = datetime(2026, 2, 23, 14, 30, 0, tzinfo=UTC)
+        cursor_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440088")
+        encoded_cursor = _encode_cursor(cursor_ts, cursor_id)
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+                f"?cursor={encoded_cursor}",
+            )
+
+        assert resp.status_code == 200
+
+    # --- R8: next_cursor decodes to JSON with ts and id ---
+
+    @pytest.mark.asyncio
+    async def test_next_cursor_decodes_to_ts_and_id(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """next_cursor in response decodes to JSON with valid ts and id fields."""
+        from app.schemas.chat import MessageItem, MessageListResponse
+
+        now = datetime.now(tz=UTC)
+        last_id = uuid.uuid4()
+        items = [
+            MessageItem(
+                id=str(last_id),
+                role="user",
+                content="Hello",
+                media_url=None,
+                metadata=None,
+                created_at=now,
+            ),
+        ]
+        mock_response = MessageListResponse(
+            items=items,
+            next_cursor=_encode_cursor(now, last_id),
+            has_more=True,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=1",
+            )
+
+        data = resp.json()
+        raw_cursor = data["next_cursor"]
+        padded = raw_cursor + "=" * (-len(raw_cursor) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(padded))
+        assert "ts" in decoded
+        assert "id" in decoded
+        # ts is valid ISO 8601
+        datetime.fromisoformat(decoded["ts"])
+        # id is valid UUID
+        uuid.UUID(decoded["id"])
+
+    # --- R9: Empty cursor string returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_empty_cursor_string_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Empty cursor string returns 400."""
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            "?cursor=",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- Old format cursor (plain ISO timestamp) returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_old_format_cursor_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Plain ISO 8601 timestamp cursor (old format) returns 400."""
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            "?cursor=2026-02-23T14:30:00%2B00:00",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -1221,3 +1221,507 @@ class TestGetMessagesAdditional:
         )
         assert resp.status_code == 400
         assert resp.json()["detail"] == "Invalid cursor format"
+
+
+# ---------------------------------------------------------------------------
+# Pagination edge-case route tests (backend-tester: P01-07)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessagesPaginationEdgeCases:
+    """Edge-case route tests for cursor-based pagination (P01-07)."""
+
+    # --- Cursor with extra fields still works (forward-compatible) ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_with_extra_fields_accepted(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON with extra fields beyond ts and id is still accepted."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        payload = json.dumps({
+            "ts": "2026-02-23T14:30:00+00:00",
+            "id": str(uuid.uuid4()),
+            "extra_field": "should_be_ignored",
+        }).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+                f"?cursor={encoded}",
+            )
+
+        assert resp.status_code == 200
+
+    # --- Cursor with valid base64 but empty JSON object ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_empty_json_object_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor with valid base64 encoding of empty JSON object returns 400."""
+        payload = json.dumps({}).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- Cursor with valid base64 but JSON array instead of object ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_json_array_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor with valid base64 encoding of JSON array returns 400."""
+        payload = json.dumps(["2026-02-23T14:30:00+00:00", str(uuid.uuid4())]).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- Cursor with ts as integer (wrong type) ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_ts_as_integer_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON with ts as integer instead of ISO string returns 400."""
+        payload = json.dumps({
+            "ts": 1234567890,
+            "id": str(uuid.uuid4()),
+        }).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- Cursor with id as integer (wrong type) ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_id_as_integer_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON with id as integer instead of UUID string returns 400."""
+        payload = json.dumps({
+            "ts": "2026-02-23T14:30:00+00:00",
+            "id": 12345,
+        }).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- limit=1 boundary ---
+
+    @pytest.mark.asyncio
+    async def test_limit_equals_one_accepted(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """limit=1 is accepted and returns at most 1 item."""
+        from app.schemas.chat import MessageItem, MessageListResponse
+
+        now = datetime.now(tz=UTC)
+        item = MessageItem(
+            id=str(uuid.uuid4()),
+            role="user",
+            content="Hello",
+            media_url=None,
+            metadata=None,
+            created_at=now,
+        )
+        mock_response = MessageListResponse(
+            items=[item],
+            next_cursor=_encode_cursor(now, uuid.uuid4()),
+            has_more=True,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=1",
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) == 1
+
+    # --- limit=100 boundary ---
+
+    @pytest.mark.asyncio
+    async def test_limit_equals_100_accepted(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """limit=100 is accepted (maximum allowed)."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=100",
+            )
+
+        assert resp.status_code == 200
+
+    # --- Negative limit returns 422 ---
+
+    @pytest.mark.asyncio
+    async def test_negative_limit_returns_422(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Negative limit returns 422."""
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=-1",
+        )
+        assert resp.status_code == 422
+
+    # --- Non-integer limit returns 422 ---
+
+    @pytest.mark.asyncio
+    async def test_non_integer_limit_returns_422(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Non-integer limit value returns 422."""
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=abc",
+        )
+        assert resp.status_code == 422
+
+    # --- Cursor with null bytes in base64 ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_with_null_bytes_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor containing null bytes encoded in base64 returns 400."""
+        encoded = base64.urlsafe_b64encode(b"\x00\x00\x00").decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- Cursor with extremely long string returns 400 ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_very_long_string_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Very long cursor string returns 400 (not a valid cursor)."""
+        long_cursor = base64.urlsafe_b64encode(b"x" * 10000).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={long_cursor}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- Multi-page sequential walk via route ---
+
+    @pytest.mark.asyncio
+    async def test_multi_page_walk_returns_no_duplicates(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Sequential page walk using next_cursor returns no duplicate IDs."""
+        from app.schemas.chat import MessageItem, MessageListResponse
+
+        now = datetime.now(tz=UTC)
+        all_ids = [uuid.uuid4() for _ in range(6)]
+
+        # Page 1: items 0-2, has_more=True
+        page1_items = [
+            MessageItem(
+                id=str(all_ids[i]),
+                role="user",
+                content=f"msg{i}",
+                media_url=None,
+                metadata=None,
+                created_at=now - timedelta(minutes=i),
+            )
+            for i in range(3)
+        ]
+        page1_cursor = _encode_cursor(
+            now - timedelta(minutes=2), all_ids[2],
+        )
+        page1_response = MessageListResponse(
+            items=page1_items,
+            next_cursor=page1_cursor,
+            has_more=True,
+        )
+
+        # Page 2: items 3-5, has_more=False
+        page2_items = [
+            MessageItem(
+                id=str(all_ids[i]),
+                role="user",
+                content=f"msg{i}",
+                media_url=None,
+                metadata=None,
+                created_at=now - timedelta(minutes=i),
+            )
+            for i in range(3, 6)
+        ]
+        page2_response = MessageListResponse(
+            items=page2_items,
+            next_cursor=None,
+            has_more=False,
+        )
+
+        call_count = 0
+
+        def _mock_get_messages(*args: object, **kwargs: object) -> MessageListResponse:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return page1_response
+            return page2_response
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            side_effect=_mock_get_messages,
+        ):
+            # First page
+            resp1 = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=3",
+            )
+            data1 = resp1.json()
+            assert resp1.status_code == 200
+            assert len(data1["items"]) == 3
+            assert data1["has_more"] is True
+            cursor = data1["next_cursor"]
+
+            # Second page
+            resp2 = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+                f"?limit=3&cursor={cursor}",
+            )
+            data2 = resp2.json()
+            assert resp2.status_code == 200
+            assert len(data2["items"]) == 3
+            assert data2["has_more"] is False
+
+        # No duplicate IDs across pages
+        ids1 = {m["id"] for m in data1["items"]}
+        ids2 = {m["id"] for m in data2["items"]}
+        assert ids1.isdisjoint(ids2)
+        assert len(ids1 | ids2) == 6
+
+    # --- next_cursor in response matches last item exactly ---
+
+    @pytest.mark.asyncio
+    async def test_next_cursor_matches_last_item_in_response(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """next_cursor ts and id match the last item in the response items array."""
+        from app.schemas.chat import MessageItem, MessageListResponse
+
+        now = datetime.now(tz=UTC)
+        last_id = uuid.uuid4()
+        last_ts = now - timedelta(minutes=5)
+
+        items = [
+            MessageItem(
+                id=str(uuid.uuid4()),
+                role="user",
+                content="first",
+                media_url=None,
+                metadata=None,
+                created_at=now,
+            ),
+            MessageItem(
+                id=str(last_id),
+                role="assistant",
+                content="second",
+                media_url=None,
+                metadata=None,
+                created_at=last_ts,
+            ),
+        ]
+        mock_response = MessageListResponse(
+            items=items,
+            next_cursor=_encode_cursor(last_ts, last_id),
+            has_more=True,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages?limit=2",
+            )
+
+        data = resp.json()
+        raw_cursor = data["next_cursor"]
+        padded = raw_cursor + "=" * (-len(raw_cursor) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(padded))
+
+        # ts and id must match last item
+        last_item = data["items"][-1]
+        assert decoded["id"] == last_item["id"]
+
+    # --- Cursor with padding characters is still decodable ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_with_base64_padding_accepted(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor that includes trailing = padding is accepted."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        payload = json.dumps({
+            "ts": "2026-02-23T14:30:00+00:00",
+            "id": str(uuid.uuid4()),
+        }).encode()
+        # Keep padding (do not strip =)
+        encoded_with_padding = base64.urlsafe_b64encode(payload).decode()
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ):
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+                f"?cursor={encoded_with_padding}",
+            )
+
+        assert resp.status_code == 200
+
+    # --- Cursor with whitespace-only base64 decoded content ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_whitespace_base64_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor that decodes to whitespace-only bytes returns 400."""
+        encoded = base64.urlsafe_b64encode(b"   ").decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- Default limit (no limit param) returns 200 ---
+
+    @pytest.mark.asyncio
+    async def test_default_limit_returns_200(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Omitting limit param uses default (20) and returns 200."""
+        from app.schemas.chat import MessageListResponse
+
+        mock_response = MessageListResponse(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        with patch(
+            "app.services.chat_service.ChatService.get_messages",
+            return_value=mock_response,
+        ) as mock_get:
+            resp = await client.get(
+                f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages",
+            )
+
+        assert resp.status_code == 200
+        # Verify the service was called with limit=20
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs.get("limit") == 20 or call_kwargs[1].get("limit") == 20
+
+    # --- Cursor with ts as null ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_ts_null_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON with ts=null returns 400."""
+        payload = json.dumps({
+            "ts": None,
+            "id": str(uuid.uuid4()),
+        }).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"
+
+    # --- Cursor with id as null ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_id_null_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Cursor JSON with id=null returns 400."""
+        payload = json.dumps({
+            "ts": "2026-02-23T14:30:00+00:00",
+            "id": None,
+        }).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        resp = await client.get(
+            f"/api/v1/characters/{FAKE_CHARACTER_ID}/messages"
+            f"?cursor={encoded}",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid cursor format"

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -14,6 +14,7 @@ os.environ.setdefault(
 )
 
 import asyncio  # noqa: E402
+import base64  # noqa: E402
 import json  # noqa: E402
 import uuid  # noqa: E402
 from collections.abc import AsyncGenerator  # noqa: E402
@@ -25,7 +26,10 @@ import pytest  # noqa: E402
 
 from app.services.chat_service import (  # noqa: E402
     ChatService,
+    MessageCursor,
+    _decode_cursor,
     _deduplicate_memories,
+    _encode_cursor,
     _persist_exchange,
 )
 
@@ -1234,7 +1238,7 @@ class TestGetMessagesAdditional:
 
     @pytest.mark.asyncio
     async def test_cursor_filter_applied(self) -> None:
-        """get_messages applies cursor filter correctly."""
+        """get_messages applies composite cursor filter correctly."""
         mock_db = AsyncMock()
         service = ChatService(mock_db)
 
@@ -1257,11 +1261,14 @@ class TestGetMessagesAdditional:
 
         mock_db.execute = AsyncMock(side_effect=_mock_execute)
 
-        cursor_time = datetime.now(tz=UTC) - timedelta(hours=1)
+        cursor = MessageCursor(
+            ts=datetime.now(tz=UTC) - timedelta(hours=1),
+            id=uuid.uuid4(),
+        )
         response = await service.get_messages(
             character_id=FAKE_CHARACTER_ID,
             user_id=FAKE_USER_ID,
-            cursor=cursor_time,
+            cursor=cursor,
             limit=20,
         )
 
@@ -1307,7 +1314,7 @@ class TestGetMessagesAdditional:
 
     @pytest.mark.asyncio
     async def test_next_cursor_matches_last_item(self) -> None:
-        """next_cursor equals the last item's created_at when has_more is true."""
+        """next_cursor encodes the last item's (created_at, id) as base64 JSON."""
         mock_db = AsyncMock()
         service = ChatService(mock_db)
 
@@ -1347,8 +1354,11 @@ class TestGetMessagesAdditional:
 
         assert response.has_more is True
         assert len(response.items) == 3
-        # next_cursor should be the created_at of the last returned item
-        assert response.next_cursor == messages[2].created_at.isoformat()
+        # next_cursor should be a base64-encoded JSON with ts and id of last item
+        assert response.next_cursor is not None
+        decoded = _decode_cursor(response.next_cursor)
+        assert decoded.ts == messages[2].created_at
+        assert decoded.id == messages[2].id
 
 
 # ---------------------------------------------------------------------------
@@ -1944,3 +1954,277 @@ class TestGetRecentMessages:
         result = await service._get_recent_messages(FAKE_CONVERSATION_ID)
 
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Composite cursor helper unit tests (U1-U7)
+# ---------------------------------------------------------------------------
+
+
+class TestCursorHelpers:
+    """Unit tests for _encode_cursor, _decode_cursor, and MessageCursor."""
+
+    # --- U1: _encode_cursor returns a string ---
+
+    def test_encode_cursor_returns_string(self) -> None:
+        """_encode_cursor returns a string."""
+        now = datetime.now(tz=UTC)
+        msg_id = uuid.uuid4()
+        result = _encode_cursor(now, msg_id)
+        assert isinstance(result, str)
+
+    # --- U2: _encode_cursor output is valid base64 ---
+
+    def test_encode_cursor_is_valid_base64(self) -> None:
+        """_encode_cursor output can be base64-decoded."""
+        now = datetime.now(tz=UTC)
+        msg_id = uuid.uuid4()
+        result = _encode_cursor(now, msg_id)
+        padded = result + "=" * (-len(result) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        # Should be valid JSON
+        payload = json.loads(decoded)
+        assert "ts" in payload
+        assert "id" in payload
+
+    # --- U3: _decode_cursor returns a MessageCursor ---
+
+    def test_decode_cursor_returns_message_cursor(self) -> None:
+        """_decode_cursor returns a MessageCursor instance."""
+        now = datetime.now(tz=UTC)
+        msg_id = uuid.uuid4()
+        encoded = _encode_cursor(now, msg_id)
+        result = _decode_cursor(encoded)
+        assert isinstance(result, MessageCursor)
+
+    # --- U4: _decode_cursor roundtrip returns correct ts and id ---
+
+    def test_decode_cursor_roundtrip_correct_values(self) -> None:
+        """decode(encode(ts, id)) returns the original ts and id."""
+        now = datetime.now(tz=UTC)
+        msg_id = uuid.uuid4()
+        encoded = _encode_cursor(now, msg_id)
+        decoded = _decode_cursor(encoded)
+        assert decoded.ts == now
+        assert decoded.id == msg_id
+
+    # --- U5: _decode_cursor with empty string raises 400 ---
+
+    def test_decode_cursor_empty_string_raises_400(self) -> None:
+        """_decode_cursor raises HTTPException(400) for empty string."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            _decode_cursor("")
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Invalid cursor format"
+
+    # --- U6: _decode_cursor with plain ISO timestamp (old format) raises 400 ---
+
+    def test_decode_cursor_plain_iso_raises_400(self) -> None:
+        """_decode_cursor raises HTTPException(400) for plain ISO timestamp."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            _decode_cursor("2026-02-23T14:30:00+00:00")
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Invalid cursor format"
+
+    # --- U7: _decode_cursor with valid base64 but missing ts raises 400 ---
+
+    def test_decode_cursor_missing_ts_raises_400(self) -> None:
+        """_decode_cursor raises HTTPException(400) when ts is missing."""
+        from fastapi import HTTPException
+
+        payload = json.dumps({"id": str(uuid.uuid4())}).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        with pytest.raises(HTTPException) as exc_info:
+            _decode_cursor(encoded)
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Invalid cursor format"
+
+    # --- Additional: _decode_cursor with garbage bytes raises 400 ---
+
+    def test_decode_cursor_garbage_raises_400(self) -> None:
+        """_decode_cursor raises HTTPException(400) for random garbage."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            _decode_cursor("abcxyz123456")
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Invalid cursor format"
+
+    # --- S4: Roundtrip test ---
+
+    def test_cursor_roundtrip(self) -> None:
+        """Encode then decode roundtrip preserves values."""
+        ts = datetime(2026, 2, 23, 14, 30, 0, tzinfo=UTC)
+        msg_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440088")
+        encoded = _encode_cursor(ts, msg_id)
+        decoded = _decode_cursor(encoded)
+        assert decoded.ts == ts
+        assert decoded.id == msg_id
+
+    # --- S5: _decode_cursor raises HTTPException(400) for garbage ---
+
+    def test_decode_raises_for_garbage(self) -> None:
+        """_decode_cursor raises 400 for non-decodable input."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            _decode_cursor("!!!totally-invalid!!!")
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Same-timestamp tiebreaker tests (S1-S3)
+# ---------------------------------------------------------------------------
+
+
+class TestSameTimestampPagination:
+    """Tests for same-timestamp tiebreaker in composite cursor pagination."""
+
+    # --- S1: Two messages with same created_at but different ids ---
+
+    @pytest.mark.asyncio
+    async def test_same_timestamp_different_ids_paginated_correctly(self) -> None:
+        """Two messages with same created_at are correctly paginated with limit=1."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        now = datetime.now(tz=UTC)
+        # Two messages with SAME created_at, different ids
+        msg1 = _make_fake_message(content="first", offset_minutes=0)
+        msg1.created_at = now
+        msg1.id = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+        msg2 = _make_fake_message(content="second", offset_minutes=0)
+        msg2.created_at = now
+        msg2.id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+        call_count = 0
+
+        # First call: returns both messages (limit=1, so 2 = limit+1 returned)
+        async def _mock_execute_page1(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                # msg1 has larger id so comes first in DESC order
+                result.scalars.return_value.all.return_value = [msg1, msg2]
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute_page1)
+
+        # First page
+        response1 = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=1,
+        )
+
+        assert len(response1.items) == 1
+        assert response1.items[0].content == "first"
+        assert response1.has_more is True
+        assert response1.next_cursor is not None
+
+        # Verify cursor encodes the last returned item
+        decoded = _decode_cursor(response1.next_cursor)
+        assert decoded.ts == msg1.created_at
+        assert decoded.id == msg1.id
+
+    # --- S2: next_cursor encodes to valid base64 JSON ---
+
+    @pytest.mark.asyncio
+    async def test_next_cursor_is_valid_base64_json(self) -> None:
+        """next_cursor in get_messages response is valid base64 JSON with ts and id."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        messages = [
+            _make_fake_message(content=f"msg{i}", offset_minutes=i) for i in range(3)
+        ]
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = messages
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=2,
+        )
+
+        assert response.next_cursor is not None
+        # Decode and verify structure
+        padded = response.next_cursor + "=" * (-len(response.next_cursor) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(padded))
+        assert "ts" in decoded
+        assert "id" in decoded
+        datetime.fromisoformat(decoded["ts"])
+        uuid.UUID(decoded["id"])
+
+    # --- S3: Service accepts MessageCursor and tuple comparison works ---
+
+    @pytest.mark.asyncio
+    async def test_service_accepts_message_cursor(self) -> None:
+        """Service method accepts MessageCursor and executes query without error."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+        cursor = MessageCursor(
+            ts=datetime.now(tz=UTC),
+            id=uuid.uuid4(),
+        )
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=cursor,
+            limit=20,
+        )
+
+        assert response.items == []
+        assert response.has_more is False

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -2228,3 +2228,613 @@ class TestSameTimestampPagination:
 
         assert response.items == []
         assert response.has_more is False
+
+
+# ---------------------------------------------------------------------------
+# Pagination edge-case service tests (backend-tester: P01-07)
+# ---------------------------------------------------------------------------
+
+
+class TestPaginationEdgeCases:
+    """Edge-case service tests for cursor-based pagination (P01-07)."""
+
+    # --- Helper for building mock_execute with call_count pattern ---
+
+    @staticmethod
+    def _build_mock_execute(
+        mock_char: MagicMock,
+        mock_conv: MagicMock,
+        messages: list[MagicMock],
+    ):
+        """Return an async side_effect function for mock_db.execute.
+
+        Call 1 -> character lookup, Call 2 -> conversation lookup,
+        Call 3+ -> message query.
+        """
+        call_count = 0
+
+        async def _mock_execute(stmt: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = messages
+            return result
+
+        return _mock_execute
+
+    # --- Exactly N messages where N=limit (has_more boundary) ---
+
+    @pytest.mark.asyncio
+    async def test_exactly_limit_messages_has_more_false(self) -> None:
+        """When DB returns exactly limit rows (not limit+1), has_more is False."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        # Create exactly 5 messages (limit=5 means service queries 6, gets 5 back)
+        messages = [
+            _make_fake_message(content=f"msg{i}", offset_minutes=i)
+            for i in range(5)
+        ]
+
+        mock_db.execute = AsyncMock(
+            side_effect=self._build_mock_execute(mock_char, mock_conv, messages),
+        )
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=5,
+        )
+
+        assert len(response.items) == 5
+        assert response.has_more is False
+        assert response.next_cursor is None
+
+    # --- Exactly limit+1 messages (has_more=True, returns limit items) ---
+
+    @pytest.mark.asyncio
+    async def test_limit_plus_one_messages_has_more_true(self) -> None:
+        """When DB returns limit+1 rows, has_more is True and only limit items returned."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        # Create limit+1 = 6 messages for limit=5
+        messages = [
+            _make_fake_message(content=f"msg{i}", offset_minutes=i)
+            for i in range(6)
+        ]
+
+        mock_db.execute = AsyncMock(
+            side_effect=self._build_mock_execute(mock_char, mock_conv, messages),
+        )
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=5,
+        )
+
+        assert len(response.items) == 5
+        assert response.has_more is True
+        assert response.next_cursor is not None
+
+    # --- Single message in conversation ---
+
+    @pytest.mark.asyncio
+    async def test_single_message_returns_correctly(self) -> None:
+        """Conversation with exactly one message returns it correctly."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        msg = _make_fake_message(content="only message", offset_minutes=0)
+
+        mock_db.execute = AsyncMock(
+            side_effect=self._build_mock_execute(mock_char, mock_conv, [msg]),
+        )
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=20,
+        )
+
+        assert len(response.items) == 1
+        assert response.items[0].content == "only message"
+        assert response.has_more is False
+        assert response.next_cursor is None
+
+    # --- Same-timestamp with 3 messages: multi-page walk ---
+
+    @pytest.mark.asyncio
+    async def test_three_same_timestamp_messages_paginate_correctly(self) -> None:
+        """Three messages with identical created_at paginate without duplicates."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        now = datetime.now(tz=UTC)
+
+        # Three messages at same timestamp, different UUIDs (ordered DESC by id)
+        msg_a = _make_fake_message(content="msg_a")
+        msg_a.created_at = now
+        msg_a.id = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+        msg_b = _make_fake_message(content="msg_b")
+        msg_b.created_at = now
+        msg_b.id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+        msg_c = _make_fake_message(content="msg_c")
+        msg_c.created_at = now
+        msg_c.id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+        # Page 1: limit=1, returns [msg_a, msg_b] (limit+1=2)
+        page1_call_count = 0
+
+        async def _mock_execute_page1(stmt: object) -> MagicMock:
+            nonlocal page1_call_count
+            page1_call_count += 1
+            result = MagicMock()
+            if page1_call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif page1_call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                # msg_a has larger id so comes first in DESC order
+                result.scalars.return_value.all.return_value = [msg_a, msg_b]
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute_page1)
+
+        # First page
+        response1 = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=1,
+        )
+
+        assert len(response1.items) == 1
+        assert response1.items[0].content == "msg_a"
+        assert response1.has_more is True
+
+        # Decode cursor and verify it points to msg_a
+        cursor1 = _decode_cursor(response1.next_cursor)
+        assert cursor1.ts == now
+        assert cursor1.id == msg_a.id
+
+        # Page 2: cursor from page1, returns [msg_b, msg_c] (limit+1=2)
+        page2_call_count = 0
+
+        async def _mock_execute_page2(stmt: object) -> MagicMock:
+            nonlocal page2_call_count
+            page2_call_count += 1
+            result = MagicMock()
+            if page2_call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif page2_call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = [msg_b, msg_c]
+            return result
+
+        mock_db.execute = AsyncMock(side_effect=_mock_execute_page2)
+
+        response2 = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=cursor1,
+            limit=1,
+        )
+
+        assert len(response2.items) == 1
+        assert response2.items[0].content == "msg_b"
+        assert response2.has_more is True
+
+        # Page 3: returns [msg_c] only (no extra row)
+        page3_call_count = 0
+
+        async def _mock_execute_page3(stmt: object) -> MagicMock:
+            nonlocal page3_call_count
+            page3_call_count += 1
+            result = MagicMock()
+            if page3_call_count == 1:
+                result.scalar_one_or_none.return_value = mock_char
+            elif page3_call_count == 2:
+                result.scalar_one_or_none.return_value = mock_conv
+            else:
+                result.scalars.return_value.all.return_value = [msg_c]
+            return result
+
+        cursor2 = _decode_cursor(response2.next_cursor)
+        mock_db.execute = AsyncMock(side_effect=_mock_execute_page3)
+
+        response3 = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=cursor2,
+            limit=1,
+        )
+
+        assert len(response3.items) == 1
+        assert response3.items[0].content == "msg_c"
+        assert response3.has_more is False
+
+        # All three messages appeared exactly once across all pages
+        all_contents = [
+            response1.items[0].content,
+            response2.items[0].content,
+            response3.items[0].content,
+        ]
+        assert sorted(all_contents) == sorted(["msg_a", "msg_b", "msg_c"])
+
+    # --- Cursor with future timestamp returns all messages ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_with_future_timestamp_returns_all_messages(self) -> None:
+        """Cursor with far-future timestamp returns messages older than the cursor."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        now = datetime.now(tz=UTC)
+        messages = [
+            _make_fake_message(content=f"msg{i}", offset_minutes=i)
+            for i in range(3)
+        ]
+
+        mock_db.execute = AsyncMock(
+            side_effect=self._build_mock_execute(mock_char, mock_conv, messages),
+        )
+
+        future_cursor = MessageCursor(
+            ts=now + timedelta(days=365),
+            id=uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+        )
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=future_cursor,
+            limit=20,
+        )
+
+        # All 3 messages are older than the future cursor, so all returned
+        assert len(response.items) == 3
+
+    # --- Cursor pointing past oldest message returns empty ---
+
+    @pytest.mark.asyncio
+    async def test_cursor_past_oldest_message_returns_empty(self) -> None:
+        """Cursor older than all messages returns empty items."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        # No messages match the cursor filter (all messages are newer)
+        mock_db.execute = AsyncMock(
+            side_effect=self._build_mock_execute(mock_char, mock_conv, []),
+        )
+
+        old_cursor = MessageCursor(
+            ts=datetime(2020, 1, 1, tzinfo=UTC),
+            id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        )
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=old_cursor,
+            limit=20,
+        )
+
+        assert response.items == []
+        assert response.has_more is False
+        assert response.next_cursor is None
+
+    # --- Multi-page walk: 3 pages of 3 messages each ---
+
+    @pytest.mark.asyncio
+    async def test_multi_page_walk_three_pages(self) -> None:
+        """Multi-page walk through 9 messages in pages of 3 returns all without duplicates."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        now = datetime.now(tz=UTC)
+        all_messages = []
+        for i in range(9):
+            msg = _make_fake_message(content=f"msg{i}", offset_minutes=i)
+            msg.created_at = now - timedelta(minutes=i)
+            msg.id = uuid.UUID(f"00000000-0000-0000-0000-{i:012d}")
+            all_messages.append(msg)
+
+        all_collected_ids: set[str] = set()
+        cursor: MessageCursor | None = None
+
+        for page_num in range(3):
+            page_call_count = 0
+            start = page_num * 3
+            # Simulate DB returning limit+1=4 rows for first 2 pages, 3 for last
+            if page_num < 2:
+                page_msgs = all_messages[start : start + 4]
+            else:
+                page_msgs = all_messages[start : start + 3]
+
+            async def _mock_execute(
+                stmt: object,
+                _msgs: list[MagicMock] = page_msgs,
+            ) -> MagicMock:
+                nonlocal page_call_count
+                page_call_count += 1
+                result = MagicMock()
+                if page_call_count == 1:
+                    result.scalar_one_or_none.return_value = mock_char
+                elif page_call_count == 2:
+                    result.scalar_one_or_none.return_value = mock_conv
+                else:
+                    result.scalars.return_value.all.return_value = _msgs
+                return result
+
+            mock_db.execute = AsyncMock(side_effect=_mock_execute)
+
+            response = await service.get_messages(
+                character_id=FAKE_CHARACTER_ID,
+                user_id=FAKE_USER_ID,
+                cursor=cursor,
+                limit=3,
+            )
+
+            page_ids = {item.id for item in response.items}
+            # No duplicates between this page and previously collected
+            assert page_ids.isdisjoint(all_collected_ids), (
+                f"Duplicate IDs found on page {page_num + 1}"
+            )
+            all_collected_ids.update(page_ids)
+
+            if response.next_cursor is not None:
+                cursor = _decode_cursor(response.next_cursor)
+            else:
+                cursor = None
+
+        # All 9 messages collected
+        assert len(all_collected_ids) == 9
+
+    # --- next_cursor is None when has_more is False ---
+
+    @pytest.mark.asyncio
+    async def test_next_cursor_none_when_has_more_false(self) -> None:
+        """next_cursor is always None when has_more is False."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        # 2 messages with limit=5 -> no overflow -> has_more=False
+        messages = [
+            _make_fake_message(content=f"msg{i}", offset_minutes=i)
+            for i in range(2)
+        ]
+
+        mock_db.execute = AsyncMock(
+            side_effect=self._build_mock_execute(mock_char, mock_conv, messages),
+        )
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=5,
+        )
+
+        assert response.has_more is False
+        assert response.next_cursor is None
+
+    # --- Items have correct MessageItem fields ---
+
+    @pytest.mark.asyncio
+    async def test_items_have_correct_fields(self) -> None:
+        """Each item in response has all required MessageItem fields."""
+        mock_db = AsyncMock()
+        service = ChatService(mock_db)
+
+        mock_char = _make_fake_character()
+        mock_conv = _make_fake_conversation()
+
+        msg = _make_fake_message(content="Test content", offset_minutes=0)
+        msg.media_url = "https://example.com/image.jpg"
+        msg.metadata_ = {"key": "value"}
+
+        mock_db.execute = AsyncMock(
+            side_effect=self._build_mock_execute(mock_char, mock_conv, [msg]),
+        )
+
+        response = await service.get_messages(
+            character_id=FAKE_CHARACTER_ID,
+            user_id=FAKE_USER_ID,
+            cursor=None,
+            limit=20,
+        )
+
+        assert len(response.items) == 1
+        item = response.items[0]
+        assert item.id == str(msg.id)
+        assert item.role == msg.role
+        assert item.content == msg.content
+        assert item.media_url == msg.media_url
+        assert item.metadata == msg.metadata_
+        assert item.created_at == msg.created_at
+
+
+# ---------------------------------------------------------------------------
+# Cursor helper edge-case tests (backend-tester: P01-07)
+# ---------------------------------------------------------------------------
+
+
+class TestCursorHelpersEdgeCases:
+    """Additional edge-case tests for cursor encode/decode helpers."""
+
+    # --- Encode with timezone-aware datetime ---
+
+    def test_encode_with_utc_timezone(self) -> None:
+        """_encode_cursor works correctly with UTC timezone-aware datetime."""
+        ts = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+        msg_id = uuid.uuid4()
+        encoded = _encode_cursor(ts, msg_id)
+        decoded = _decode_cursor(encoded)
+        assert decoded.ts == ts
+        assert decoded.id == msg_id
+
+    # --- Roundtrip with microseconds preserved ---
+
+    def test_roundtrip_preserves_microseconds(self) -> None:
+        """Cursor roundtrip preserves microsecond precision in timestamp."""
+        ts = datetime(2026, 2, 23, 14, 30, 0, 123456, tzinfo=UTC)
+        msg_id = uuid.uuid4()
+        encoded = _encode_cursor(ts, msg_id)
+        decoded = _decode_cursor(encoded)
+        assert decoded.ts == ts
+        assert decoded.ts.microsecond == 123456
+
+    # --- Encode with uuid.UUID edge values ---
+
+    def test_encode_with_nil_uuid(self) -> None:
+        """_encode_cursor works with nil UUID (all zeros)."""
+        ts = datetime.now(tz=UTC)
+        nil_uuid = uuid.UUID("00000000-0000-0000-0000-000000000000")
+        encoded = _encode_cursor(ts, nil_uuid)
+        decoded = _decode_cursor(encoded)
+        assert decoded.id == nil_uuid
+
+    def test_encode_with_max_uuid(self) -> None:
+        """_encode_cursor works with max UUID (all f's)."""
+        ts = datetime.now(tz=UTC)
+        max_uuid = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+        encoded = _encode_cursor(ts, max_uuid)
+        decoded = _decode_cursor(encoded)
+        assert decoded.id == max_uuid
+
+    # --- MessageCursor is frozen (immutable) ---
+
+    def test_message_cursor_is_frozen(self) -> None:
+        """MessageCursor dataclass is frozen (immutable)."""
+        from dataclasses import FrozenInstanceError
+
+        cursor = MessageCursor(
+            ts=datetime.now(tz=UTC),
+            id=uuid.uuid4(),
+        )
+        with pytest.raises(FrozenInstanceError):
+            cursor.ts = datetime.now(tz=UTC)  # type: ignore[misc]
+
+    def test_message_cursor_is_frozen_id(self) -> None:
+        """MessageCursor id field is also frozen."""
+        from dataclasses import FrozenInstanceError
+
+        cursor = MessageCursor(
+            ts=datetime.now(tz=UTC),
+            id=uuid.uuid4(),
+        )
+        with pytest.raises(FrozenInstanceError):
+            cursor.id = uuid.uuid4()  # type: ignore[misc]
+
+    # --- Decode with valid base64 that decodes to a JSON string (not object) ---
+
+    def test_decode_json_string_returns_400(self) -> None:
+        """_decode_cursor raises 400 for base64 JSON string value."""
+        from fastapi import HTTPException
+
+        payload = json.dumps("just a string").encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        with pytest.raises(HTTPException) as exc_info:
+            _decode_cursor(encoded)
+        assert exc_info.value.status_code == 400
+
+    # --- Decode with valid base64 JSON but ts is empty string ---
+
+    def test_decode_ts_empty_string_returns_400(self) -> None:
+        """_decode_cursor raises 400 when ts is an empty string."""
+        from fastapi import HTTPException
+
+        payload = json.dumps({"ts": "", "id": str(uuid.uuid4())}).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        with pytest.raises(HTTPException) as exc_info:
+            _decode_cursor(encoded)
+        assert exc_info.value.status_code == 400
+
+    # --- Decode with valid base64 JSON but id is empty string ---
+
+    def test_decode_id_empty_string_returns_400(self) -> None:
+        """_decode_cursor raises 400 when id is an empty string."""
+        from fastapi import HTTPException
+
+        payload = json.dumps({
+            "ts": "2026-02-23T14:30:00+00:00",
+            "id": "",
+        }).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        with pytest.raises(HTTPException) as exc_info:
+            _decode_cursor(encoded)
+        assert exc_info.value.status_code == 400
+
+    # --- Multiple roundtrips produce consistent results ---
+
+    def test_multiple_roundtrips_consistent(self) -> None:
+        """Encoding the same cursor multiple times produces the same string."""
+        ts = datetime(2026, 2, 23, 14, 30, 0, tzinfo=UTC)
+        msg_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440088")
+
+        encoded1 = _encode_cursor(ts, msg_id)
+        encoded2 = _encode_cursor(ts, msg_id)
+        assert encoded1 == encoded2
+
+    # --- Decode with base64 JSON containing timezone offsets ---
+
+    def test_decode_ts_with_positive_timezone_offset(self) -> None:
+        """_decode_cursor handles positive timezone offset in ts."""
+        payload = json.dumps({
+            "ts": "2026-02-23T17:30:00+03:00",
+            "id": str(uuid.uuid4()),
+        }).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        result = _decode_cursor(encoded)
+        assert result.ts.utcoffset().total_seconds() == 10800  # +03:00
+
+    # --- Decode with negative timezone offset ---
+
+    def test_decode_ts_with_negative_timezone_offset(self) -> None:
+        """_decode_cursor handles negative timezone offset in ts."""
+        msg_id = uuid.uuid4()
+        payload = json.dumps({
+            "ts": "2026-02-23T09:30:00-05:00",
+            "id": str(msg_id),
+        }).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode()
+        result = _decode_cursor(encoded)
+        assert result.ts.utcoffset().total_seconds() == -18000  # -05:00
+        assert result.id == msg_id

--- a/docs/features/messages-pagination.md
+++ b/docs/features/messages-pagination.md
@@ -1,0 +1,308 @@
+# Messages Pagination
+
+> Upgrades the message history endpoint to use a composite `(created_at, id)` cursor encoded as base64 URL-safe JSON, eliminating duplicate/skipped messages when timestamps collide and adding graceful error handling for invalid cursors.
+
+**Status**: Released
+**Added in**: Phase 1 (P01-07)
+**Platforms**: Backend
+**GitHub Issue**: #9
+
+---
+
+## Overview
+
+Messages pagination (P01-07) hardens the cursor-based pagination on the `GET /api/v1/characters/{character_id}/messages` endpoint that was initially delivered in P01-06 (chat-streaming). The original implementation used a plain ISO 8601 timestamp as the cursor, which has a correctness bug: when two messages share the same `created_at` value, the `created_at < $cursor` filter can skip one message or return it twice on different pages.
+
+This scenario is not theoretical. The `_persist_exchange` background task inserts the user message and assistant message in a single database transaction. PostgreSQL's `server_default=func.now()` assigns both rows the same `created_at` timestamp. If the client paginates and the cursor lands on that shared timestamp, the result set is ambiguous.
+
+P01-07 replaces the plain timestamp cursor with a composite `(created_at, id)` cursor. The UUID acts as a deterministic tiebreaker when timestamps collide. The cursor is encoded as base64 URL-safe JSON, making it opaque to clients and preventing manual construction. Invalid cursor values now return HTTP 400 instead of crashing with an unhandled 500 error.
+
+---
+
+## Architecture
+
+### How It Works (Data Flow)
+
+1. The mobile client sends `GET /api/v1/characters/{character_id}/messages` with an optional `cursor` query parameter and an optional `limit` parameter (default 20, max 100).
+2. The route handler extracts `user_id` from the JWT via the `get_current_user` dependency.
+3. If a `cursor` string is present, `_decode_cursor()` base64-decodes it, JSON-parses the result, and extracts a `datetime` (`ts`) and a `UUID` (`id`) into a frozen `MessageCursor` dataclass. Any failure at any step raises `HTTPException(400, "Invalid cursor format")`.
+4. `ChatService.get_messages()` validates character ownership (403 if mismatch) and looks up the conversation (404 if not found).
+5. The service builds a SQLAlchemy query ordered by `(created_at DESC, id DESC)` with `LIMIT = limit + 1`. If a cursor is provided, the query adds a row-value comparison filter: `(created_at, id) < (cursor.ts, cursor.id)`.
+6. The extra row (limit + 1) determines `has_more`. Only the first `limit` rows are returned.
+7. If `has_more` is true, `_encode_cursor()` serializes the last returned message's `(created_at, id)` as base64 URL-safe JSON to produce `next_cursor`.
+8. The response is returned as `MessageListResponse` with `items`, `next_cursor`, and `has_more`.
+
+### Cursor Encoding and Decoding
+
+The cursor is a base64url-encoded JSON object with two fields:
+
+```json
+{"ts": "2026-02-23T14:30:00+00:00", "id": "550e8400-e29b-41d4-a716-446655440088"}
+```
+
+**Encoding** (building `next_cursor` for the response):
+1. Take the last message's `created_at` (ISO 8601) and `id` (UUID string).
+2. Serialize as JSON: `{"ts": "<ISO 8601>", "id": "<UUID>"}`.
+3. Encode with `base64.urlsafe_b64encode()`.
+4. Strip trailing `=` padding characters.
+
+**Decoding** (parsing the `cursor` query parameter):
+1. Restore base64 padding: append `=` characters until `len(cursor) % 4 == 0`.
+2. `base64.urlsafe_b64decode()` the padded string.
+3. `json.loads()` the decoded bytes.
+4. Extract `ts` and parse with `datetime.fromisoformat()`.
+5. Extract `id` and parse with `uuid.UUID()`.
+6. Return a `MessageCursor(ts=..., id=...)` frozen dataclass.
+7. If any step fails, raise `HTTPException(status_code=400, detail="Invalid cursor format")`.
+
+### SQL Query Pattern
+
+The row-value comparison `(created_at, id) < ($cursor_ts, $cursor_id)` is standard SQL. PostgreSQL evaluates it as:
+
+```
+created_at < $cursor_ts
+OR (created_at = $cursor_ts AND id < $cursor_id)
+```
+
+This correctly handles the tiebreaker when two messages share the same timestamp. In SQLAlchemy, this is expressed using `sqlalchemy.tuple_()`:
+
+```python
+from sqlalchemy import tuple_
+
+stmt = stmt.where(
+    tuple_(Message.created_at, Message.id) < tuple_(cursor.ts, cursor.id)
+)
+```
+
+### Database Tables Involved
+
+| Table | Operation | Notes |
+|-------|-----------|-------|
+| `characters` | SELECT | Ownership check: `user_id = $user_id`, active check |
+| `conversations` | SELECT | Look up conversation by `character_id` |
+| `messages` | SELECT | Cursor-based pagination with `(created_at DESC, id DESC)` ordering |
+
+No new tables or columns were added. The existing composite index `idx_messages_conv_time` on `(conversation_id, created_at DESC)` supports the query. The `id` tiebreaker operates on the small result set (max `limit + 1` rows) after the index scan, so no additional index is needed.
+
+---
+
+## API Reference
+
+See [`docs/04-veri-api.md`](../04-veri-api.md) for the full API contract.
+
+### GET /api/v1/characters/{character_id}/messages
+
+**Auth**: Bearer JWT required
+**Success Status**: `200 OK`
+
+Retrieves paginated message history for a character's conversation using composite cursor-based pagination.
+
+**Query Parameters**:
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `cursor` | string | no | none | Base64 URL-safe encoded JSON: `{"ts": "<ISO 8601>", "id": "<UUID>"}`. Messages strictly older than this cursor position are returned. When absent, the newest messages are returned. |
+| `limit` | integer | no | 20 | Number of messages per page. Min 1, max 100. |
+
+**Response Body (200 OK)**:
+
+```json
+{
+  "items": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440088",
+      "role": "assistant",
+      "content": "Great! Let's start with some conversation practice.",
+      "media_url": null,
+      "metadata": null,
+      "created_at": "2026-02-23T14:30:05+00:00"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440087",
+      "role": "user",
+      "content": "I want to practice English today!",
+      "media_url": null,
+      "metadata": null,
+      "created_at": "2026-02-23T14:30:05+00:00"
+    }
+  ],
+  "next_cursor": "eyJ0cyI6ICIyMDI2LTAyLTIzVDE0OjI1OjAwKzAwOjAwIiwgImlkIjogIjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDA4NiJ9",
+  "has_more": true
+}
+```
+
+Note: both messages in the example share the same `created_at` value (`14:30:05`). The composite cursor ensures the next page starts after the correct message.
+
+**Response Fields**:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `items` | array | Messages in reverse chronological order (newest first) |
+| `items[].id` | string (UUID) | Message primary key |
+| `items[].role` | string | `"user"` or `"assistant"` |
+| `items[].content` | string | Message text |
+| `items[].media_url` | string or null | S3 URL for attached media |
+| `items[].metadata` | object or null | Intent action data or other metadata |
+| `items[].created_at` | string (ISO 8601) | Message creation timestamp |
+| `next_cursor` | string or null | Opaque base64-encoded cursor for the next page. Null when no more messages. |
+| `has_more` | boolean | True if older messages exist beyond this page |
+
+**Error Responses**:
+
+| Status | Detail | When |
+|--------|--------|------|
+| 400 | `"Invalid cursor format"` | Cursor is not valid base64, not valid JSON, missing `ts` or `id` fields, `ts` is not a valid ISO 8601 timestamp, `id` is not a valid UUID, or cursor is an empty string |
+| 401 | `"Invalid or expired token"` | Missing or invalid JWT |
+| 403 | `"Character does not belong to user"` | Ownership mismatch |
+| 404 | `"Character not found"` | Non-existent or inactive character |
+| 404 | `"Conversation not found"` | Character has no conversation |
+| 422 | Standard FastAPI validation error | Invalid limit range or invalid UUID path parameter |
+
+### Cursor Format Details
+
+The cursor is **opaque** to clients. Clients receive `next_cursor` from one response and pass it verbatim as the `cursor` parameter on the next request. Clients must not construct cursors manually or depend on the internal format.
+
+**Encoded example**: `eyJ0cyI6ICIyMDI2LTAyLTIzVDE0OjMwOjAwKzAwOjAwIiwgImlkIjogIjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDA4OCJ9`
+
+**Decoded**: `{"ts": "2026-02-23T14:30:00+00:00", "id": "550e8400-e29b-41d4-a716-446655440088"}`
+
+Old-format cursors (plain ISO 8601 timestamps from P01-06) are **not** supported and will return HTTP 400. This is acceptable because no mobile client has shipped and no client has persisted old cursors.
+
+---
+
+## Configuration
+
+No new configuration values were added in P01-07. The pagination endpoint uses the same configuration established in P01-06.
+
+**Relevant existing settings**:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| Default `limit` | int | 20 | Hardcoded as the FastAPI query parameter default. Min 1, max 100. |
+
+Note: `docs/standards/common.md` Section 6 specifies a default limit of 30. The implementation uses 20 to match the original P01-06 behavior and issue description. This is documented here so the mobile team is aware of the default page size.
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `backend/app/routes/chat.py` | Route handler for `get_messages`. Decodes the cursor string via `_decode_cursor()` and delegates to `ChatService.get_messages()`. |
+| `backend/app/services/chat_service.py` | `MessageCursor` frozen dataclass, `_encode_cursor()` and `_decode_cursor()` helpers, and the `ChatService.get_messages()` method with `tuple_()` row-value comparison. |
+| `backend/app/schemas/chat.py` | `MessageListResponse` schema (unchanged -- `next_cursor` is `str | None`; only its content format changed from plain ISO to base64 JSON). |
+
+### What Changed vs P01-06
+
+| Aspect | P01-06 (before) | P01-07 (after) |
+|--------|-----------------|----------------|
+| Cursor format | Plain ISO 8601 timestamp string | Base64 URL-safe JSON `{"ts": ..., "id": ...}` |
+| Cursor type in service | `datetime | None` | `MessageCursor | None` |
+| WHERE clause | `created_at < cursor` | `tuple_(created_at, id) < tuple_(ts, id)` |
+| `next_cursor` encoding | `items[-1].created_at.isoformat()` | `_encode_cursor(items[-1].created_at, items[-1].id)` |
+| Invalid cursor handling | Unhandled `ValueError` producing HTTP 500 | `HTTPException(400, "Invalid cursor format")` |
+
+---
+
+## Testing
+
+### Coverage Summary
+
+| File | Tests | Line Coverage | Branch Coverage |
+|------|-------|---------------|-----------------|
+| `test_chat_routes.py` | 62 total (18 new pagination edge-case tests) | 100% | 100% |
+| `test_chat_service.py` | 97 total (21 new pagination edge-case tests) | 100% | 100% |
+| **Combined (chat files)** | **192 passed, 0 failed** | **98% lines** | **Above 70% branches** |
+
+Full backend suite: 952 passed, 0 failed, 0 skipped. No regressions.
+
+### Key Test Scenarios
+
+**Route-level tests** (`TestGetMessagesPaginationEdgeCases`):
+- Invalid cursor variants: not base64, valid base64 but invalid JSON, missing `ts` field, missing `id` field, `ts` not ISO 8601, `id` not a UUID, empty string, null bytes, very long string, whitespace, old-format plain timestamp
+- Valid cursor acceptance: base64 cursor with padding accepted, `next_cursor` decodes to valid JSON with `ts` and `id`
+- Limit boundaries: limit=1, limit=100, negative limit, non-integer limit
+- Multi-page sequential walk: no duplicate message IDs across pages
+- Default limit: omitting the parameter returns 200
+
+**Service-level tests** (`TestPaginationEdgeCases`, `TestCursorHelpersEdgeCases`):
+- Same-timestamp tiebreaker: three messages with identical `created_at` paginated with limit=1 across three pages, each appearing exactly once
+- Cursor roundtrip: `_decode_cursor(_encode_cursor(ts, id))` preserves values including microsecond precision and timezone offsets
+- Boundary conditions: exactly `limit` messages (has_more=false), exactly `limit+1` messages (has_more=true), single message, cursor with future timestamp, cursor past oldest message
+- `MessageCursor` immutability: frozen dataclass rejects attribute assignment
+- Edge case inputs: nil UUID, max UUID, positive/negative timezone offsets
+
+### Running Tests
+
+Chat pagination tests only:
+
+```bash
+cd backend && python -m pytest tests/test_chat_routes.py tests/test_chat_service.py -v -k "pagination or cursor or Cursor"
+```
+
+All chat tests (includes P01-06 tests):
+
+```bash
+cd backend && python -m pytest tests/test_chat_routes.py tests/test_chat_service.py -v
+```
+
+Full backend suite:
+
+```bash
+cd backend && python -m pytest tests/ -v --ignore=tests/test_migration.py
+```
+
+---
+
+## Known Limitations
+
+- **No backward compatibility for old cursors**: Plain ISO 8601 timestamp cursors from P01-06 are rejected with HTTP 400. This is intentional since no mobile client has shipped.
+- **Default limit is 20, not 30**: The `docs/standards/common.md` Section 6 standard specifies 30 as the default limit, but the implementation uses 20 to match the P01-06 behavior and issue description. Mobile clients should not hardcode this value and should respect the `has_more` flag.
+- **No additional index for the id tiebreaker**: The existing index `idx_messages_conv_time` on `(conversation_id, created_at DESC)` does not include `id`. The `id` tiebreaker operates on the small result set after the index scan. If performance profiling on very large conversations shows issues, a three-column index `(conversation_id, created_at DESC, id DESC)` can be added.
+- **Cursor expiry is not enforced**: Cursors do not expire. A cursor from an old response will still work as long as the referenced message exists. If a message is hard-deleted (not currently supported), the cursor will return messages older than the deleted message's position.
+
+---
+
+## Design Decisions
+
+### Why composite `(created_at, id)` instead of plain timestamp
+
+The plain timestamp cursor has a correctness bug when two messages share the same `created_at` (which happens every time `_persist_exchange` inserts a user-assistant pair in one transaction). The composite cursor with UUID tiebreaker is the only correct solution. This also aligns with `docs/standards/common.md` Section 6.
+
+### Why base64 URL-safe encoding
+
+Base64 makes the cursor opaque to clients. They cannot construct cursors manually or depend on the internal format. URL-safe base64 (using `-` and `_` instead of `+` and `/`) avoids URL encoding issues. Trailing `=` padding is stripped on encode and restored on decode for cleanliness.
+
+### Why a single error message for all cursor failures
+
+All cursor parse failures (bad base64, bad JSON, missing fields, wrong types) return the same `{"detail": "Invalid cursor format"}` message. Exposing internal parsing details (e.g., "invalid base64" vs. "missing ts field") would leak implementation details and provide no actionable information to the client.
+
+### Why `MessageCursor` as a frozen dataclass
+
+A frozen dataclass provides type safety, immutability, and semantic clarity. The cursor is decoded once and threaded through to the query. Using a plain tuple or dict would lose meaning and invite bugs.
+
+### Why `tuple_()` instead of manual OR-based WHERE clause
+
+SQLAlchemy's `tuple_()` generates a native PostgreSQL row-value comparison `(a, b) < (c, d)`, which is semantically correct, optimizable by the query planner, and less error-prone than writing the equivalent `(a < c) OR (a = c AND b < d)` manually.
+
+---
+
+## Extending This Feature
+
+**Changing the default page size**: Modify the `default=20` value in the `limit` query parameter definition in `backend/app/routes/chat.py`. The `ge=1, le=100` constraints are also set there. No service-layer changes needed.
+
+**Adding cursor expiry**: To reject cursors older than N hours, add a check in `_decode_cursor()` that compares `cursor.ts` against `datetime.now(UTC)` and raises HTTP 400 if the cursor is too old. This would force clients to re-fetch from the beginning if they have been idle too long.
+
+**Migrating to a three-column index**: If performance profiling shows the `id` tiebreaker is slow on large conversations, create: `CREATE INDEX idx_messages_conv_time_id ON messages (conversation_id, created_at DESC, id DESC)`. The existing index can then be dropped. No application code changes are needed.
+
+**Adding a `direction` parameter**: To support forward pagination (loading newer messages), add a `direction` query parameter (`before` or `after`). In the `after` case, reverse the comparison to `(created_at, id) > (cursor.ts, cursor.id)` and change the ORDER BY to `ASC`. This would enable real-time message polling.
+
+---
+
+## Related Documentation
+
+- [Chat Streaming](./chat-streaming.md) -- the parent feature (P01-06) that created this endpoint
+- [Database Schema](./database-schema.md) -- the `messages`, `conversations`, and `characters` tables
+- [Cognito Auth Middleware](./cognito-auth-middleware.md) -- JWT verification used by this endpoint
+- [Database Schema and API Endpoints](../04-veri-api.md) -- authoritative source for table definitions
+- [Pagination Standard](../standards/common.md) -- Section 6 specifies the cursor encoding convention

--- a/docs/pipeline/messages-pagination-architect.handoff.md
+++ b/docs/pipeline/messages-pagination-architect.handoff.md
@@ -1,0 +1,69 @@
+# Architect Handoff: Messages Pagination
+
+**Date**: 2026-02-24
+**Agent**: architect
+**Status**: COMPLETE
+
+## What Was Designed
+
+Hardening of the cursor-based message pagination endpoint (`GET /api/v1/characters/:id/messages`), which was initially implemented in P01-06. The main change is upgrading the cursor format from a plain ISO 8601 timestamp to a composite `(created_at, id)` cursor encoded as base64 URL-safe JSON. This fixes a correctness bug where two messages with identical timestamps could be skipped or duplicated during pagination. Additionally, invalid cursor input now returns HTTP 400 instead of an unhandled 500 error.
+
+## Key Decisions
+
+- **Composite cursor `(created_at, id)` over plain timestamp**: Two messages can share the same `created_at` (e.g., user and assistant messages persisted in one transaction). The plain timestamp cursor cannot distinguish between them. The composite cursor with UUID tiebreaker eliminates this bug. This also aligns with `docs/standards/common.md` Section 6.
+- **Base64 URL-safe encoding**: Makes the cursor opaque to clients, prevents manual cursor construction, and avoids URL encoding issues. Follows `docs/standards/common.md` Section 6.
+- **No backward compatibility for old cursors**: No mobile client has shipped. Old-format cursors (plain ISO timestamps) will return HTTP 400. Clean break avoids dead code.
+- **No index changes**: The existing `idx_messages_conv_time` on `(conversation_id, created_at DESC)` is sufficient. The `id` tiebreaker operates on the small result set (max `limit + 1` rows) after the index scan.
+- **Default limit stays at 20**: Matches the issue description. `docs/standards/common.md` says 30, but the issue says 20 and no client has shipped. Backend-dev may adjust if directed.
+- **SQLAlchemy `tuple_()` for row-value comparison**: Generates correct `(a, b) < (c, d)` SQL. Cleaner and less error-prone than manual OR-based WHERE clause.
+- **Single HTTPException(400) for all cursor parse failures**: Do not expose internal error details (bad base64 vs bad JSON) to the client. One message: "Invalid cursor format".
+
+## Spec Location
+
+`shared/feature-specs/messages-pagination.md`
+
+## Assumptions Made
+
+- PostgreSQL supports row-value comparison `(a, b) < (c, d)` natively (confirmed: this is standard SQL).
+- SQLAlchemy's `tuple_()` function generates correct PostgreSQL SQL for row-value comparisons.
+- No mobile client has persisted old-format cursors. There is no backward compatibility requirement.
+- The existing `idx_messages_conv_time` index on `(conversation_id, created_at DESC)` provides adequate performance for the upgraded query. A three-column index `(conversation_id, created_at DESC, id DESC)` can be added later if profiling warrants it.
+
+## Dependencies
+
+- Requires: P01-06 (chat-streaming -- the existing endpoint, service, schema, and tests)
+- Blocks: backend-dev, backend-tester (they implement and test the changes)
+
+## File Manifest
+
+```
+Backend:
+  MODIFY  backend/app/routes/chat.py           -- Cursor decoding, 400 error handling
+  MODIFY  backend/app/services/chat_service.py  -- MessageCursor dataclass, tuple_ query, base64 encode/decode helpers
+  MODIFY  backend/tests/test_chat_routes.py     -- Update existing cursor tests, add invalid cursor tests
+  MODIFY  backend/tests/test_chat_service.py    -- Update existing cursor tests, add composite cursor tests, add cursor helper tests
+
+Shared:
+  CREATE  shared/feature-specs/messages-pagination.md
+  CREATE  docs/pipeline/messages-pagination-architect.handoff.md
+```
+
+## Notes for Developers
+
+### For backend-dev
+
+- The scope is small: modify 2 production files, update 2 test files. No new files needed beyond the spec and handoff.
+- Start with `MessageCursor` dataclass + `_encode_cursor()` + `_decode_cursor()` helpers in `chat_service.py`. Test them before modifying the route/service logic.
+- Use `from sqlalchemy import tuple_` for the row-value comparison. This is the clean SQLAlchemy way to express `(created_at, id) < ($ts, $id)`.
+- Handle base64 padding: strip `=` on encode, restore on decode (add `=` until `len % 4 == 0`).
+- The route handler should catch cursor decode errors and return HTTP 400 with `{"detail": "Invalid cursor format"}`.
+- Search for `cursor=` and `fromisoformat` in existing test files to find all tests that need updating.
+
+### For backend-tester
+
+- Focus on: (1) invalid cursor format tests (R1-R9 in spec), (2) same-timestamp tiebreaker test (S1), (3) cursor roundtrip test (S4, U1-U7), (4) no regressions in POST endpoint tests.
+- The tiebreaker scenario is the most important correctness test. Create two messages with identical `created_at`, paginate with `limit=1`, verify no duplicates and no skips.
+
+## Next Steps
+
+backend-dev should read the spec at `shared/feature-specs/messages-pagination.md` and implement the cursor format upgrade and error handling. backend-tester follows with test coverage.

--- a/docs/pipeline/messages-pagination-backend-dev.handoff.md
+++ b/docs/pipeline/messages-pagination-backend-dev.handoff.md
@@ -1,0 +1,65 @@
+# Backend Dev Handoff: Messages Pagination
+
+**Date**: 2026-02-24
+**Agent**: backend-dev
+**Status**: COMPLETE
+
+## Implemented Files
+
+- `backend/app/routes/chat.py` -- Updated cursor parsing: replaced `datetime.fromisoformat()` with `_decode_cursor()` (base64 composite cursor). Invalid cursors now return HTTP 400 with `{"detail": "Invalid cursor format"}`.
+- `backend/app/services/chat_service.py` -- Added `MessageCursor` frozen dataclass, `_encode_cursor()`, `_decode_cursor()` helpers. Modified `get_messages()` to accept `MessageCursor | None` and use `sqlalchemy.tuple_()` for row-value comparison `(created_at, id) < (cursor.ts, cursor.id)`. Updated `next_cursor` encoding from plain ISO timestamp to base64 URL-safe JSON.
+- `backend/tests/test_chat_routes.py` -- Updated 3 existing tests to use base64 cursors. Added 10 new tests for invalid cursor variants (not base64, bad JSON, missing fields, bad types, empty string, old format) and valid cursor acceptance.
+- `backend/tests/test_chat_service.py` -- Updated 2 existing tests (`test_cursor_filter_applied`, `test_next_cursor_matches_last_item`) to use `MessageCursor`. Added 14 new tests: cursor helper unit tests (U1-U7), same-timestamp tiebreaker tests (S1-S3), cursor roundtrip test (S4), garbage input test (S5).
+
+## Endpoints Modified
+
+- `GET /api/v1/characters/{character_id}/messages` -- Cursor format changed from plain ISO 8601 timestamp to base64 URL-safe JSON `{"ts": "<ISO 8601>", "id": "<UUID>"}`. Invalid cursor now returns HTTP 400 instead of 500.
+
+## Test Results
+
+- pytest: 913 passed, 0 failed (120 in chat test files)
+- ruff: clean on production code (`backend/app/`)
+- No regressions in any other test file
+
+## Test Command
+
+```bash
+cd backend && python -m pytest tests/test_chat_routes.py tests/test_chat_service.py -v
+```
+
+## Known Issues / Deviations from Spec
+
+- None. Implementation follows the spec exactly.
+- The 3 pre-existing ruff F841 warnings in test files (unused variables at lines 1132, 1829, 1929 of `test_chat_service.py`) are from P01-06 code and were not introduced by this change.
+
+## Notes for Backend Tester
+
+### Cursor Encoding Details
+
+- Cursor is base64 URL-safe encoded JSON: `{"ts": "2026-02-23T14:30:00+00:00", "id": "550e8400-..."}`
+- Padding (`=`) is stripped on encode, restored on decode using `cursor + "=" * (-len(cursor) % 4)`
+- `_encode_cursor(ts, msg_id)` and `_decode_cursor(cursor_str)` are importable from `app.services.chat_service`
+
+### Mock Requirements
+
+- Route tests mock `app.services.chat_service.ChatService.get_messages` (returns `MessageListResponse`)
+- Service tests mock `db.execute` with call_count pattern (1=character, 2=conversation, 3=messages)
+- Import `_encode_cursor` from `app.services.chat_service` to build valid test cursors
+- Import `MessageCursor` for service-level tests that pass cursor objects
+
+### Edge Cases to Pay Attention To
+
+- **Same-timestamp tiebreaker**: Two messages with identical `created_at` but different UUIDs must be paginated correctly. The `tuple_()` comparison ensures deterministic ordering by `(created_at DESC, id DESC)`.
+- **Empty cursor string**: `?cursor=` (empty string) must return 400, not 200.
+- **Old-format cursor**: Plain ISO 8601 timestamp like `2026-02-23T14:30:00+00:00` must return 400 (not backward compatible -- no client has shipped).
+- **Various malformed base64**: Each type of malformation (not base64, valid base64 but not JSON, valid JSON but missing fields, valid JSON but wrong types) all produce the same 400 error with `"Invalid cursor format"`.
+
+### What Changed vs P01-06
+
+| Aspect | P01-06 (before) | P01-07 (after) |
+|--------|-----------------|----------------|
+| Cursor format | Plain ISO 8601 timestamp string | Base64 URL-safe JSON `{"ts": ..., "id": ...}` |
+| Cursor type in service | `datetime \| None` | `MessageCursor \| None` |
+| WHERE clause | `created_at < cursor` | `tuple_(created_at, id) < tuple_(ts, id)` |
+| next_cursor encoding | `items[-1].created_at.isoformat()` | `_encode_cursor(items[-1].created_at, items[-1].id)` |
+| Invalid cursor handling | Unhandled `ValueError` -> 500 | `HTTPException(400, "Invalid cursor format")` |

--- a/docs/pipeline/messages-pagination-backend-test.handoff.md
+++ b/docs/pipeline/messages-pagination-backend-test.handoff.md
@@ -1,0 +1,65 @@
+# Backend Test Handoff: Messages Pagination
+
+**Date**: 2026-02-24
+**Agent**: backend-tester
+**Status**: COMPLETE
+
+## Test Files Written
+- `backend/tests/test_chat_routes.py` -- 62 tests total (18 new pagination edge-case tests added)
+- `backend/tests/test_chat_service.py` -- 97 tests total (21 new pagination edge-case tests added)
+
+## New Test Classes Added
+
+### test_chat_routes.py
+- `TestGetMessagesPaginationEdgeCases` (18 tests):
+  - Cursor with extra JSON fields (forward-compatible)
+  - Cursor with empty JSON object, JSON array, ts/id as wrong types (integer, null)
+  - Limit boundary tests (limit=1, limit=100, negative, non-integer)
+  - Cursor with null bytes, very long string, whitespace
+  - Multi-page sequential walk (no duplicate IDs)
+  - next_cursor matches last item in response
+  - Cursor with base64 padding accepted
+  - Default limit (omit param) returns 200
+
+### test_chat_service.py
+- `TestPaginationEdgeCases` (9 tests):
+  - Exactly limit messages (has_more=False boundary)
+  - Exactly limit+1 messages (has_more=True boundary)
+  - Single message in conversation
+  - Three same-timestamp messages multi-page walk (3 pages)
+  - Cursor with future timestamp (returns all messages)
+  - Cursor past oldest message (returns empty)
+  - Multi-page walk 3 pages of 3 messages (9 total, no duplicates)
+  - next_cursor is None when has_more is False
+  - Items have all required MessageItem fields
+
+- `TestCursorHelpersEdgeCases` (12 tests):
+  - Encode/decode with UTC timezone
+  - Roundtrip preserves microsecond precision
+  - Encode with nil UUID and max UUID
+  - MessageCursor frozen immutability (ts and id)
+  - Decode JSON string (not object) returns 400
+  - Decode with ts empty string returns 400
+  - Decode with id empty string returns 400
+  - Multiple roundtrips produce consistent results
+  - Decode with positive timezone offset (+03:00)
+  - Decode with negative timezone offset (-05:00)
+
+## Coverage Results
+- `backend/app/routes/chat.py`: 100% lines, 100% branches
+- `backend/app/services/chat_service.py`: 100% lines, 100% branches
+- `backend/app/schemas/chat.py`: 90% lines, 86% branches
+- **Combined**: 98% lines (target: >= 80%), branches well above 70%
+
+## Test Run Results
+- Chat test files: 192 passed, 0 failed, 0 skipped
+- Full backend suite: 952 passed, 0 failed, 0 skipped
+- No regressions in any other test file
+
+## Issues Found During Testing
+- None. All cursor encoding/decoding edge cases behave as specified.
+
+## Notes for Reviewer
+- The same-timestamp tiebreaker test (`test_three_same_timestamp_messages_paginate_correctly`) simulates the realistic scenario where `_persist_exchange` inserts user and assistant messages with identical `created_at` values. It walks 3 pages of 1 message each and verifies no duplicates or skips.
+- The multi-page walk tests use mock DB responses that simulate the `LIMIT+1` overflow pattern, verifying the cursor chain produces disjoint page sets.
+- All 39 new tests focus exclusively on the P01-07 cursor pagination changes and do not modify any existing tests.

--- a/docs/pipeline/messages-pagination-doc.handoff.md
+++ b/docs/pipeline/messages-pagination-doc.handoff.md
@@ -1,0 +1,17 @@
+# Doc Writer Handoff: Messages Pagination
+
+**Date**: 2026-02-24
+**Agent**: doc-writer
+**Status**: COMPLETE
+
+## Documents Written
+- `docs/features/messages-pagination.md` -- main feature documentation
+- `CHANGELOG.md` -- added entry under [Unreleased]
+
+## Summary
+Documented the P01-07 messages pagination feature, which upgrades the GET messages endpoint from a plain ISO 8601 timestamp cursor to a composite `(created_at, id)` cursor encoded as base64 URL-safe JSON. The documentation covers the cursor encoding/decoding flow, the SQL row-value comparison pattern using `tuple_()`, error handling for invalid cursors (HTTP 400), all test scenarios including same-timestamp tiebreaker tests, and design decisions explaining why each approach was chosen.
+
+## Notes
+- The default page limit is 20, which deviates from the `docs/standards/common.md` Section 6 standard of 30. This is documented in the Known Limitations section.
+- No backward compatibility for old-format cursors is provided, which is acceptable since no mobile client has shipped. Noted in Known Limitations.
+- The chat-streaming feature doc (`docs/features/chat-streaming.md`) still references the old cursor format in its GET endpoint description (plain ISO 8601). A future update to that document may be warranted, but modifying it is out of scope for this handoff since it is a separate feature's documentation.

--- a/docs/pipeline/messages-pagination-review.handoff.md
+++ b/docs/pipeline/messages-pagination-review.handoff.md
@@ -1,0 +1,102 @@
+# Reviewer Handoff: Messages Pagination (P01-07)
+
+**Date**: 2026-02-24
+**Agent**: reviewer
+**Status**: APPROVED
+
+## Review Summary
+
+| Category | Passed | Warnings | Issues |
+|----------|--------|----------|--------|
+| Architecture | 6 | 0 | 0 |
+| Code Quality | 6 | 0 | 0 |
+| Testing | 6 | 0 | 0 |
+| Security | 4 | 0 | 0 |
+| **Total** | **22** | **0** | **0** |
+
+## Checklist Results
+
+### Architecture
+
+- [x] **Cursor pagination -- no OFFSET**: PASS. Grep for `OFFSET` in `backend/app/` returned zero results. Query uses `LIMIT limit+1` with cursor-based WHERE clause.
+- [x] **Composite cursor (created_at, id) for tiebreaking**: PASS. `MessageCursor` frozen dataclass with `ts` and `id` fields. Query uses `tuple_(Message.created_at, Message.id) < tuple_(cursor.ts, cursor.id)`.
+- [x] **Base64 URL-safe encoding for cursor opacity**: PASS. `_encode_cursor()` uses `base64.urlsafe_b64encode()` with padding stripped. `_decode_cursor()` restores padding before decoding.
+- [x] **Invalid cursor produces HTTP 400 (not 500)**: PASS. `_decode_cursor()` wraps all parsing in `try/except Exception` and raises `HTTPException(400, "Invalid cursor format")`.
+- [x] **user_id from JWT only**: PASS. Both route handlers extract `current_user.id` from `Depends(get_current_user)`. Grep for `user_id.*body` in routes returned zero results.
+- [x] **SQLAlchemy tuple_() for row-value comparison**: PASS. `from sqlalchemy import tuple_` used at service line 22, applied at lines 302-303.
+
+### Code Quality
+
+- [x] **No hardcoded secrets**: PASS. All grep checks (`api_key=`, `secret=`, `password=`, `Bearer`) clean.
+- [x] **Error messages user-friendly**: PASS. Messages are `"Invalid cursor format"`, `"Character does not belong to user"`, etc.
+- [x] **All API errors handled explicitly**: PASS. 400 (invalid cursor), 403 (ownership), 404 (not found), 422 (validation) all handled.
+- [x] **No TODO/FIXME in production code**: PASS. Grep returned zero results.
+- [x] **async def on all routes**: PASS. Both `send_message` and `get_messages` use `async def`. No synchronous handlers found.
+- [x] **No print() in production code**: PASS. Uses `logger` throughout.
+
+### Testing
+
+- [x] **Coverage >= 80%**: PASS. 100% lines on routes and service, 90% on schemas. Combined 98% line coverage.
+- [x] **External services mocked**: PASS. All tests mock DB, Anthropic, Mem0, and background tasks.
+- [x] **Edge cases covered**: PASS. 9 invalid cursor variants (R1-R9), same-timestamp tiebreaker (2 and 3 messages), boundary conditions (limit=1, limit=100, exactly limit, limit+1), future cursor, past-oldest cursor, empty conversation, multi-page walks.
+- [x] **Cursor roundtrip tested**: PASS. Multiple roundtrip tests including microsecond precision and consistent encoding.
+- [x] **Multi-page walk tested**: PASS. Route-level (2 pages, 6 items), service-level (3 pages, 9 items), same-timestamp (3 pages, 3 items). All verify no duplicate IDs.
+- [x] **Ownership tested**: PASS. Both route and service tests verify 403 for another user's character.
+
+### Security
+
+- [x] **No credentials in code**: PASS.
+- [x] **No user_id in request body**: PASS.
+- [x] **SQL injection prevention**: PASS. All queries use SQLAlchemy parameterized statements.
+- [x] **No internal IDs exposed in errors**: PASS.
+
+## Grep Checks Run
+
+| Pattern | Path | Result |
+|---------|------|--------|
+| `OFFSET` | `backend/app/` | Zero matches |
+| `user_id.*body\|body.*user_id` | `backend/app/routes/` | Zero matches |
+| `api_key\s*=\s*['"]` | `backend/app/` | Zero matches |
+| `secret\s*=\s*['"]` | `backend/app/` | Zero matches |
+| `password\s*=\s*['"]` | `backend/app/` | Zero matches |
+| `^def ` (sync handlers) | `backend/app/routes/` | Zero matches |
+| `/conversations` | `backend/app/routes/` | Zero matches |
+| `TODO\|FIXME` | Modified production files | Zero matches |
+| `print(` | `backend/app/` | Zero matches |
+| f-string SQL patterns | `chat_service.py` | Zero matches |
+
+## Files Reviewed
+
+**Backend (Production)**:
+- `backend/app/routes/chat.py` (94 lines) -- PASS
+- `backend/app/services/chat_service.py` (616 lines) -- PASS
+- `backend/app/schemas/chat.py` (122 lines) -- PASS (unchanged for P01-07, verified no regressions)
+
+**Backend (Tests)**:
+- `backend/tests/test_chat_routes.py` (1728 lines, 62 tests) -- PASS
+- `backend/tests/test_chat_service.py` (2841 lines, 97 tests) -- PASS
+- `backend/tests/test_chat_schemas.py` (366 lines) -- PASS (unchanged for P01-07, verified no regressions)
+
+**Pipeline**:
+- `shared/feature-specs/messages-pagination.md` -- PASS (complete spec)
+- `docs/pipeline/messages-pagination-architect.handoff.md` -- PASS
+- `docs/pipeline/messages-pagination-backend-dev.handoff.md` -- PASS
+- `docs/pipeline/messages-pagination-backend-test.handoff.md` -- PASS
+
+## Issues Resolved During Review
+
+- None (first-pass clean)
+
+## Warnings (Not Blocking)
+
+- `_decode_cursor()` is a private function (leading underscore) imported across module boundaries (`chat_service.py` -> `routes/chat.py`). Works correctly and is intentionally exported for tests. Consider making it a public function or moving to a `utils/cursor.py` module in a future refactor.
+- Default limit is 20, while `docs/standards/common.md` Section 6 says 30. The spec explicitly discusses this deviation in Section 8 and accepts 20. Mobile team should be aware of the default when implementing infinite scroll.
+
+## Test Coverage Summary
+
+| File | Lines | Branches |
+|------|-------|----------|
+| `backend/app/routes/chat.py` | 100% | 100% |
+| `backend/app/services/chat_service.py` | 100% | 100% |
+| `backend/app/schemas/chat.py` | 90% | 86% |
+| **Combined** | **98%** | **>70%** |

--- a/shared/feature-specs/messages-pagination.md
+++ b/shared/feature-specs/messages-pagination.md
@@ -1,0 +1,446 @@
+# Feature Spec: P01-07 -- Messages Pagination
+
+**Feature ID**: P01-07
+**Phase**: 1
+**Layer**: backend
+**GitHub Issue**: #9
+**Date**: 2026-02-24
+**Author**: architect
+
+---
+
+## 1. Overview
+
+### What This Feature Does
+
+P01-07 hardens and completes the cursor-based message pagination endpoint (`GET /api/v1/characters/:id/messages`) that was initially implemented as part of P01-06 (chat-streaming). While P01-06 delivered a working endpoint, it used a simplified cursor mechanism (plain ISO 8601 timestamp) that does not comply with the project's pagination standard in `docs/standards/common.md` Section 6 and has correctness issues when multiple messages share the same `created_at` value.
+
+This feature delivers three categories of work:
+
+1. **Cursor encoding upgrade**: Replace the plain ISO 8601 cursor with a composite `(created_at, id)` cursor encoded as base64 URL-safe JSON. This eliminates the possibility of skipping or duplicating messages when two messages share the same timestamp (common during background persistence, which inserts the user and assistant messages in a single transaction with the same server clock time).
+
+2. **Error handling hardening**: Add graceful handling for invalid cursor values (malformed strings, invalid base64, invalid JSON) so the endpoint returns HTTP 400 with a clear error message instead of an unhandled 500 error.
+
+3. **Comprehensive test coverage**: Add targeted tests for the pagination edge cases that P01-06 tests did not cover: identical-timestamp messages, multi-page sequential pagination, invalid cursor format, and cursor boundary conditions.
+
+### Why It Exists
+
+The current plain-timestamp cursor is incorrect in a specific but realistic scenario. When a user sends a message and receives a response, the `_persist_exchange` background task inserts both the user message and the assistant message in a single DB transaction. PostgreSQL's `now()` server default assigns both messages the same `created_at` timestamp. If the client paginates and the cursor equals this shared timestamp, the `created_at < $cursor` filter may skip one of the two messages or include it twice on different pages, depending on insertion order.
+
+The composite `(created_at, id)` cursor with a `(created_at, id)` ordering in the query eliminates this ambiguity. The `id` (UUID) breaks the tie deterministically.
+
+### Dependencies
+
+- **Requires**: P01-06 (chat-streaming -- provides the existing endpoint, service, schema, and tests)
+- **Blocks**: Mobile chat UI scroll-back functionality (must have correct pagination before mobile implements infinite scroll)
+
+### What Already Exists from P01-06
+
+All of the following files were created in P01-06 and will be MODIFIED (not created) in this feature:
+
+| File | What Exists | What Changes |
+|------|-------------|--------------|
+| `backend/app/routes/chat.py` | `get_messages()` route with `cursor: str`, parses via `datetime.fromisoformat()` | Cursor parsing switches to base64 decode + JSON parse. Error handling for invalid cursor. |
+| `backend/app/services/chat_service.py` | `ChatService.get_messages()` with `cursor: datetime`, query uses `created_at < cursor` | Cursor type changes to a `MessageCursor` dataclass. Query adds `id` as tiebreaker. `next_cursor` encoding changes to base64 JSON. |
+| `backend/app/schemas/chat.py` | `MessageListResponse` with `next_cursor: str` | No schema changes. The `next_cursor` field type stays `str | None`. Only its content format changes (from ISO timestamp to base64 JSON). |
+| `backend/tests/test_chat_routes.py` | `TestGetMessages` + `TestGetMessagesAdditional` classes | Add new tests for invalid cursor, base64 cursor format, same-timestamp messages. |
+| `backend/tests/test_chat_service.py` | `TestGetMessages` + `TestGetMessagesAdditional` classes | Add new tests for composite cursor query, tiebreaker ordering, cursor encoding/decoding. |
+
+---
+
+## 2. Data Models
+
+### No New Tables
+
+This feature does not create or alter any database tables.
+
+### No New Columns
+
+All required columns already exist on the `messages` table (see `docs/04-veri-api.md`).
+
+### Index Consideration
+
+The existing composite index `idx_messages_conv_time` on `(conversation_id, created_at DESC)` supports the current query. The upgraded query adds `id DESC` as a secondary sort column. PostgreSQL can use the existing index for the `conversation_id` and `created_at` filter; the `id` tiebreaker operates on the small result set after the index scan (max `limit + 1` rows), so no additional index is needed for Phase 1.
+
+If performance profiling later shows that the `id` tiebreaker causes issues on very large conversations, a new index `(conversation_id, created_at DESC, id DESC)` can be added. This is NOT required now.
+
+### Mem0 Operations
+
+None. This feature does not interact with Mem0.
+
+---
+
+## 3. API Changes
+
+### Modified Endpoint: GET /api/v1/characters/:id/messages
+
+The endpoint path, auth requirement, and response schema are unchanged. Only the cursor format and error handling change.
+
+```
+Method: GET
+Path: /api/v1/characters/{character_id}/messages
+Auth: Bearer JWT required
+```
+
+**Query Parameters (unchanged path, new cursor semantics):**
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `cursor` | string | no | none | Base64 URL-safe encoded JSON object `{"ts": "<ISO 8601>", "id": "<UUID>"}`. Messages strictly older than this cursor are returned. When absent, the newest messages are returned. |
+| `limit` | integer | no | 20 | Number of messages to return per page. Min 1, max 100. |
+
+**Cursor Format:**
+
+The cursor is a base64url-encoded JSON string containing two fields:
+
+```json
+{"ts": "2026-02-23T14:30:00+00:00", "id": "550e8400-e29b-41d4-a716-446655440088"}
+```
+
+Encoded example: `eyJ0cyI6ICIyMDI2LTAyLTIzVDE0OjMwOjAwKzAwOjAwIiwgImlkIjogIjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDA4OCJ9`
+
+The `ts` field is the `created_at` ISO 8601 timestamp of the last message on the previous page. The `id` field is the UUID of that same message. Together they define a unique position in the ordered message list.
+
+**Backward Compatibility Note:**
+
+The cursor format is opaque to the client. Clients receive `next_cursor` from one response and pass it as `cursor` on the next request. Since no mobile clients have shipped yet (Phase 1 backend-only), there is no backward compatibility concern. Old-format cursors (plain ISO timestamps) from P01-06 will not be supported -- they will return HTTP 400. This is acceptable because no client has persisted old cursors.
+
+**Response 200 OK (unchanged schema):**
+
+```json
+{
+  "items": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440088",
+      "role": "assistant",
+      "content": "Great! Let's start with some conversation practice.",
+      "media_url": null,
+      "metadata": null,
+      "created_at": "2026-02-23T14:30:05+00:00"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440087",
+      "role": "user",
+      "content": "I want to practice English today!",
+      "media_url": null,
+      "metadata": null,
+      "created_at": "2026-02-23T14:30:05+00:00"
+    }
+  ],
+  "next_cursor": "eyJ0cyI6ICIyMDI2LTAyLTIzVDE0OjI1OjAwKzAwOjAwIiwgImlkIjogIjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDA4NiJ9",
+  "has_more": true
+}
+```
+
+Note in the example above: both messages share the same `created_at` value (`14:30:05`). The composite cursor ensures the next page starts after the correct message.
+
+**New Error Response:**
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| 400 | Invalid cursor format (not valid base64, not valid JSON, missing `ts` or `id` fields, `ts` not a valid ISO 8601 timestamp, `id` not a valid UUID) | `{"detail": "Invalid cursor format"}` |
+
+Previously, a malformed cursor would produce an unhandled `ValueError` exception, causing an HTTP 500.
+
+**Unchanged Error Responses:**
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| 401 | Missing or invalid JWT | `{"detail": "Invalid or expired token"}` |
+| 403 | Character does not belong to user | `{"detail": "Character does not belong to user"}` |
+| 404 | Character not found or inactive | `{"detail": "Character not found"}` |
+| 404 | Character has no conversation | `{"detail": "Conversation not found"}` |
+| 422 | Invalid limit (< 1 or > 100) or invalid UUID path param | Standard FastAPI 422 |
+
+**SQL Pattern for Composite Cursor Pagination:**
+
+```sql
+-- First page (no cursor):
+SELECT id, role, content, media_url, metadata, created_at
+FROM messages
+WHERE conversation_id = $conversation_id
+ORDER BY created_at DESC, id DESC
+LIMIT $limit + 1;
+
+-- Subsequent pages (with cursor):
+SELECT id, role, content, media_url, metadata, created_at
+FROM messages
+WHERE conversation_id = $conversation_id
+  AND (created_at, id) < ($cursor_ts, $cursor_id)
+ORDER BY created_at DESC, id DESC
+LIMIT $limit + 1;
+```
+
+The `(created_at, id) < ($cursor_ts, $cursor_id)` is a row-value comparison. PostgreSQL evaluates this as: `created_at < $cursor_ts OR (created_at = $cursor_ts AND id < $cursor_id)`. This correctly handles the tiebreaker when two messages have the same timestamp.
+
+In SQLAlchemy, this is expressed using `sqlalchemy.tuple_()`:
+
+```python
+from sqlalchemy import tuple_
+
+stmt = stmt.where(
+    tuple_(Message.created_at, Message.id) < tuple_(cursor.ts, cursor.id)
+)
+```
+
+---
+
+## 4. Backend Logic
+
+### Cursor Encoding and Decoding
+
+A new helper module or set of utility functions handles cursor encoding and decoding. These can live in the chat service file or as a small utility.
+
+**Encoding (when building `next_cursor` in the response):**
+
+```
+1. Take the last message item's (created_at, id).
+2. Build a JSON string: {"ts": "<ISO 8601>", "id": "<UUID>"}
+3. Encode with base64.urlsafe_b64encode().
+4. Decode bytes to string (strip padding if desired, but standard base64 with padding is fine).
+```
+
+**Decoding (when parsing the `cursor` query parameter):**
+
+```
+1. base64.urlsafe_b64decode() the cursor string.
+2. json.loads() the result.
+3. Extract "ts" -> datetime.fromisoformat()
+4. Extract "id" -> uuid.UUID()
+5. If any step fails, raise HTTPException(400, "Invalid cursor format").
+```
+
+The decoded cursor is represented as a dataclass or named tuple:
+
+```
+@dataclass(frozen=True)
+class MessageCursor:
+    ts: datetime
+    id: uuid.UUID
+```
+
+### Modified Service Method: `ChatService.get_messages()`
+
+**Signature change:**
+
+```
+Before:  cursor: datetime | None
+After:   cursor: MessageCursor | None
+```
+
+The route handler decodes the cursor string into a `MessageCursor` before calling the service.
+
+**Query change:**
+
+```
+Before:
+  stmt = stmt.where(Message.created_at < cursor)
+  .order_by(Message.created_at.desc(), Message.id.desc())
+
+After:
+  stmt = stmt.where(
+      tuple_(Message.created_at, Message.id) < tuple_(cursor.ts, cursor.id)
+  )
+  .order_by(Message.created_at.desc(), Message.id.desc())
+```
+
+**next_cursor change:**
+
+```
+Before:
+  next_cursor = items[-1].created_at.isoformat()
+
+After:
+  next_cursor = _encode_cursor(items[-1].created_at, items[-1].id)
+```
+
+Where `_encode_cursor(ts: datetime, id: uuid.UUID) -> str` produces the base64 JSON string.
+
+### Modified Route Handler: `get_messages()`
+
+**Before:**
+
+```python
+parsed_cursor: datetime | None = None
+if cursor is not None:
+    parsed_cursor = datetime.fromisoformat(cursor)
+```
+
+**After:**
+
+```python
+parsed_cursor: MessageCursor | None = None
+if cursor is not None:
+    parsed_cursor = _decode_cursor(cursor)
+    # _decode_cursor raises HTTPException(400) on invalid format
+```
+
+### Error Handling
+
+The `_decode_cursor()` function wraps all parsing in a try/except and raises a single `HTTPException(status_code=400, detail="Invalid cursor format")` for any failure mode: bad base64, bad JSON, missing fields, bad timestamp, bad UUID.
+
+---
+
+## 5. Test Requirements
+
+### New Route Tests (add to `TestGetMessagesAdditional` in `test_chat_routes.py`)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| R1 | Invalid cursor (not base64) returns 400 | HTTP 400, `{"detail": "Invalid cursor format"}` |
+| R2 | Invalid cursor (valid base64, invalid JSON) returns 400 | HTTP 400, `{"detail": "Invalid cursor format"}` |
+| R3 | Invalid cursor (valid JSON, missing `ts` field) returns 400 | HTTP 400, `{"detail": "Invalid cursor format"}` |
+| R4 | Invalid cursor (valid JSON, missing `id` field) returns 400 | HTTP 400, `{"detail": "Invalid cursor format"}` |
+| R5 | Invalid cursor (valid JSON, `ts` not ISO 8601) returns 400 | HTTP 400, `{"detail": "Invalid cursor format"}` |
+| R6 | Invalid cursor (valid JSON, `id` not a UUID) returns 400 | HTTP 400, `{"detail": "Invalid cursor format"}` |
+| R7 | Valid base64 cursor is accepted and passed to service | HTTP 200 |
+| R8 | `next_cursor` in response is valid base64, decodes to JSON with `ts` and `id` | Decode and verify structure |
+| R9 | Empty cursor string returns 400 | HTTP 400 |
+
+### New Service Tests (add to `TestGetMessagesAdditional` in `test_chat_service.py`)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| S1 | Two messages with same `created_at` but different `id` are correctly paginated | Second page returns the message with the smaller `id` |
+| S2 | `next_cursor` encodes to valid base64 JSON with `ts` and `id` | Decode and verify |
+| S3 | Service method accepts `MessageCursor` and applies tuple comparison | Query executes without error |
+| S4 | `_encode_cursor()` roundtrips with `_decode_cursor()` | Decode(encode(ts, id)) == (ts, id) |
+| S5 | `_decode_cursor()` raises HTTPException(400) for garbage input | Correct exception |
+
+### New Unit Tests for Cursor Helpers (add to `test_chat_service.py` or a separate `test_cursor.py`)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| U1 | `_encode_cursor()` returns a string | Type check |
+| U2 | `_encode_cursor()` output is valid base64 | base64 decode succeeds |
+| U3 | `_decode_cursor()` returns a `MessageCursor` | Type check |
+| U4 | `_decode_cursor()` with valid input returns correct `ts` and `id` | Value equality |
+| U5 | `_decode_cursor()` with empty string raises 400 | HTTPException |
+| U6 | `_decode_cursor()` with plain ISO timestamp (old format) raises 400 | HTTPException |
+| U7 | `_decode_cursor()` with valid base64 but `ts` missing raises 400 | HTTPException |
+
+### Existing Tests That May Need Update
+
+The following existing tests use plain ISO timestamp cursors and will break after the format change. They must be updated to use the new base64 cursor format:
+
+- `TestGetMessages.test_get_messages_with_cursor` -- passes `?cursor=2026-02-23T14:30:00%2B00:00` as a plain ISO timestamp
+- `TestGetMessagesAdditional.test_get_messages_next_cursor_format` -- asserts that `next_cursor` is a parseable ISO 8601 string (it will now be base64)
+- `TestGetMessagesAdditional.test_cursor_filter_applied` (in service tests) -- passes a `datetime` as cursor (now needs `MessageCursor`)
+- `TestGetMessagesAdditional.test_next_cursor_matches_last_item` (in service tests) -- asserts `next_cursor == messages[2].created_at.isoformat()` (now base64)
+
+---
+
+## 6. Acceptance Criteria
+
+1. Given a valid `GET /api/v1/characters/:id/messages` request without a cursor, when the endpoint is called, then it returns the newest messages ordered by `(created_at DESC, id DESC)` with a base64-encoded `next_cursor` containing both `ts` and `id` fields.
+
+2. Given a `next_cursor` value from a previous response, when it is passed as the `cursor` query parameter, then only messages strictly older than the cursor position are returned (no duplicates, no skips).
+
+3. Given two messages with identical `created_at` timestamps but different UUIDs, when the client paginates with `limit=1` through them, then each message appears exactly once across the two pages.
+
+4. Given an invalid cursor string that is not valid base64, when it is passed as the `cursor` parameter, then the endpoint returns HTTP 400 with `{"detail": "Invalid cursor format"}`.
+
+5. Given a cursor string that is valid base64 but does not contain valid JSON, when it is passed as the `cursor` parameter, then the endpoint returns HTTP 400 with `{"detail": "Invalid cursor format"}`.
+
+6. Given a cursor string that is valid base64 JSON but missing the `ts` field, when it is passed as the `cursor` parameter, then the endpoint returns HTTP 400 with `{"detail": "Invalid cursor format"}`.
+
+7. Given a cursor string that is valid base64 JSON but the `id` field is not a valid UUID, when it is passed as the `cursor` parameter, then the endpoint returns HTTP 400 with `{"detail": "Invalid cursor format"}`.
+
+8. Given the `next_cursor` field in any 200 response where `has_more` is true, when the cursor is base64-decoded and JSON-parsed, then it contains a `ts` field (valid ISO 8601 timestamp) and an `id` field (valid UUID string).
+
+9. Given the `next_cursor` field in any 200 response where `has_more` is true, when the cursor's `ts` and `id` are compared to the last message in the `items` array, then they match exactly (the cursor points to the last returned message).
+
+10. Given a conversation with zero messages, when the endpoint is called without a cursor, then the response is `{"items": [], "next_cursor": null, "has_more": false}`.
+
+11. Given all existing test scenarios from P01-06 for the GET messages endpoint, when the tests are updated to use the new cursor format, then all tests pass with exit code 0.
+
+12. Given the backend test suite, when `pytest` is run, then all new and updated tests pass and there are no regressions in other test files.
+
+---
+
+## 7. File Manifest
+
+```
+Backend:
+  MODIFY  backend/app/routes/chat.py           -- Cursor decoding, 400 error handling
+  MODIFY  backend/app/services/chat_service.py  -- MessageCursor dataclass, tuple_ query, base64 encode/decode helpers
+  MODIFY  backend/tests/test_chat_routes.py     -- Update existing cursor tests, add invalid cursor tests
+  MODIFY  backend/tests/test_chat_service.py    -- Update existing cursor tests, add composite cursor tests, add cursor helper tests
+
+Shared:
+  CREATE  shared/feature-specs/messages-pagination.md           (this file)
+  CREATE  docs/pipeline/messages-pagination-architect.handoff.md
+```
+
+| Action | Count |
+|--------|-------|
+| CREATE | 2 |
+| MODIFY | 4 |
+| DELETE | 0 |
+| **Total** | **6** |
+
+### Files NOT Modified
+
+- `backend/app/schemas/chat.py` -- The `MessageListResponse` schema is unchanged. The `next_cursor` field is already `str | None`, and its content format changing from plain ISO to base64 does not affect the Pydantic model.
+- `backend/app/main.py` -- No router changes. The chat router is already registered.
+- `backend/app/config.py` -- No new config values needed.
+- `backend/app/models/message.py` -- No model changes. The existing `idx_messages_conv_time` index is sufficient.
+- `backend/requirements.txt` -- No new dependencies. `base64` and `json` are Python stdlib.
+
+---
+
+## 8. Design Decisions and Rationale
+
+### Why composite `(created_at, id)` cursor instead of plain timestamp
+
+The plain timestamp cursor has a correctness bug. When `_persist_exchange` inserts both the user message and assistant message in one transaction, PostgreSQL's `server_default=func.now()` assigns both the same `created_at`. If the cursor equals this timestamp, `created_at < cursor` may skip one message or include it twice depending on the query's secondary sort. The composite cursor with row-value comparison eliminates this ambiguity.
+
+This is also what `docs/standards/common.md` Section 6 prescribes: "Cursor encodes `(created_at, id)` as base64 URL-safe JSON."
+
+### Why base64 URL-safe encoding
+
+Base64 encoding makes the cursor opaque to clients. They cannot construct cursors manually or depend on the internal format. URL-safe base64 avoids issues with URL encoding of `+` and `/` characters. This follows the pattern specified in `docs/standards/common.md` Section 6.
+
+### Why not support old-format cursors (backward compatibility)
+
+No mobile client has shipped yet. The only consumer of the old cursor format is the test suite, which we are updating. Adding backward-compatibility logic for a format that was live for zero days adds complexity with no benefit. A clean break is appropriate here.
+
+### Why not change the default limit from 20 to 30
+
+`docs/standards/common.md` Section 6 says "Default limit: 30." The issue description says "returns 20 messages." The current implementation uses 20. For consistency with the issue description and to avoid a behavioral change that could affect mobile client expectations (even though no client is shipped), this spec keeps the default at 20. If alignment with the common standard is preferred, the backend-dev can adjust to 30 -- the spec does not prescribe one value over the other. The important thing is that the default is documented and the mobile team knows it.
+
+### Why MessageCursor as a frozen dataclass
+
+A frozen dataclass provides type safety and immutability. The cursor is decoded once and passed through to the query. Using a plain tuple or dict would lose the semantic meaning and invite bugs.
+
+### Why tuple_ comparison instead of OR-based WHERE clause
+
+SQLAlchemy's `tuple_()` generates a PostgreSQL row-value comparison `(a, b) < (c, d)`, which is semantically correct and optimizable by the query planner. Writing the equivalent `(a < c) OR (a = c AND b < d)` manually is more error-prone and harder to read. PostgreSQL natively supports row-value comparisons and can use the composite index efficiently.
+
+---
+
+## 9. Notes for Developers
+
+### For backend-dev
+
+- **Start with the cursor helpers** (`_encode_cursor`, `_decode_cursor`, `MessageCursor` dataclass). Test them in isolation before modifying the service and route.
+
+- **SQLAlchemy `tuple_` import**: Use `from sqlalchemy import tuple_` for the row-value comparison. This generates correct PostgreSQL SQL.
+
+- **Error handling in `_decode_cursor`**: Wrap the entire decode chain in a single try/except that catches `Exception` and raises `HTTPException(status_code=400, detail="Invalid cursor format")`. Do not expose internal error messages (no "invalid base64" vs "invalid JSON" distinction to the client).
+
+- **base64 padding**: `base64.urlsafe_b64encode()` may produce trailing `=` padding characters. These are valid in URLs but some clients may strip them. To be safe, strip padding on encode and add it back on decode. The standard formula: add `=` characters until `len(s) % 4 == 0`.
+
+- **Test update scope**: Update the existing tests that pass plain ISO cursors. Search for `cursor=` in both test files to find them. The cursor tests in the service file pass `datetime` objects directly -- those change to `MessageCursor` objects.
+
+- **Keep the route handler thin**: The route should decode the cursor and pass a `MessageCursor` to the service. All cursor encoding (for `next_cursor`) happens in the service. The route does not need to know the cursor internals beyond decoding.
+
+### For backend-tester
+
+- **Test the roundtrip**: Encode a cursor, decode it, verify the values match. This catches encoding bugs.
+
+- **Test the tiebreaker scenario**: Create two mock messages with the exact same `created_at` but different UUIDs. Paginate with `limit=1`. First page should return the message with the larger `(created_at, id)` tuple. Second page (using first page's `next_cursor`) should return the other message.
+
+- **Test invalid cursors exhaustively**: Each malformed cursor variant (bad base64, bad JSON, missing fields, wrong types) should produce HTTP 400 with the exact error message.
+
+- **Verify no regressions**: After updating existing tests, run the full `test_chat_routes.py` and `test_chat_service.py` suites. All POST-endpoint tests should be completely unaffected.


### PR DESCRIPTION
## messages-pagination

Upgrades GET /characters/:id/messages cursor-based pagination from plain ISO timestamp to composite (created_at, id) cursor encoded as base64 URL-safe JSON. Fixes correctness bug where same-timestamp messages could be skipped/duplicated.

Closes #9

---

## Pipeline Summary

| Stage | Agent | Status |
|-------|-------|--------|
| Architecture | architect | ✅ |
| Backend Implementation | backend-dev | ✅ |
| Backend Tests | backend-tester | ✅ |
| Documentation | doc-writer | ✅ |
| Code Review | reviewer | ✅ Approved |

## Spec
`shared/feature-specs/messages-pagination.md`

## Test Coverage
- **192 chat tests** — 100% line & branch coverage on routes + service
- **952 total tests** passing (0 failures)

## Key Changes
- Composite `(created_at, id)` cursor with base64 URL-safe encoding
- SQLAlchemy `tuple_()` for row-value comparison
- Invalid cursor → HTTP 400 (not 500)
- 39 new edge case tests (invalid cursors, same-timestamp tiebreaker, multi-page walk)

🤖 Generated via `/pipeline-run P01-07`