### PR TITLE
feat(onboarding-endpoint): onboarding-endpoint [P01-09]

### DIFF
--- a/.claude/agent-memory/architect/MEMORY.md
+++ b/.claude/agent-memory/architect/MEMORY.md
@@ -147,3 +147,21 @@
 - For features that are pure external-API wrappers (Mem0, etc.), the "Data Models" section is "no new tables, no new columns" but should list which existing columns are READ.
 - When an external SDK returns data in its own format, document the expected response shape and how each field maps to the Pydantic schema.
 - For features with multiple routers in one module, document the registration pattern in main.py explicitly.
+
+## Key Decisions Log (P01-09)
+
+- P01-09: Onboarding memories seeded as GLOBAL (user_id only, no agent_id) -- basic user facts should be visible to all characters per docs/05-ai-bellek.md.
+- P01-09: Single Haiku call for all 7 Q&A pairs -- cheaper and faster than 7 separate calls.
+- P01-09: Deterministic fallback when Haiku returns unparseable JSON -- onboarding must not block on LLM flakiness.
+- P01-09: 409 Conflict for re-onboarding -- prevents duplicate memory seeding.
+- P01-09: Profile.name updated from preferred_name answer if different -- users register with full name but prefer nicknames.
+- P01-09: Foreground Mem0 seeding (not background task) -- one-time operation, need accurate success/failure reporting for retries.
+- P01-09: Ordering: Haiku (stateless) -> Mem0 (idempotent) -> DB flag -- maximizes retry safety.
+- P01-09: No new config values needed -- anthropic_api_key, claude_haiku_model, mem0_api_key all exist.
+
+## Implementation State After P01-08
+
+- `backend/app/routes/` has `__init__.py` + `health.py` + `auth.py` + `characters.py` + `chat.py` + `memories.py`.
+- `backend/app/services/` has `__init__.py` (empty) + `auth_service.py` + `character_service.py` + `chat_service.py` + `memory_service.py`.
+- `backend/app/schemas/` has `__init__.py` (empty) + `health.py` + `auth.py` + `character.py` + `chat.py` + `memory.py`.
+- `backend/app/main.py` registers health, auth, characters, chat, and memories (global + character) routers (6 include_router calls).

--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -40,7 +40,19 @@
 - Backend-tester created SEPARATE `_extended.py` files this time (not appended to originals)
 - 110 total tests at 100% coverage
 
+## Onboarding Endpoint Review Notes
+- Single endpoint: POST /api/v1/onboarding/complete (router prefix set in main.py)
+- Global Mem0 scope: `user_id` only, NO `agent_id` -- onboarding facts visible to all characters
+- Retry-safe ordering: Haiku (stateless) -> Mem0 (idempotent) -> DB flag update
+- `except HTTPException: raise` before generic `except Exception` -- critical for preserving 429 etc.
+- Claude SDK is natively async (AsyncAnthropic), Mem0 SDK is sync (wrapped in asyncio.to_thread)
+- Fallback templates in `_FALLBACK_TEMPLATES` dict when Haiku returns unparseable output
+- Pydantic validates max_length BEFORE field_validator strip() runs (documented in tests)
+- Backend-tester created SEPARATE `_extended.py` files (consistent with memory-endpoints pattern)
+- 131 total tests at 100% line + branch coverage
+
 ## Completed Reviews
 - P01-05 character-crud (backend layer): APPROVED 2026-02-23, 0 issues found
 - P01-06 chat-streaming (backend layer): APPROVED 2026-02-24, 0 issues found, 130 tests at 100% coverage
 - P01-08 memory-endpoints (backend layer): APPROVED 2026-02-24, 0 issues found, 110 tests at 100% coverage
+- P01-09 onboarding-endpoint (backend layer): APPROVED 2026-02-24, 0 issues found, 131 tests at 100% coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [P01-06] SSE streaming chat endpoint with Claude AI integration, Mem0 memory, and device action intents
 - [P01-07] Composite cursor-based message pagination with (created_at, id) tiebreaker
 - [P01-08] Mem0 memory management endpoints (list, delete, clear per character + global memories)
+- [P01-09] Onboarding endpoint with Claude Haiku memory conversion and Mem0 seeding
 
 ---
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from fastapi.responses import JSONResponse
 from app.config import settings
 from app.core.logging import setup_logging
 from app.db.session import engine
-from app.routes import auth, characters, chat, health, memories
+from app.routes import auth, characters, chat, health, memories, onboarding
 
 logger = logging.getLogger("ember")
 
@@ -57,6 +57,7 @@ def create_app() -> FastAPI:
     app.include_router(chat.router, prefix="/api/v1/characters", tags=["chat"])
     app.include_router(memories.global_router, prefix="/api/v1", tags=["memories"])
     app.include_router(memories.character_router, prefix="/api/v1/characters", tags=["memories"])
+    app.include_router(onboarding.router, prefix="/api/v1/onboarding", tags=["onboarding"])
 
     # Global exception handler
     @app.exception_handler(Exception)

--- a/backend/app/routes/onboarding.py
+++ b/backend/app/routes/onboarding.py
@@ -1,0 +1,40 @@
+"""Onboarding route handler -- POST /api/v1/onboarding/complete.
+
+Receives 7 onboarding Q&A answers, converts them to Mem0 memories via
+Claude Haiku, seeds global memories, and marks the profile as onboarded.
+All business logic is delegated to OnboardingService.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_current_user, get_db
+from app.models.profile import Profile
+from app.schemas.onboarding import OnboardingRequest, OnboardingResponse
+from app.services.onboarding_service import OnboardingService
+
+router = APIRouter()
+
+
+@router.post("/complete", response_model=OnboardingResponse)
+async def complete_onboarding(
+    body: OnboardingRequest,
+    profile: Profile = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> OnboardingResponse:
+    """Complete the user onboarding flow.
+
+    Accepts 7 Q&A pairs, converts them to structured memory statements
+    via Claude Haiku, seeds them into Mem0 as global memories, and sets
+    ``profiles.onboarding_completed = true``.
+
+    Returns 409 if onboarding has already been completed.
+    Returns 503 if Claude Haiku or Mem0 is unavailable.
+    """
+    service = OnboardingService(db)
+    return await service.complete_onboarding(
+        profile=profile,
+        answers=body.answers,
+    )

--- a/backend/app/schemas/onboarding.py
+++ b/backend/app/schemas/onboarding.py
@@ -1,0 +1,83 @@
+"""Pydantic request/response schemas for the onboarding endpoint.
+
+Covers the POST /api/v1/onboarding/complete request validation
+(7 required Q&A pairs) and the success response.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_QUESTION_KEYS: frozenset[str] = frozenset({
+    "preferred_name",
+    "occupation",
+    "daily_rhythm",
+    "health_goal",
+    "stress_management",
+    "sleep_schedule",
+    "communication_style",
+})
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
+class OnboardingAnswer(BaseModel):
+    """A single Q&A pair from the onboarding flow."""
+
+    question_key: str
+    answer: str = Field(..., min_length=1, max_length=500)
+
+    @field_validator("question_key")
+    @classmethod
+    def validate_key(cls, v: str) -> str:
+        """Reject unknown question keys."""
+        if v not in VALID_QUESTION_KEYS:
+            msg = f"Invalid question_key: {v}"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("answer")
+    @classmethod
+    def strip_answer(cls, v: str) -> str:
+        """Strip whitespace and reject blank answers."""
+        stripped = v.strip()
+        if not stripped:
+            msg = "Answer must not be blank"
+            raise ValueError(msg)
+        return stripped
+
+
+class OnboardingRequest(BaseModel):
+    """Request body for POST /api/v1/onboarding/complete."""
+
+    answers: list[OnboardingAnswer] = Field(..., min_length=7, max_length=7)
+
+    @model_validator(mode="after")
+    def validate_all_keys_present(self) -> Self:
+        """Ensure all 7 question keys are present with no duplicates."""
+        keys = {a.question_key for a in self.answers}
+        if keys != VALID_QUESTION_KEYS:
+            missing = VALID_QUESTION_KEYS - keys
+            msg = f"Missing question keys: {', '.join(sorted(missing))}"
+            raise ValueError(msg)
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class OnboardingResponse(BaseModel):
+    """Response for POST /api/v1/onboarding/complete."""
+
+    onboarding_completed: bool
+    memories_seeded: int

--- a/backend/app/services/onboarding_service.py
+++ b/backend/app/services/onboarding_service.py
@@ -1,0 +1,228 @@
+"""Onboarding service -- business logic for completing user onboarding.
+
+Converts onboarding Q&A answers into structured memory statements using
+Claude Haiku, seeds those memories into Mem0 (global scope), and updates
+the user profile's onboarding_completed flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+
+from anthropic import AsyncAnthropic
+from fastapi import HTTPException, status
+from mem0 import MemoryClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models.profile import Profile
+from app.schemas.onboarding import OnboardingAnswer, OnboardingResponse
+
+logger = logging.getLogger("ember")
+
+# ---------------------------------------------------------------------------
+# Prompt template for Claude Haiku memory conversion
+# ---------------------------------------------------------------------------
+
+_MEMORY_CONVERSION_PROMPT = """\
+You are a memory extraction system. Convert the following onboarding Q&A answers \
+into concise, factual memory statements about the user. Each statement should be a \
+single sentence that an AI companion can use to personalize conversations.
+
+Rules:
+- Output ONLY a JSON array of strings. No other text.
+- Each string is one factual memory statement.
+- Use third person ("Prefers to be called Alex", not "I prefer to be called Alex").
+- Keep each statement under 100 characters.
+- Generate exactly one memory statement per Q&A pair.
+- Do not add information that is not in the answers.
+
+Q&A Pairs:
+1. Preferred name: {preferred_name}
+2. Occupation: {occupation}
+3. Daily rhythm: {daily_rhythm}
+4. Health/fitness goal: {health_goal}
+5. Stress management: {stress_management}
+6. Sleep schedule: {sleep_schedule}
+7. Communication preference: {communication_style}
+
+Output the JSON array now:"""
+
+# ---------------------------------------------------------------------------
+# Fallback templates when Haiku returns unparseable output
+# ---------------------------------------------------------------------------
+
+_FALLBACK_TEMPLATES: dict[str, str] = {
+    "preferred_name": "Prefers to be called {answer}",
+    "occupation": "Works as {answer}",
+    "daily_rhythm": "Daily rhythm: {answer}",
+    "health_goal": "Health/fitness goal: {answer}",
+    "stress_management": "Stress management: {answer}",
+    "sleep_schedule": "Sleep schedule: {answer}",
+    "communication_style": "Communication preference: {answer}",
+}
+
+
+class OnboardingService:
+    """Encapsulates all onboarding business logic."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def complete_onboarding(
+        self,
+        profile: Profile,
+        answers: list[OnboardingAnswer],
+    ) -> OnboardingResponse:
+        """Process onboarding answers: convert to memories, seed Mem0, update profile.
+
+        Steps (ordered for retry safety):
+        1. Check if already onboarded -> 409
+        2. Call Claude Haiku to convert Q&A -> structured memory strings
+        3. Seed memories into Mem0 (global scope, user_id only)
+        4. Update profile.onboarding_completed = True (and name if different)
+        5. Commit DB transaction
+        """
+        # Step 1: Idempotency guard
+        if profile.onboarding_completed:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Onboarding already completed",
+            )
+
+        # Build a lookup dict for easy access by question_key
+        answers_map: dict[str, str] = {a.question_key: a.answer for a in answers}
+
+        # Step 2: Convert answers to structured memories via Haiku
+        memories = await self._convert_answers_to_memories(answers_map)
+
+        # Step 3: Seed memories into Mem0 (global scope)
+        await self._seed_memories(
+            memories=memories,
+            mem0_user_id=profile.mem0_user_id,
+        )
+
+        # Step 4: Update profile
+        profile.onboarding_completed = True
+
+        # Update preferred name if different (case-insensitive comparison)
+        preferred_name = answers_map.get("preferred_name", "").strip()
+        current_name = (profile.name or "").strip()
+        if preferred_name and preferred_name.lower() != current_name.lower():
+            profile.name = preferred_name
+
+        # Step 5: Commit DB changes
+        await self.db.commit()
+
+        return OnboardingResponse(
+            onboarding_completed=True,
+            memories_seeded=len(memories),
+        )
+
+    async def _convert_answers_to_memories(
+        self,
+        answers_map: dict[str, str],
+    ) -> list[str]:
+        """Call Claude Haiku to convert Q&A pairs into structured memory statements.
+
+        Falls back to deterministic formatting if Haiku fails or returns
+        unparseable output.
+        """
+        prompt = _MEMORY_CONVERSION_PROMPT.format(**answers_map)
+
+        try:
+            client = AsyncAnthropic(api_key=settings.anthropic_api_key)
+            response = await client.messages.create(
+                model=settings.claude_haiku_model,
+                max_tokens=512,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            raw_text = response.content[0].text.strip()
+
+            return self._parse_haiku_response(raw_text, answers_map)
+
+        except HTTPException:
+            raise
+        except Exception:
+            logger.exception("Claude Haiku API error during onboarding memory conversion")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="AI service temporarily unavailable",
+            ) from None
+
+    def _parse_haiku_response(
+        self,
+        raw_text: str,
+        answers_map: dict[str, str],
+    ) -> list[str]:
+        """Parse Haiku JSON response; fallback to deterministic format on failure."""
+        try:
+            # Strip markdown code block delimiters if present
+            cleaned = re.sub(r"^```(?:json)?\s*", "", raw_text)
+            cleaned = re.sub(r"\s*```$", "", cleaned)
+
+            parsed = json.loads(cleaned)
+
+            # Validate: must be a list of strings
+            if (
+                isinstance(parsed, list)
+                and all(isinstance(item, str) for item in parsed)
+                and len(parsed) > 0
+            ):
+                return parsed
+
+            # Unexpected format -- fall back
+            logger.warning(
+                "Haiku returned valid JSON but unexpected format; using fallback",
+            )
+            return self._fallback_memories(answers_map)
+
+        except (json.JSONDecodeError, ValueError):
+            logger.warning(
+                "Haiku returned non-JSON response; using fallback memories",
+            )
+            return self._fallback_memories(answers_map)
+
+    @staticmethod
+    def _fallback_memories(answers_map: dict[str, str]) -> list[str]:
+        """Generate deterministic memory strings from onboarding answers."""
+        memories: list[str] = []
+        for key, template in _FALLBACK_TEMPLATES.items():
+            answer = answers_map.get(key, "")
+            if answer:
+                memories.append(template.format(answer=answer))
+        return memories
+
+    async def _seed_memories(
+        self,
+        memories: list[str],
+        mem0_user_id: str,
+    ) -> None:
+        """Seed structured memory statements into Mem0 (global scope).
+
+        Memories are seeded with user_id only (no agent_id) so they are
+        visible to all characters via the global memory search path.
+
+        The Mem0 SDK is synchronous, so calls are wrapped in asyncio.to_thread().
+        """
+        try:
+            client = MemoryClient(api_key=settings.mem0_api_key)
+            # Pass memories as a list of user messages for Mem0 to extract and store
+            messages = [{"role": "user", "content": m} for m in memories]
+            await asyncio.to_thread(
+                client.add,
+                messages,
+                user_id=mem0_user_id,
+            )
+        except Exception:
+            logger.exception(
+                "Mem0 add failed during onboarding for user_id=%s",
+                mem0_user_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="AI service temporarily unavailable",
+            ) from None

--- a/backend/tests/test_onboarding_routes.py
+++ b/backend/tests/test_onboarding_routes.py
@@ -1,0 +1,393 @@
+"""Route-level integration tests for the onboarding endpoint.
+
+Uses the FastAPI test client with mocked dependencies to test HTTP status
+codes, response structure, and request validation for
+POST /api/v1/onboarding/complete.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import json  # noqa: E402
+import uuid  # noqa: E402
+from collections.abc import AsyncGenerator  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from app.dependencies import get_current_user, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_USER_ID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+
+STANDARD_MEMORIES = [
+    "Prefers to be called Alex",
+    "Works as a software engineer",
+    "Morning person",
+    "Goal: lose 10 kg",
+    "Manages stress with walks and podcasts",
+    "Sleeps from 11 PM to 6:30 AM",
+    "Wants regular check-ins without being overwhelmed",
+]
+
+
+def _build_valid_request_body() -> dict[str, list[dict[str, str]]]:
+    """Return a valid request body with all 7 answers."""
+    return {
+        "answers": [
+            {"question_key": "preferred_name", "answer": "Alex"},
+            {"question_key": "occupation", "answer": "Software engineer"},
+            {"question_key": "daily_rhythm", "answer": "Morning person"},
+            {"question_key": "health_goal", "answer": "Lose 10 kg"},
+            {"question_key": "stress_management", "answer": "Walks and podcasts"},
+            {"question_key": "sleep_schedule", "answer": "11 PM to 6:30 AM"},
+            {"question_key": "communication_style", "answer": "Check in regularly"},
+        ],
+    }
+
+
+def _make_fake_profile(
+    onboarding_completed: bool = False,
+    name: str = "Alexander",
+) -> MagicMock:
+    """Create a fake Profile-like object for auth dependency override."""
+    profile = MagicMock()
+    profile.id = FAKE_USER_ID
+    profile.email = "test@ember.ai"
+    profile.name = name
+    profile.mem0_user_id = f"user_{FAKE_USER_ID}"
+    profile.fcm_token = None
+    profile.timezone = "UTC"
+    profile.avatar_url = None
+    profile.preferred_language = "en"
+    profile.onboarding_completed = onboarding_completed
+    profile.subscription_tier = "free"
+    profile.subscription_expires_at = None
+    profile.created_at = datetime.now(tz=UTC)
+    profile.updated_at = datetime.now(tz=UTC)
+    return profile
+
+
+def _mock_haiku_response(memories: list[str]) -> MagicMock:
+    """Create a mock Claude Haiku response."""
+    mock_response = MagicMock()
+    mock_content = MagicMock()
+    mock_content.text = json.dumps(memories)
+    mock_response.content = [mock_content]
+    return mock_response
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+    """Yield a mock database session."""
+    mock_db = AsyncMock()
+    mock_db.commit = AsyncMock()
+    yield mock_db
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client with mocked DB and auth (onboarding NOT completed)."""
+    fake_profile = _make_fake_profile(onboarding_completed=False)
+
+    async def override_user() -> MagicMock:
+        return fake_profile
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def completed_client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client where onboarding is already completed."""
+    fake_profile = _make_fake_profile(onboarding_completed=True)
+
+    async def override_user() -> MagicMock:
+        return fake_profile
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def unauthed_client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client without auth override."""
+    app.dependency_overrides[get_db] = _override_get_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingComplete:
+    """Tests for POST /api/v1/onboarding/complete."""
+
+    @pytest.mark.asyncio
+    async def test_r1_happy_path(self, client: AsyncClient) -> None:
+        """R1: Valid request with all 7 answers returns 200."""
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["onboarding_completed"] is True
+        assert data["memories_seeded"] == 7
+
+    @pytest.mark.asyncio
+    async def test_r2_already_completed(self, completed_client: AsyncClient) -> None:
+        """R2: Returns 409 when onboarding already completed."""
+        resp = await completed_client.post(
+            "/api/v1/onboarding/complete",
+            json=_build_valid_request_body(),
+        )
+        assert resp.status_code == 409
+        assert resp.json()["detail"] == "Onboarding already completed"
+
+    @pytest.mark.asyncio
+    async def test_r3_missing_question_keys(self, client: AsyncClient) -> None:
+        """R3: Returns 422 when fewer than 7 answers provided."""
+        body = _build_valid_request_body()
+        body["answers"] = body["answers"][:5]
+        resp = await client.post("/api/v1/onboarding/complete", json=body)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_r4_duplicate_question_keys(self, client: AsyncClient) -> None:
+        """R4: Returns 422 when duplicate question keys provided."""
+        body = _build_valid_request_body()
+        # Replace last answer with a duplicate of the first key
+        body["answers"][6] = {"question_key": "preferred_name", "answer": "Duplicate"}
+        resp = await client.post("/api/v1/onboarding/complete", json=body)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_r5_invalid_question_key(self, client: AsyncClient) -> None:
+        """R5: Returns 422 when an invalid question_key is provided."""
+        body = _build_valid_request_body()
+        body["answers"][0] = {"question_key": "favorite_color", "answer": "Blue"}
+        resp = await client.post("/api/v1/onboarding/complete", json=body)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_r6_empty_answer(self, client: AsyncClient) -> None:
+        """R6: Returns 422 when an answer is empty string."""
+        body = _build_valid_request_body()
+        body["answers"][0]["answer"] = ""
+        resp = await client.post("/api/v1/onboarding/complete", json=body)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_r7_answer_exceeding_500_chars(self, client: AsyncClient) -> None:
+        """R7: Returns 422 when an answer exceeds 500 characters."""
+        body = _build_valid_request_body()
+        body["answers"][0]["answer"] = "x" * 501
+        resp = await client.post("/api/v1/onboarding/complete", json=body)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_r8_without_auth(self, unauthed_client: AsyncClient) -> None:
+        """R8: Returns 401/403 without auth header."""
+        resp = await unauthed_client.post(
+            "/api/v1/onboarding/complete",
+            json=_build_valid_request_body(),
+        )
+        assert resp.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_r9_haiku_failure(self, client: AsyncClient) -> None:
+        """R9: Returns 503 when Claude Haiku fails."""
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(
+                side_effect=Exception("Claude API error"),
+            )
+            mock_cls.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "AI service temporarily unavailable"
+
+    @pytest.mark.asyncio
+    async def test_r10_mem0_failure(self, client: AsyncClient) -> None:
+        """R10: Returns 503 when Mem0 fails."""
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch(
+                "app.services.onboarding_service.asyncio.to_thread",
+                new_callable=AsyncMock,
+                side_effect=Exception("Mem0 connection refused"),
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "AI service temporarily unavailable"
+
+    @pytest.mark.asyncio
+    async def test_r11_updates_profile_name(self, client: AsyncClient) -> None:
+        """R11: Updates profile name when preferred_name differs from current name."""
+        # The fake profile has name="Alexander", preferred_name answer is "Alex"
+        fake_profile = _make_fake_profile(name="Alexander")
+
+        async def override_user() -> MagicMock:
+            return fake_profile
+
+        app.dependency_overrides[get_current_user] = override_user
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        assert fake_profile.name == "Alex"
+
+    @pytest.mark.asyncio
+    async def test_r12_does_not_update_name_when_same(self, client: AsyncClient) -> None:
+        """R12: Does not update profile name when preferred_name matches."""
+        fake_profile = _make_fake_profile(name="Alex")
+
+        async def override_user() -> MagicMock:
+            return fake_profile
+
+        app.dependency_overrides[get_current_user] = override_user
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        assert fake_profile.name == "Alex"
+
+    @pytest.mark.asyncio
+    async def test_r13_haiku_unparseable_uses_fallback(self, client: AsyncClient) -> None:
+        """R13: Returns 200 with fallback memories when Haiku returns non-JSON."""
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = "Here are the memories:\n- Prefers to be called Alex"
+        mock_response.content = [mock_content]
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["onboarding_completed"] is True
+        assert data["memories_seeded"] == 7
+
+    @pytest.mark.asyncio
+    async def test_r14_whitespace_only_answer(self, client: AsyncClient) -> None:
+        """R14: Returns 422 for whitespace-only answer."""
+        body = _build_valid_request_body()
+        body["answers"][0]["answer"] = "   "
+        resp = await client.post("/api/v1/onboarding/complete", json=body)
+        assert resp.status_code == 422

--- a/backend/tests/test_onboarding_routes_extended.py
+++ b/backend/tests/test_onboarding_routes_extended.py
@@ -1,0 +1,596 @@
+"""Extended route-level integration tests for the onboarding endpoint.
+
+Covers edge cases not in the original test_onboarding_routes.py:
+- Response content-type verification
+- Empty request body / missing answers field
+- Unicode / special characters in answers through HTTP
+- Exactly 500-char answers via HTTP
+- Haiku returns empty list (fallback used)
+- Haiku returns dict (fallback used)
+- Profile name case-insensitive with UPPER
+- Profile name is None
+- Response structure validation (correct keys, correct types)
+- GET method not allowed
+- Multiple validation errors at once
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import json  # noqa: E402
+import uuid  # noqa: E402
+from collections.abc import AsyncGenerator  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from app.dependencies import get_current_user, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_USER_ID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+
+STANDARD_MEMORIES = [
+    "Prefers to be called Alex",
+    "Works as a software engineer",
+    "Morning person",
+    "Goal: lose 10 kg",
+    "Manages stress with walks and podcasts",
+    "Sleeps from 11 PM to 6:30 AM",
+    "Wants regular check-ins without being overwhelmed",
+]
+
+
+def _build_valid_request_body() -> dict[str, list[dict[str, str]]]:
+    """Return a valid request body with all 7 answers."""
+    return {
+        "answers": [
+            {"question_key": "preferred_name", "answer": "Alex"},
+            {"question_key": "occupation", "answer": "Software engineer"},
+            {"question_key": "daily_rhythm", "answer": "Morning person"},
+            {"question_key": "health_goal", "answer": "Lose 10 kg"},
+            {"question_key": "stress_management", "answer": "Walks and podcasts"},
+            {"question_key": "sleep_schedule", "answer": "11 PM to 6:30 AM"},
+            {"question_key": "communication_style", "answer": "Check in regularly"},
+        ],
+    }
+
+
+def _make_fake_profile(
+    onboarding_completed: bool = False,
+    name: str | None = "Alexander",
+) -> MagicMock:
+    """Create a fake Profile-like object for auth dependency override."""
+    profile = MagicMock()
+    profile.id = FAKE_USER_ID
+    profile.email = "test@ember.ai"
+    profile.name = name
+    profile.mem0_user_id = f"user_{FAKE_USER_ID}"
+    profile.fcm_token = None
+    profile.timezone = "UTC"
+    profile.avatar_url = None
+    profile.preferred_language = "en"
+    profile.onboarding_completed = onboarding_completed
+    profile.subscription_tier = "free"
+    profile.subscription_expires_at = None
+    profile.created_at = datetime.now(tz=UTC)
+    profile.updated_at = datetime.now(tz=UTC)
+    return profile
+
+
+def _mock_haiku_response(memories: list[str]) -> MagicMock:
+    """Create a mock Claude Haiku response."""
+    mock_response = MagicMock()
+    mock_content = MagicMock()
+    mock_content.text = json.dumps(memories)
+    mock_response.content = [mock_content]
+    return mock_response
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _override_get_db() -> AsyncGenerator[AsyncMock, None]:
+    """Yield a mock database session."""
+    mock_db = AsyncMock()
+    mock_db.commit = AsyncMock()
+    yield mock_db
+
+
+def _make_client_fixture(
+    onboarding_completed: bool = False,
+    name: str | None = "Alexander",
+) -> AsyncGenerator[AsyncClient, None]:
+    """Factory for creating client fixtures with configurable profile."""
+
+    async def _fixture() -> AsyncGenerator[AsyncClient, None]:
+        fake_profile = _make_fake_profile(
+            onboarding_completed=onboarding_completed,
+            name=name,
+        )
+
+        async def override_user() -> MagicMock:
+            return fake_profile
+
+        app.dependency_overrides[get_db] = _override_get_db
+        app.dependency_overrides[get_current_user] = override_user
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+        app.dependency_overrides.clear()
+
+    return _fixture
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client with mocked DB and auth (onboarding NOT completed)."""
+    fake_profile = _make_fake_profile(onboarding_completed=False)
+
+    async def override_user() -> MagicMock:
+        return fake_profile
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client_name_none() -> AsyncGenerator[AsyncClient, None]:
+    """Provide a client fixture where profile.name is None."""
+    fake_profile = _make_fake_profile(name=None)
+
+    async def override_user() -> MagicMock:
+        return fake_profile
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        ac.fake_profile = fake_profile  # type: ignore[attr-defined]
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client_name_upper() -> AsyncGenerator[AsyncClient, None]:
+    """Provide a client fixture where profile.name is 'ALEX'."""
+    fake_profile = _make_fake_profile(name="ALEX")
+
+    async def override_user() -> MagicMock:
+        return fake_profile
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        ac.fake_profile = fake_profile  # type: ignore[attr-defined]
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingCompleteExtended:
+    """Extended tests for POST /api/v1/onboarding/complete."""
+
+    @pytest.mark.asyncio
+    async def test_response_content_type_json(self, client: AsyncClient) -> None:
+        """Response Content-Type is application/json."""
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        assert "application/json" in resp.headers["content-type"]
+
+    @pytest.mark.asyncio
+    async def test_response_has_correct_keys(self, client: AsyncClient) -> None:
+        """Response JSON has exactly the expected keys."""
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        data = resp.json()
+        assert set(data.keys()) == {"onboarding_completed", "memories_seeded"}
+        assert isinstance(data["onboarding_completed"], bool)
+        assert isinstance(data["memories_seeded"], int)
+
+    @pytest.mark.asyncio
+    async def test_empty_request_body(self, client: AsyncClient) -> None:
+        """Empty request body returns 422."""
+        resp = await client.post(
+            "/api/v1/onboarding/complete",
+            json={},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_null_answers_field(self, client: AsyncClient) -> None:
+        """null answers field returns 422."""
+        resp = await client.post(
+            "/api/v1/onboarding/complete",
+            json={"answers": None},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_answers_not_a_list(self, client: AsyncClient) -> None:
+        """answers as a string instead of list returns 422."""
+        resp = await client.post(
+            "/api/v1/onboarding/complete",
+            json={"answers": "not a list"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_unicode_answers_via_http(self, client: AsyncClient) -> None:
+        """Unicode characters in answers are handled correctly via HTTP."""
+        body = _build_valid_request_body()
+        body["answers"][0]["answer"] = "Mehmet"
+        body["answers"][1]["answer"] = "Yazilim muhendisi"
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=body,
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_exactly_500_char_answer_via_http(self, client: AsyncClient) -> None:
+        """Answer at exactly 500 characters is accepted via HTTP."""
+        body = _build_valid_request_body()
+        body["answers"][1]["answer"] = "a" * 500
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=body,
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_haiku_returns_empty_list_uses_fallback(
+        self, client: AsyncClient,
+    ) -> None:
+        """When Haiku returns an empty JSON array, fallback is used and 200 is returned."""
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = "[]"
+        mock_response.content = [mock_content]
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["memories_seeded"] == 7
+
+    @pytest.mark.asyncio
+    async def test_haiku_returns_dict_uses_fallback(
+        self, client: AsyncClient,
+    ) -> None:
+        """When Haiku returns a JSON dict instead of array, fallback is used."""
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = '{"memories": ["Prefers Alex"]}'
+        mock_response.content = [mock_content]
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["memories_seeded"] == 7
+
+    @pytest.mark.asyncio
+    async def test_profile_name_none_updated_via_route(
+        self, client_name_none: AsyncClient,
+    ) -> None:
+        """Profile name is updated when it starts as None."""
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client_name_none.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        assert client_name_none.fake_profile.name == "Alex"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_profile_name_upper_not_updated(
+        self, client_name_upper: AsyncClient,
+    ) -> None:
+        """Profile name 'ALEX' is not updated when preferred_name is 'Alex'."""
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client_name_upper.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        assert client_name_upper.fake_profile.name == "ALEX"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_get_method_not_allowed(self, client: AsyncClient) -> None:
+        """GET /api/v1/onboarding/complete returns 405 Method Not Allowed."""
+        resp = await client.get("/api/v1/onboarding/complete")
+        assert resp.status_code == 405
+
+    @pytest.mark.asyncio
+    async def test_special_characters_in_all_answers(
+        self, client: AsyncClient,
+    ) -> None:
+        """Answers with special characters (quotes, brackets, ampersands) are accepted."""
+        body = {
+            "answers": [
+                {"question_key": "preferred_name", "answer": 'Al"ex & <friends>'},
+                {"question_key": "occupation", "answer": "Engineer (senior) @ company"},
+                {"question_key": "daily_rhythm", "answer": "Night owl -- 100%!"},
+                {"question_key": "health_goal", "answer": "Run > 5km/day"},
+                {"question_key": "stress_management", "answer": "Music & meditation"},
+                {"question_key": "sleep_schedule", "answer": "12AM-8AM (approx.)"},
+                {"question_key": "communication_style", "answer": "Don't be too pushy"},
+            ],
+        }
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=body,
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_409_response_detail_format(self, client: AsyncClient) -> None:
+        """409 response has correct detail message format."""
+        fake_profile = _make_fake_profile(onboarding_completed=True)
+
+        async def override_user() -> MagicMock:
+            return fake_profile
+
+        app.dependency_overrides[get_current_user] = override_user
+
+        resp = await client.post(
+            "/api/v1/onboarding/complete",
+            json=_build_valid_request_body(),
+        )
+
+        assert resp.status_code == 409
+        data = resp.json()
+        assert "detail" in data
+        assert data["detail"] == "Onboarding already completed"
+
+    @pytest.mark.asyncio
+    async def test_422_response_has_detail_field(self, client: AsyncClient) -> None:
+        """422 response has a detail field with validation error info."""
+        resp = await client.post(
+            "/api/v1/onboarding/complete",
+            json={"answers": []},
+        )
+        assert resp.status_code == 422
+        data = resp.json()
+        assert "detail" in data
+
+    @pytest.mark.asyncio
+    async def test_503_on_haiku_with_connection_error(
+        self, client: AsyncClient,
+    ) -> None:
+        """Connection error to Claude Haiku returns 503."""
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(
+                side_effect=ConnectionError("Failed to connect to Claude"),
+            )
+            mock_cls.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_503_on_haiku_with_timeout(self, client: AsyncClient) -> None:
+        """Timeout to Claude Haiku returns 503."""
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(
+                side_effect=TimeoutError("Claude Haiku timed out"),
+            )
+            mock_cls.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_haiku_markdown_code_block_via_route(
+        self, client: AsyncClient,
+    ) -> None:
+        """Haiku response wrapped in markdown code block is parsed correctly via route."""
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = '```json\n' + json.dumps(STANDARD_MEMORIES) + '\n```'
+        mock_response.content = [mock_content]
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            resp = await client.post(
+                "/api/v1/onboarding/complete",
+                json=_build_valid_request_body(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["memories_seeded"] == 7

--- a/backend/tests/test_onboarding_schemas.py
+++ b/backend/tests/test_onboarding_schemas.py
@@ -1,0 +1,160 @@
+"""Unit tests for onboarding Pydantic schemas.
+
+Tests validation of OnboardingAnswer, OnboardingRequest, and
+OnboardingResponse models, covering all edge cases for question keys,
+answer content, and the 7-key completeness constraint.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from app.schemas.onboarding import (  # noqa: E402
+    VALID_QUESTION_KEYS,
+    OnboardingAnswer,
+    OnboardingRequest,
+    OnboardingResponse,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_valid_answers() -> list[dict[str, str]]:
+    """Return a minimal valid set of 7 onboarding answers as dicts."""
+    return [
+        {"question_key": "preferred_name", "answer": "Alex"},
+        {"question_key": "occupation", "answer": "Software engineer"},
+        {"question_key": "daily_rhythm", "answer": "Morning person"},
+        {"question_key": "health_goal", "answer": "Lose 10 kg"},
+        {"question_key": "stress_management", "answer": "Walks and podcasts"},
+        {"question_key": "sleep_schedule", "answer": "11 PM to 6:30 AM"},
+        {"question_key": "communication_style", "answer": "Check in but don't overwhelm"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# OnboardingAnswer tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingAnswer:
+    """Tests for the OnboardingAnswer model."""
+
+    def test_valid_answer(self) -> None:
+        """T1 partial: A valid answer is accepted."""
+        ans = OnboardingAnswer(question_key="preferred_name", answer="Alex")
+        assert ans.question_key == "preferred_name"
+        assert ans.answer == "Alex"
+
+    def test_invalid_question_key(self) -> None:
+        """T4: Invalid question_key raises ValidationError."""
+        with pytest.raises(ValidationError, match="Invalid question_key"):
+            OnboardingAnswer(question_key="favorite_color", answer="Blue")
+
+    def test_whitespace_only_answer(self) -> None:
+        """T5: Answer that is whitespace only raises ValidationError."""
+        with pytest.raises(ValidationError, match="Answer must not be blank"):
+            OnboardingAnswer(question_key="preferred_name", answer="   ")
+
+    def test_answer_exceeding_500_chars(self) -> None:
+        """T6: Answer exceeding 500 characters raises ValidationError."""
+        long_answer = "x" * 501
+        with pytest.raises(ValidationError):
+            OnboardingAnswer(question_key="preferred_name", answer=long_answer)
+
+    def test_strip_answer_trims_whitespace(self) -> None:
+        """T7: Whitespace is stripped from valid answers."""
+        ans = OnboardingAnswer(question_key="preferred_name", answer="  Alex  ")
+        assert ans.answer == "Alex"
+
+    def test_empty_string_answer(self) -> None:
+        """Empty string answer raises ValidationError."""
+        with pytest.raises(ValidationError):
+            OnboardingAnswer(question_key="preferred_name", answer="")
+
+    def test_all_valid_keys_accepted(self) -> None:
+        """Every valid question key is accepted."""
+        for key in VALID_QUESTION_KEYS:
+            ans = OnboardingAnswer(question_key=key, answer="Some answer")
+            assert ans.question_key == key
+
+
+# ---------------------------------------------------------------------------
+# OnboardingRequest tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingRequest:
+    """Tests for the OnboardingRequest model."""
+
+    def test_valid_request_with_all_keys(self) -> None:
+        """T1: Valid request with all 7 keys passes validation."""
+        req = OnboardingRequest(answers=_build_valid_answers())
+        assert len(req.answers) == 7
+
+    def test_missing_one_key(self) -> None:
+        """T2: 6 answers (missing one key) raises ValidationError."""
+        answers = _build_valid_answers()[:6]
+        with pytest.raises(ValidationError):
+            OnboardingRequest(answers=answers)
+
+    def test_duplicate_key(self) -> None:
+        """T3: 8 answers (duplicate key) raises ValidationError due to max_length=7."""
+        answers = _build_valid_answers()
+        answers.append({"question_key": "preferred_name", "answer": "Another Name"})
+        with pytest.raises(ValidationError):
+            OnboardingRequest(answers=answers)
+
+    def test_duplicate_key_same_count(self) -> None:
+        """Duplicate key with 7 items but missing another key raises ValidationError."""
+        answers = _build_valid_answers()
+        # Replace communication_style with a duplicate preferred_name
+        answers[6] = {"question_key": "preferred_name", "answer": "Duplicate"}
+        with pytest.raises(ValidationError, match="Missing question keys"):
+            OnboardingRequest(answers=answers)
+
+    def test_invalid_key_in_answers(self) -> None:
+        """T4: Invalid question_key within the answers raises ValidationError."""
+        answers = _build_valid_answers()
+        answers[0] = {"question_key": "invalid_key", "answer": "Value"}
+        with pytest.raises(ValidationError):
+            OnboardingRequest(answers=answers)
+
+    def test_order_does_not_matter(self) -> None:
+        """Answers can be in any order and still validate."""
+        answers = list(reversed(_build_valid_answers()))
+        req = OnboardingRequest(answers=answers)
+        assert len(req.answers) == 7
+
+
+# ---------------------------------------------------------------------------
+# OnboardingResponse tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingResponse:
+    """Tests for the OnboardingResponse model."""
+
+    def test_response_serializes_correctly(self) -> None:
+        """T8: Response serializes as expected."""
+        resp = OnboardingResponse(onboarding_completed=True, memories_seeded=7)
+        data = resp.model_dump()
+        assert data == {"onboarding_completed": True, "memories_seeded": 7}
+
+    def test_response_json(self) -> None:
+        """Response produces correct JSON string."""
+        resp = OnboardingResponse(onboarding_completed=True, memories_seeded=7)
+        json_str = resp.model_dump_json()
+        assert '"onboarding_completed":true' in json_str
+        assert '"memories_seeded":7' in json_str

--- a/backend/tests/test_onboarding_schemas_extended.py
+++ b/backend/tests/test_onboarding_schemas_extended.py
@@ -1,0 +1,288 @@
+"""Extended schema tests for onboarding Pydantic models.
+
+Covers edge cases not in the original test_onboarding_schemas.py:
+- Unicode / special characters in answers
+- Boundary-length answers (exactly 1, exactly 500)
+- Missing fields entirely
+- Extra fields ignored
+- Newline-only answers
+- Tab / mixed whitespace
+- Multiple validation errors at once
+- VALID_QUESTION_KEYS is a frozenset with exactly 7 items
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from app.schemas.onboarding import (  # noqa: E402
+    VALID_QUESTION_KEYS,
+    OnboardingAnswer,
+    OnboardingRequest,
+    OnboardingResponse,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_valid_answers() -> list[dict[str, str]]:
+    """Return a minimal valid set of 7 onboarding answers as dicts."""
+    return [
+        {"question_key": "preferred_name", "answer": "Alex"},
+        {"question_key": "occupation", "answer": "Software engineer"},
+        {"question_key": "daily_rhythm", "answer": "Morning person"},
+        {"question_key": "health_goal", "answer": "Lose 10 kg"},
+        {"question_key": "stress_management", "answer": "Walks and podcasts"},
+        {"question_key": "sleep_schedule", "answer": "11 PM to 6:30 AM"},
+        {"question_key": "communication_style", "answer": "Check in but don't overwhelm"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# OnboardingAnswer -- extended edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingAnswerEdgeCases:
+    """Edge-case tests for OnboardingAnswer validation."""
+
+    def test_unicode_answer_accepted(self) -> None:
+        """Unicode characters in answers are accepted."""
+        ans = OnboardingAnswer(
+            question_key="preferred_name",
+            answer="Mehmet Ozgur",
+        )
+        assert ans.answer == "Mehmet Ozgur"
+
+    def test_accented_characters_accepted(self) -> None:
+        """Accented characters in answers are preserved."""
+        ans = OnboardingAnswer(
+            question_key="preferred_name",
+            answer="Rene",
+        )
+        assert ans.answer == "Rene"
+
+    def test_cjk_characters_accepted(self) -> None:
+        """CJK (Chinese/Japanese/Korean) characters are accepted."""
+        ans = OnboardingAnswer(
+            question_key="preferred_name",
+            answer="Taro",
+        )
+        assert ans.answer == "Taro"
+
+    def test_exactly_one_char_answer(self) -> None:
+        """Minimum valid answer: exactly 1 non-whitespace character."""
+        ans = OnboardingAnswer(question_key="preferred_name", answer="A")
+        assert ans.answer == "A"
+
+    def test_exactly_500_char_answer(self) -> None:
+        """Answer at exactly 500 characters is accepted."""
+        long_answer = "x" * 500
+        ans = OnboardingAnswer(question_key="preferred_name", answer=long_answer)
+        assert len(ans.answer) == 500
+
+    def test_499_chars_plus_whitespace_rejected_by_max_length(self) -> None:
+        """499 chars + 2 spaces = 501 chars total, rejected by max_length=500 before strip.
+
+        Pydantic validates max_length on the raw input BEFORE field_validator runs.
+        """
+        answer_with_space = " " + "y" * 499 + " "
+        with pytest.raises(ValidationError):
+            OnboardingAnswer(question_key="preferred_name", answer=answer_with_space)
+
+    def test_498_chars_plus_whitespace_accepted(self) -> None:
+        """498 chars + 2 spaces = 500 chars total, accepted, then stripped to 498."""
+        answer_with_space = " " + "y" * 498 + " "
+        ans = OnboardingAnswer(question_key="preferred_name", answer=answer_with_space)
+        assert len(ans.answer) == 498
+
+    def test_newline_only_answer_rejected(self) -> None:
+        """Answer that is only newlines is rejected (blank after strip)."""
+        with pytest.raises(ValidationError, match="Answer must not be blank"):
+            OnboardingAnswer(question_key="preferred_name", answer="\n\n\n")
+
+    def test_tab_only_answer_rejected(self) -> None:
+        """Answer that is only tabs is rejected (blank after strip)."""
+        with pytest.raises(ValidationError, match="Answer must not be blank"):
+            OnboardingAnswer(question_key="preferred_name", answer="\t\t")
+
+    def test_mixed_whitespace_only_answer_rejected(self) -> None:
+        """Answer that is only mixed whitespace is rejected."""
+        with pytest.raises(ValidationError, match="Answer must not be blank"):
+            OnboardingAnswer(
+                question_key="preferred_name",
+                answer=" \t \n \r\n ",
+            )
+
+    def test_answer_with_internal_newlines_preserved(self) -> None:
+        """Answers with internal newlines are preserved (only outer whitespace stripped)."""
+        ans = OnboardingAnswer(
+            question_key="occupation",
+            answer="  Software engineer\nAt a startup  ",
+        )
+        assert ans.answer == "Software engineer\nAt a startup"
+
+    def test_missing_question_key_field(self) -> None:
+        """Missing question_key field entirely raises ValidationError."""
+        with pytest.raises(ValidationError):
+            OnboardingAnswer(answer="Alex")  # type: ignore[call-arg]
+
+    def test_missing_answer_field(self) -> None:
+        """Missing answer field entirely raises ValidationError."""
+        with pytest.raises(ValidationError):
+            OnboardingAnswer(question_key="preferred_name")  # type: ignore[call-arg]
+
+    def test_null_answer_rejected(self) -> None:
+        """None as answer raises ValidationError."""
+        with pytest.raises(ValidationError):
+            OnboardingAnswer(question_key="preferred_name", answer=None)  # type: ignore[arg-type]
+
+    def test_numeric_answer_rejected(self) -> None:
+        """Numeric (non-string) answer raises ValidationError."""
+        with pytest.raises(ValidationError):
+            OnboardingAnswer(question_key="preferred_name", answer=123)  # type: ignore[arg-type]
+
+    def test_special_characters_in_answer(self) -> None:
+        """Special characters like quotes and brackets are accepted."""
+        ans = OnboardingAnswer(
+            question_key="occupation",
+            answer='Software "engineer" at <company> & more',
+        )
+        assert ans.answer == 'Software "engineer" at <company> & more'
+
+
+# ---------------------------------------------------------------------------
+# OnboardingRequest -- extended edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingRequestEdgeCases:
+    """Edge-case tests for OnboardingRequest validation."""
+
+    def test_empty_answers_list(self) -> None:
+        """Empty answers list raises ValidationError (min_length=7)."""
+        with pytest.raises(ValidationError):
+            OnboardingRequest(answers=[])
+
+    def test_single_answer_rejected(self) -> None:
+        """Only 1 answer raises ValidationError (needs 7)."""
+        with pytest.raises(ValidationError):
+            OnboardingRequest(
+                answers=[{"question_key": "preferred_name", "answer": "Alex"}],
+            )
+
+    def test_missing_answers_field_entirely(self) -> None:
+        """Missing answers field raises ValidationError."""
+        with pytest.raises(ValidationError):
+            OnboardingRequest()  # type: ignore[call-arg]
+
+    def test_null_answers_rejected(self) -> None:
+        """None as answers raises ValidationError."""
+        with pytest.raises(ValidationError):
+            OnboardingRequest(answers=None)  # type: ignore[arg-type]
+
+    def test_all_keys_with_whitespace_trimmed_answers(self) -> None:
+        """All 7 answers with leading/trailing whitespace are trimmed and accepted."""
+        answers = [
+            {"question_key": "preferred_name", "answer": "  Alex  "},
+            {"question_key": "occupation", "answer": "  Engineer  "},
+            {"question_key": "daily_rhythm", "answer": "  Morning  "},
+            {"question_key": "health_goal", "answer": "  Run  "},
+            {"question_key": "stress_management", "answer": "  Walk  "},
+            {"question_key": "sleep_schedule", "answer": "  11-7  "},
+            {"question_key": "communication_style", "answer": "  Friendly  "},
+        ]
+        req = OnboardingRequest(answers=answers)
+        for a in req.answers:
+            assert not a.answer.startswith(" ")
+            assert not a.answer.endswith(" ")
+
+    def test_all_max_length_answers_accepted(self) -> None:
+        """All 7 answers at exactly 500 chars each are accepted."""
+        answers = []
+        for key in VALID_QUESTION_KEYS:
+            answers.append({"question_key": key, "answer": "a" * 500})
+        req = OnboardingRequest(answers=answers)
+        assert len(req.answers) == 7
+
+    def test_mixed_valid_and_one_invalid_key(self) -> None:
+        """6 valid keys and 1 invalid key raises ValidationError."""
+        answers = _build_valid_answers()
+        answers[3] = {"question_key": "bad_key", "answer": "Something"}
+        with pytest.raises(ValidationError):
+            OnboardingRequest(answers=answers)
+
+    def test_all_same_key_rejected(self) -> None:
+        """7 answers with the same key are rejected."""
+        answers = [
+            {"question_key": "preferred_name", "answer": f"Name {i}"}
+            for i in range(7)
+        ]
+        with pytest.raises(ValidationError):
+            OnboardingRequest(answers=answers)
+
+
+# ---------------------------------------------------------------------------
+# OnboardingResponse -- extended tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnboardingResponseEdgeCases:
+    """Edge-case tests for OnboardingResponse serialization."""
+
+    def test_memories_seeded_zero(self) -> None:
+        """memories_seeded can be 0."""
+        resp = OnboardingResponse(onboarding_completed=True, memories_seeded=0)
+        assert resp.memories_seeded == 0
+
+    def test_memories_seeded_large_number(self) -> None:
+        """memories_seeded can be a large number (e.g., if Haiku generates many)."""
+        resp = OnboardingResponse(onboarding_completed=True, memories_seeded=100)
+        assert resp.memories_seeded == 100
+
+    def test_onboarding_completed_false(self) -> None:
+        """onboarding_completed can be False (edge case for error scenarios)."""
+        resp = OnboardingResponse(onboarding_completed=False, memories_seeded=0)
+        assert resp.onboarding_completed is False
+
+
+# ---------------------------------------------------------------------------
+# VALID_QUESTION_KEYS constant
+# ---------------------------------------------------------------------------
+
+
+class TestValidQuestionKeys:
+    """Tests for the VALID_QUESTION_KEYS constant itself."""
+
+    def test_exactly_seven_keys(self) -> None:
+        """VALID_QUESTION_KEYS contains exactly 7 keys."""
+        assert len(VALID_QUESTION_KEYS) == 7
+
+    def test_is_frozenset(self) -> None:
+        """VALID_QUESTION_KEYS is a frozenset (immutable)."""
+        assert isinstance(VALID_QUESTION_KEYS, frozenset)
+
+    def test_expected_keys_present(self) -> None:
+        """All expected question keys are present."""
+        expected = {
+            "preferred_name",
+            "occupation",
+            "daily_rhythm",
+            "health_goal",
+            "stress_management",
+            "sleep_schedule",
+            "communication_style",
+        }
+        assert VALID_QUESTION_KEYS == expected

--- a/backend/tests/test_onboarding_service.py
+++ b/backend/tests/test_onboarding_service.py
@@ -1,0 +1,571 @@
+"""Unit tests for OnboardingService business logic.
+
+Tests the service layer directly with mocked database session, Claude Haiku,
+and Mem0 client. Does not go through HTTP/FastAPI.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import json  # noqa: E402
+import uuid  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from app.schemas.onboarding import OnboardingAnswer  # noqa: E402
+from app.services.onboarding_service import (  # noqa: E402
+    _FALLBACK_TEMPLATES,
+    OnboardingService,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_USER_ID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+
+
+def _make_fake_profile(
+    onboarding_completed: bool = False,
+    name: str = "Alexander",
+) -> MagicMock:
+    """Create a fake Profile-like object."""
+    profile = MagicMock()
+    profile.id = FAKE_USER_ID
+    profile.name = name
+    profile.mem0_user_id = f"user_{FAKE_USER_ID}"
+    profile.onboarding_completed = onboarding_completed
+    return profile
+
+
+def _build_answers() -> list[OnboardingAnswer]:
+    """Return a valid list of 7 OnboardingAnswer objects."""
+    return [
+        OnboardingAnswer(question_key="preferred_name", answer="Alex"),
+        OnboardingAnswer(question_key="occupation", answer="Software engineer"),
+        OnboardingAnswer(question_key="daily_rhythm", answer="Morning person"),
+        OnboardingAnswer(question_key="health_goal", answer="Lose 10 kg"),
+        OnboardingAnswer(question_key="stress_management", answer="Walks and podcasts"),
+        OnboardingAnswer(question_key="sleep_schedule", answer="11 PM to 6:30 AM"),
+        OnboardingAnswer(question_key="communication_style", answer="Check in regularly"),
+    ]
+
+
+def _mock_haiku_response(memories: list[str]) -> MagicMock:
+    """Create a mock Claude Haiku response with a JSON array."""
+    mock_response = MagicMock()
+    mock_content = MagicMock()
+    mock_content.text = json.dumps(memories)
+    mock_response.content = [mock_content]
+    return mock_response
+
+
+def _mock_haiku_response_text(text: str) -> MagicMock:
+    """Create a mock Claude Haiku response with arbitrary text."""
+    mock_response = MagicMock()
+    mock_content = MagicMock()
+    mock_content.text = text
+    mock_response.content = [mock_content]
+    return mock_response
+
+
+STANDARD_MEMORIES = [
+    "Prefers to be called Alex",
+    "Works as a software engineer",
+    "Morning person",
+    "Goal: lose 10 kg",
+    "Manages stress with walks and podcasts",
+    "Sleeps from 11 PM to 6:30 AM",
+    "Wants regular check-ins without being overwhelmed",
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteOnboarding:
+    """Tests for OnboardingService.complete_onboarding()."""
+
+    @pytest.mark.asyncio
+    async def test_s1_raises_409_when_already_completed(self) -> None:
+        """S1: Raises 409 when onboarding_completed is already true."""
+        db = AsyncMock()
+        profile = _make_fake_profile(onboarding_completed=True)
+        service = OnboardingService(db)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == "Onboarding already completed"
+
+    @pytest.mark.asyncio
+    async def test_s1_no_external_calls_when_already_completed(self) -> None:
+        """S1: No Claude or Mem0 calls when already onboarded."""
+        db = AsyncMock()
+        profile = _make_fake_profile(onboarding_completed=True)
+        service = OnboardingService(db)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_claude,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0,
+            pytest.raises(HTTPException),
+        ):
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+        mock_claude.assert_not_called()
+        mock_mem0.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_s2_calls_haiku_with_correct_model(self) -> None:
+        """S2: Calls Claude Haiku with the correct model setting."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient"),
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            # Verify Haiku was called with the configured model
+            call_kwargs = mock_client.messages.create.call_args
+            assert call_kwargs.kwargs["model"] == "claude-haiku-4-5"
+
+    @pytest.mark.asyncio
+    async def test_s3_parses_haiku_json_response(self) -> None:
+        """S3: Parses Haiku JSON response into a list of 7 memory strings."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            result = await service.complete_onboarding(
+                profile=profile, answers=_build_answers(),
+            )
+
+            assert result.memories_seeded == 7
+
+    @pytest.mark.asyncio
+    async def test_s4_fallback_on_invalid_json(self) -> None:
+        """S4: Falls back to deterministic format when Haiku returns invalid JSON."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        # Return non-JSON text
+        mock_response = _mock_haiku_response_text(
+            "Here are the memories:\n- Prefers to be called Alex",
+        )
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            result = await service.complete_onboarding(
+                profile=profile, answers=_build_answers(),
+            )
+
+            assert result.onboarding_completed is True
+            assert result.memories_seeded == 7
+
+    @pytest.mark.asyncio
+    async def test_s5_mem0_called_with_user_id_only(self) -> None:
+        """S5: Mem0 add() is called with user_id only (no agent_id)."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+            patch("app.services.onboarding_service.asyncio") as mock_asyncio,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            # Make to_thread call the function synchronously
+            async def fake_to_thread(func: object, *args: object, **kwargs: object) -> object:
+                return func(*args, **kwargs)  # type: ignore[operator]
+
+            mock_asyncio.to_thread = AsyncMock(side_effect=fake_to_thread)
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            # Verify Mem0 add was called
+            mock_mem0.add.assert_called_once()
+            call_args = mock_mem0.add.call_args
+
+            # Verify user_id is passed
+            assert call_args.kwargs["user_id"] == profile.mem0_user_id
+
+            # Verify agent_id is NOT passed
+            assert "agent_id" not in call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_s6_sets_onboarding_completed(self) -> None:
+        """S6: Sets profile.onboarding_completed = True after Mem0 success."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            assert profile.onboarding_completed is True
+
+    @pytest.mark.asyncio
+    async def test_s7_updates_name_when_different(self) -> None:
+        """S7: Updates profile.name when preferred_name differs."""
+        db = AsyncMock()
+        profile = _make_fake_profile(name="Alexander")
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            # preferred_name in _build_answers() is "Alex" != "Alexander"
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            assert profile.name == "Alex"
+
+    @pytest.mark.asyncio
+    async def test_s8_does_not_update_name_when_same(self) -> None:
+        """S8: Does NOT update profile.name when it matches (case-insensitive)."""
+        db = AsyncMock()
+        profile = _make_fake_profile(name="Alex")
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            # Name should remain "Alex" (set on mock, not changed)
+            assert profile.name == "Alex"
+
+    @pytest.mark.asyncio
+    async def test_s9_commits_once_on_success(self) -> None:
+        """S9: Calls db.commit() exactly once on success."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_s10_raises_503_when_haiku_fails(self) -> None:
+        """S10: Raises 503 when Claude Haiku API fails."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(
+                side_effect=Exception("Claude API connection error"),
+            )
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(HTTPException) as exc_info:
+                await service.complete_onboarding(
+                    profile=profile, answers=_build_answers(),
+                )
+
+            assert exc_info.value.status_code == 503
+            assert exc_info.value.detail == "AI service temporarily unavailable"
+
+    @pytest.mark.asyncio
+    async def test_s11_raises_503_when_mem0_fails(self) -> None:
+        """S11: Raises 503 when Mem0 add() fails."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+            patch(
+                "app.services.onboarding_service.asyncio.to_thread",
+                new_callable=AsyncMock,
+                side_effect=Exception("Mem0 connection refused"),
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0_cls.return_value = mock_mem0
+
+            with pytest.raises(HTTPException) as exc_info:
+                await service.complete_onboarding(
+                    profile=profile, answers=_build_answers(),
+                )
+
+            assert exc_info.value.status_code == 503
+            assert exc_info.value.detail == "AI service temporarily unavailable"
+
+    @pytest.mark.asyncio
+    async def test_s12_onboarding_not_set_when_mem0_fails(self) -> None:
+        """S12: onboarding_completed remains False when Mem0 fails."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+            patch(
+                "app.services.onboarding_service.asyncio.to_thread",
+                new_callable=AsyncMock,
+                side_effect=Exception("Mem0 failure"),
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0_cls.return_value = mock_mem0
+
+            with pytest.raises(HTTPException):
+                await service.complete_onboarding(
+                    profile=profile, answers=_build_answers(),
+                )
+
+            assert profile.onboarding_completed is False
+
+
+class TestConvertAnswersToMemories:
+    """Tests for the private _convert_answers_to_memories method."""
+
+    @pytest.mark.asyncio
+    async def test_s13_prompt_contains_all_answers(self) -> None:
+        """S13: The prompt sent to Haiku contains all 7 answer values."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+
+        answers_map = {
+            "preferred_name": "Alex",
+            "occupation": "Software engineer",
+            "daily_rhythm": "Morning person",
+            "health_goal": "Lose 10 kg",
+            "stress_management": "Walks and podcasts",
+            "sleep_schedule": "11 PM to 6:30 AM",
+            "communication_style": "Check in regularly",
+        }
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            await service._convert_answers_to_memories(answers_map)
+
+            # Verify the prompt contains all answer values
+            call_kwargs = mock_client.messages.create.call_args
+            prompt_content = call_kwargs.kwargs["messages"][0]["content"]
+            for answer_value in answers_map.values():
+                assert answer_value in prompt_content
+
+
+class TestFallbackMemories:
+    """Tests for the static _fallback_memories method."""
+
+    def test_s14_generates_7_formatted_strings(self) -> None:
+        """S14: Generates 7 correctly formatted fallback memories."""
+        answers_map = {
+            "preferred_name": "Alex",
+            "occupation": "Software engineer",
+            "daily_rhythm": "Morning person",
+            "health_goal": "Lose 10 kg",
+            "stress_management": "Walks and podcasts",
+            "sleep_schedule": "11 PM to 6:30 AM",
+            "communication_style": "Check in regularly",
+        }
+
+        memories = OnboardingService._fallback_memories(answers_map)
+        assert len(memories) == 7
+
+        # Verify each memory matches the fallback template
+        for key, template in _FALLBACK_TEMPLATES.items():
+            expected = template.format(answer=answers_map[key])
+            assert expected in memories
+
+    def test_fallback_with_empty_answer(self) -> None:
+        """Fallback skips keys with empty answers."""
+        answers_map = {
+            "preferred_name": "Alex",
+            "occupation": "",
+            "daily_rhythm": "Morning person",
+            "health_goal": "Lose 10 kg",
+            "stress_management": "Walks",
+            "sleep_schedule": "11 PM to 7 AM",
+            "communication_style": "Regular check-ins",
+        }
+        memories = OnboardingService._fallback_memories(answers_map)
+        # Empty occupation should be skipped
+        assert len(memories) == 6
+
+
+class TestParseHaikuResponse:
+    """Tests for _parse_haiku_response edge cases."""
+
+    def test_markdown_code_block_stripped(self) -> None:
+        """JSON wrapped in markdown code blocks is parsed correctly."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {"preferred_name": "Alex"}
+
+        raw = '```json\n["Prefers to be called Alex"]\n```'
+        result = service._parse_haiku_response(raw, answers_map)
+        assert result == ["Prefers to be called Alex"]
+
+    def test_plain_json_parsed(self) -> None:
+        """Plain JSON array is parsed correctly."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {"preferred_name": "Alex"}
+
+        raw = '["Prefers to be called Alex"]'
+        result = service._parse_haiku_response(raw, answers_map)
+        assert result == ["Prefers to be called Alex"]
+
+    def test_non_json_triggers_fallback(self) -> None:
+        """Non-JSON text triggers fallback."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {
+            "preferred_name": "Alex",
+            "occupation": "Engineer",
+            "daily_rhythm": "Morning",
+            "health_goal": "Lose weight",
+            "stress_management": "Walking",
+            "sleep_schedule": "11-7",
+            "communication_style": "Friendly",
+        }
+
+        result = service._parse_haiku_response("Not JSON at all", answers_map)
+        assert len(result) == 7
+        assert result[0] == "Prefers to be called Alex"
+
+    def test_empty_array_triggers_fallback(self) -> None:
+        """Empty JSON array triggers fallback."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {
+            "preferred_name": "Alex",
+            "occupation": "Engineer",
+            "daily_rhythm": "Morning",
+            "health_goal": "Lose weight",
+            "stress_management": "Walking",
+            "sleep_schedule": "11-7",
+            "communication_style": "Friendly",
+        }
+
+        result = service._parse_haiku_response("[]", answers_map)
+        assert len(result) == 7

--- a/backend/tests/test_onboarding_service_extended.py
+++ b/backend/tests/test_onboarding_service_extended.py
@@ -1,0 +1,744 @@
+"""Extended unit tests for OnboardingService.
+
+Covers edge cases not in the original test_onboarding_service.py:
+- Haiku response parsing edge cases (dict, list of non-strings, mixed types,
+  code block without json qualifier, nested JSON, number in list)
+- Fallback memory generation with special characters / unicode
+- HTTPException re-raise in _convert_answers_to_memories (line 148)
+- Mem0 messages format verification
+- Profile name is None
+- Profile name case-insensitive comparison variations
+- DB commit NOT called on Haiku failure
+- DB commit NOT called on Mem0 failure
+- Haiku called with max_tokens=512
+- Answer order invariance at service level
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import json  # noqa: E402
+import uuid  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from app.schemas.onboarding import OnboardingAnswer  # noqa: E402
+from app.services.onboarding_service import (  # noqa: E402
+    OnboardingService,
+    _FALLBACK_TEMPLATES,
+    _MEMORY_CONVERSION_PROMPT,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_USER_ID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+
+STANDARD_MEMORIES = [
+    "Prefers to be called Alex",
+    "Works as a software engineer",
+    "Morning person",
+    "Goal: lose 10 kg",
+    "Manages stress with walks and podcasts",
+    "Sleeps from 11 PM to 6:30 AM",
+    "Wants regular check-ins without being overwhelmed",
+]
+
+
+def _make_fake_profile(
+    onboarding_completed: bool = False,
+    name: str | None = "Alexander",
+) -> MagicMock:
+    """Create a fake Profile-like object."""
+    profile = MagicMock()
+    profile.id = FAKE_USER_ID
+    profile.name = name
+    profile.mem0_user_id = f"user_{FAKE_USER_ID}"
+    profile.onboarding_completed = onboarding_completed
+    return profile
+
+
+def _build_answers() -> list[OnboardingAnswer]:
+    """Return a valid list of 7 OnboardingAnswer objects."""
+    return [
+        OnboardingAnswer(question_key="preferred_name", answer="Alex"),
+        OnboardingAnswer(question_key="occupation", answer="Software engineer"),
+        OnboardingAnswer(question_key="daily_rhythm", answer="Morning person"),
+        OnboardingAnswer(question_key="health_goal", answer="Lose 10 kg"),
+        OnboardingAnswer(question_key="stress_management", answer="Walks and podcasts"),
+        OnboardingAnswer(question_key="sleep_schedule", answer="11 PM to 6:30 AM"),
+        OnboardingAnswer(question_key="communication_style", answer="Check in regularly"),
+    ]
+
+
+def _build_answers_map() -> dict[str, str]:
+    """Return a valid answers map for direct service method calls."""
+    return {
+        "preferred_name": "Alex",
+        "occupation": "Software engineer",
+        "daily_rhythm": "Morning person",
+        "health_goal": "Lose 10 kg",
+        "stress_management": "Walks and podcasts",
+        "sleep_schedule": "11 PM to 6:30 AM",
+        "communication_style": "Check in regularly",
+    }
+
+
+def _mock_haiku_response(memories: list[str]) -> MagicMock:
+    """Create a mock Claude Haiku response with a JSON array."""
+    mock_response = MagicMock()
+    mock_content = MagicMock()
+    mock_content.text = json.dumps(memories)
+    mock_response.content = [mock_content]
+    return mock_response
+
+
+def _mock_haiku_response_text(text: str) -> MagicMock:
+    """Create a mock Claude Haiku response with arbitrary text."""
+    mock_response = MagicMock()
+    mock_content = MagicMock()
+    mock_content.text = text
+    mock_response.content = [mock_content]
+    return mock_response
+
+
+# ---------------------------------------------------------------------------
+# _parse_haiku_response -- extended edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestParseHaikuResponseEdgeCases:
+    """Additional edge cases for Haiku response parsing."""
+
+    def test_json_dict_triggers_fallback(self) -> None:
+        """JSON object (dict) instead of array triggers fallback."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        raw = '{"memory": "Prefers to be called Alex"}'
+        result = service._parse_haiku_response(raw, answers_map)
+        assert len(result) == 7
+        assert result[0] == "Prefers to be called Alex"
+
+    def test_json_list_of_numbers_triggers_fallback(self) -> None:
+        """JSON array of numbers (not strings) triggers fallback."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        raw = "[1, 2, 3, 4, 5, 6, 7]"
+        result = service._parse_haiku_response(raw, answers_map)
+        assert len(result) == 7
+        assert all(isinstance(m, str) for m in result)
+
+    def test_json_list_mixed_types_triggers_fallback(self) -> None:
+        """JSON array with mixed types (string + number) triggers fallback."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        raw = '["Prefers to be called Alex", 42, "Morning person"]'
+        result = service._parse_haiku_response(raw, answers_map)
+        assert len(result) == 7
+
+    def test_code_block_without_json_qualifier(self) -> None:
+        """Code block without 'json' qualifier is still stripped and parsed."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {"preferred_name": "Alex"}
+
+        raw = '```\n["Prefers to be called Alex"]\n```'
+        result = service._parse_haiku_response(raw, answers_map)
+        assert result == ["Prefers to be called Alex"]
+
+    def test_json_string_not_array_triggers_fallback(self) -> None:
+        """JSON string (not array) triggers fallback."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        raw = '"Just a string"'
+        result = service._parse_haiku_response(raw, answers_map)
+        assert len(result) == 7
+
+    def test_json_null_triggers_fallback(self) -> None:
+        """JSON null triggers fallback."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        raw = "null"
+        result = service._parse_haiku_response(raw, answers_map)
+        assert len(result) == 7
+
+    def test_json_nested_array_triggers_fallback(self) -> None:
+        """Nested array (list of lists) triggers fallback."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        raw = '[["nested"], ["arrays"]]'
+        result = service._parse_haiku_response(raw, answers_map)
+        assert len(result) == 7
+
+    def test_valid_json_with_leading_whitespace(self) -> None:
+        """JSON with leading whitespace is parsed correctly."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {"preferred_name": "Alex"}
+
+        raw = '   \n  ["Prefers to be called Alex"]  \n  '
+        result = service._parse_haiku_response(raw, answers_map)
+        assert result == ["Prefers to be called Alex"]
+
+    def test_haiku_returns_more_than_7_memories(self) -> None:
+        """Haiku returns more than 7 strings -- all are accepted (no truncation)."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {"preferred_name": "Alex"}
+
+        memories_10 = [f"Memory {i}" for i in range(10)]
+        raw = json.dumps(memories_10)
+        result = service._parse_haiku_response(raw, answers_map)
+        assert len(result) == 10
+
+    def test_haiku_returns_exactly_1_memory(self) -> None:
+        """Haiku returns a list with exactly 1 string -- accepted (len > 0)."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {"preferred_name": "Alex"}
+
+        raw = '["Only one memory"]'
+        result = service._parse_haiku_response(raw, answers_map)
+        assert result == ["Only one memory"]
+
+    def test_haiku_response_with_unicode(self) -> None:
+        """Haiku response with unicode characters is parsed correctly."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = {"preferred_name": "Mehmet"}
+
+        raw = json.dumps(["Mehmet olarak cagrilmayi tercih eder"])
+        result = service._parse_haiku_response(raw, answers_map)
+        assert len(result) == 1
+        assert "Mehmet" in result[0]
+
+
+# ---------------------------------------------------------------------------
+# _fallback_memories -- extended edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackMemoriesEdgeCases:
+    """Extended tests for deterministic fallback memory generation."""
+
+    def test_fallback_with_special_characters(self) -> None:
+        """Fallback correctly formats answers with special characters."""
+        answers_map = _build_answers_map()
+        answers_map["preferred_name"] = 'Al"ex & <friends>'
+        memories = OnboardingService._fallback_memories(answers_map)
+        assert 'Prefers to be called Al"ex & <friends>' in memories
+
+    def test_fallback_with_very_long_answers(self) -> None:
+        """Fallback handles answers at the 500-char maximum."""
+        answers_map = {k: "a" * 500 for k in _build_answers_map()}
+        memories = OnboardingService._fallback_memories(answers_map)
+        assert len(memories) == 7
+        for m in memories:
+            assert len(m) > 500  # template prefix + 500 char answer
+
+    def test_fallback_preserves_answer_order(self) -> None:
+        """Fallback memories follow _FALLBACK_TEMPLATES key order."""
+        answers_map = _build_answers_map()
+        memories = OnboardingService._fallback_memories(answers_map)
+        expected_order = list(_FALLBACK_TEMPLATES.keys())
+        for i, key in enumerate(expected_order):
+            assert _FALLBACK_TEMPLATES[key].format(answer=answers_map[key]) == memories[i]
+
+    def test_fallback_with_all_empty_answers(self) -> None:
+        """Fallback returns empty list when all answers are empty strings."""
+        answers_map = {k: "" for k in _build_answers_map()}
+        memories = OnboardingService._fallback_memories(answers_map)
+        assert len(memories) == 0
+
+    def test_fallback_with_missing_key(self) -> None:
+        """Fallback skips keys not present in answers_map."""
+        answers_map = {
+            "preferred_name": "Alex",
+            # Missing all other keys
+        }
+        memories = OnboardingService._fallback_memories(answers_map)
+        assert len(memories) == 1
+        assert memories[0] == "Prefers to be called Alex"
+
+    def test_fallback_templates_cover_all_valid_keys(self) -> None:
+        """Every valid question key has a corresponding fallback template."""
+        from app.schemas.onboarding import VALID_QUESTION_KEYS
+
+        for key in VALID_QUESTION_KEYS:
+            assert key in _FALLBACK_TEMPLATES
+
+
+# ---------------------------------------------------------------------------
+# _convert_answers_to_memories -- extended
+# ---------------------------------------------------------------------------
+
+
+class TestConvertAnswersToMemoriesExtended:
+    """Extended tests for Haiku memory conversion."""
+
+    @pytest.mark.asyncio
+    async def test_haiku_called_with_max_tokens_512(self) -> None:
+        """Haiku is called with max_tokens=512."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            await service._convert_answers_to_memories(answers_map)
+
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            assert call_kwargs["max_tokens"] == 512
+
+    @pytest.mark.asyncio
+    async def test_haiku_called_with_single_user_message(self) -> None:
+        """Haiku messages list contains exactly one user message."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            await service._convert_answers_to_memories(answers_map)
+
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            messages = call_kwargs["messages"]
+            assert len(messages) == 1
+            assert messages[0]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_httpexception_re_raised_not_wrapped(self) -> None:
+        """HTTPException raised inside Haiku call is re-raised, not wrapped as 503.
+
+        This covers line 148 of onboarding_service.py -- the `except HTTPException: raise`
+        clause that prevents HTTPExceptions from being caught by the generic Exception handler.
+        """
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            # Simulate an HTTPException being raised during the Haiku call
+            mock_client.messages.create = AsyncMock(
+                side_effect=HTTPException(status_code=429, detail="Rate limited"),
+            )
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(HTTPException) as exc_info:
+                await service._convert_answers_to_memories(answers_map)
+
+            # The original 429 should be preserved, not wrapped in 503
+            assert exc_info.value.status_code == 429
+            assert exc_info.value.detail == "Rate limited"
+
+    @pytest.mark.asyncio
+    async def test_fallback_used_when_haiku_returns_wrong_format(self) -> None:
+        """Fallback is used when Haiku returns valid JSON but wrong structure."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        # Returns a dict instead of a list
+        mock_response = _mock_haiku_response_text('{"key": "value"}')
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            result = await service._convert_answers_to_memories(answers_map)
+
+            assert len(result) == 7
+            assert result[0] == "Prefers to be called Alex"
+
+    @pytest.mark.asyncio
+    async def test_prompt_template_format_is_valid(self) -> None:
+        """The prompt template can be formatted with all required keys."""
+        answers_map = _build_answers_map()
+        # This should not raise any KeyError
+        formatted = _MEMORY_CONVERSION_PROMPT.format(**answers_map)
+        for value in answers_map.values():
+            assert value in formatted
+
+
+# ---------------------------------------------------------------------------
+# complete_onboarding -- extended edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteOnboardingExtended:
+    """Extended tests for the complete_onboarding orchestration method."""
+
+    @pytest.mark.asyncio
+    async def test_profile_name_none_gets_updated(self) -> None:
+        """When profile.name is None, preferred_name answer is used."""
+        db = AsyncMock()
+        profile = _make_fake_profile(name=None)
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            assert profile.name == "Alex"
+
+    @pytest.mark.asyncio
+    async def test_profile_name_case_insensitive_UPPER(self) -> None:
+        """Profile name 'ALEX' matches preferred_name 'Alex' (case-insensitive)."""
+        db = AsyncMock()
+        profile = _make_fake_profile(name="ALEX")
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            # Name should not be updated -- "ALEX".lower() == "alex" == "Alex".lower()
+            assert profile.name == "ALEX"
+
+    @pytest.mark.asyncio
+    async def test_profile_name_with_whitespace_trimmed(self) -> None:
+        """Profile name ' Alex ' should match preferred_name 'Alex' after strip."""
+        db = AsyncMock()
+        profile = _make_fake_profile(name="  Alex  ")
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            # Should not update because strip+lower matches
+            assert profile.name == "  Alex  "
+
+    @pytest.mark.asyncio
+    async def test_db_commit_not_called_on_haiku_failure(self) -> None:
+        """DB commit must NOT be called when Claude Haiku fails."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(
+                side_effect=Exception("Haiku down"),
+            )
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(HTTPException):
+                await service.complete_onboarding(
+                    profile=profile, answers=_build_answers(),
+                )
+
+            db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_db_commit_not_called_on_mem0_failure(self) -> None:
+        """DB commit must NOT be called when Mem0 fails."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+            patch(
+                "app.services.onboarding_service.asyncio.to_thread",
+                new_callable=AsyncMock,
+                side_effect=Exception("Mem0 down"),
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0_cls.return_value = mock_mem0
+
+            with pytest.raises(HTTPException):
+                await service.complete_onboarding(
+                    profile=profile, answers=_build_answers(),
+                )
+
+            db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_onboarding_completed_not_set_on_haiku_failure(self) -> None:
+        """profile.onboarding_completed remains False when Haiku fails."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(
+                side_effect=Exception("Haiku error"),
+            )
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(HTTPException):
+                await service.complete_onboarding(
+                    profile=profile, answers=_build_answers(),
+                )
+
+            assert profile.onboarding_completed is False
+
+    @pytest.mark.asyncio
+    async def test_mem0_messages_format(self) -> None:
+        """Mem0 add() receives memories as list of user-role message dicts."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+            patch("app.services.onboarding_service.asyncio") as mock_asyncio,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            async def fake_to_thread(func: object, *args: object, **kwargs: object) -> object:
+                return func(*args, **kwargs)  # type: ignore[operator]
+
+            mock_asyncio.to_thread = AsyncMock(side_effect=fake_to_thread)
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            # Verify Mem0 add() received the correct format
+            mock_mem0.add.assert_called_once()
+            call_args = mock_mem0.add.call_args
+
+            # First positional arg is the messages list
+            messages = call_args.args[0]
+            assert isinstance(messages, list)
+            assert len(messages) == 7
+            for msg in messages:
+                assert msg["role"] == "user"
+                assert isinstance(msg["content"], str)
+                assert len(msg["content"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_answer_order_does_not_affect_result(self) -> None:
+        """Answers in any order produce the same result."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        # Reverse the answer order
+        answers = list(reversed(_build_answers()))
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            result = await service.complete_onboarding(profile=profile, answers=answers)
+
+            assert result.onboarding_completed is True
+            assert result.memories_seeded == 7
+
+    @pytest.mark.asyncio
+    async def test_returns_onboarding_response_type(self) -> None:
+        """complete_onboarding returns an OnboardingResponse instance."""
+        from app.schemas.onboarding import OnboardingResponse
+
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            result = await service.complete_onboarding(
+                profile=profile, answers=_build_answers(),
+            )
+
+            assert isinstance(result, OnboardingResponse)
+
+    @pytest.mark.asyncio
+    async def test_fallback_memories_seeded_on_non_json_haiku(self) -> None:
+        """When Haiku returns non-JSON, fallback memories are seeded to Mem0."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response_text("Not valid JSON")
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+            patch("app.services.onboarding_service.asyncio") as mock_asyncio,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            async def fake_to_thread(func: object, *args: object, **kwargs: object) -> object:
+                return func(*args, **kwargs)  # type: ignore[operator]
+
+            mock_asyncio.to_thread = AsyncMock(side_effect=fake_to_thread)
+
+            result = await service.complete_onboarding(
+                profile=profile, answers=_build_answers(),
+            )
+
+            assert result.memories_seeded == 7
+
+            # Verify fallback memories were passed to Mem0
+            mock_mem0.add.assert_called_once()
+            messages_arg = mock_mem0.add.call_args.args[0]
+            # Check that the content matches fallback templates
+            contents = [m["content"] for m in messages_arg]
+            assert "Prefers to be called Alex" in contents
+            assert "Works as Software engineer" in contents
+
+    @pytest.mark.asyncio
+    async def test_anthropic_client_created_with_api_key(self) -> None:
+        """AsyncAnthropic is instantiated with the correct API key from settings."""
+        db = AsyncMock()
+        service = OnboardingService(db)
+        answers_map = _build_answers_map()
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            await service._convert_answers_to_memories(answers_map)
+
+            # Verify AsyncAnthropic was instantiated with api_key
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args.kwargs
+            assert "api_key" in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_mem0_client_created_with_api_key(self) -> None:
+        """MemoryClient is instantiated with the correct API key from settings."""
+        db = AsyncMock()
+        profile = _make_fake_profile()
+        service = OnboardingService(db)
+
+        mock_response = _mock_haiku_response(STANDARD_MEMORIES)
+
+        with (
+            patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls,
+            patch("app.services.onboarding_service.MemoryClient") as mock_mem0_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            mock_mem0 = MagicMock()
+            mock_mem0.add.return_value = None
+            mock_mem0_cls.return_value = mock_mem0
+
+            await service.complete_onboarding(profile=profile, answers=_build_answers())
+
+            # Verify MemoryClient was instantiated with api_key
+            mock_mem0_cls.assert_called_once()
+            call_kwargs = mock_mem0_cls.call_args.kwargs
+            assert "api_key" in call_kwargs

--- a/docs/features/onboarding-endpoint.md
+++ b/docs/features/onboarding-endpoint.md
@@ -1,0 +1,301 @@
+# Onboarding Endpoint
+
+> Completes the first-launch onboarding flow by converting 7 Q&A answers into structured Mem0 memories via Claude Haiku, seeding them as global memories visible to all characters, and marking the user profile as onboarded.
+
+**Status**: Released
+**Added in**: Phase 1 (P01-09)
+**Platforms**: Backend
+**GitHub Issue**: #11
+
+---
+
+## Overview
+
+When a new user registers with Ember, the AI companion has zero knowledge about them. The first few conversations would be generic and impersonal. The onboarding endpoint solves this by collecting answers to 7 predefined questions during first launch and converting those answers into structured, third-person memory statements that Mem0 can index and search. This way, every character -- not just the default General Friend -- can personalize conversations from the very first message.
+
+The mobile client presents the onboarding questions after registration and submits all 7 answers in a single `POST /api/v1/onboarding/complete` request. The backend uses Claude Haiku to transform raw user answers (e.g., "I wake up at 6:30, love morning runs") into concise factual statements (e.g., "Morning person, wakes up at 6:30"). These structured memories are seeded into Mem0 as global memories (no `agent_id`), making them visible to all characters through the two-layer memory search in the chat flow. The profile's `onboarding_completed` flag is then set to `true` so the client does not show the onboarding flow again.
+
+If Claude Haiku is temporarily unavailable or returns malformed output, a deterministic fallback formatter generates functional memories without blocking the user. The endpoint is retry-safe: if Mem0 or Haiku fails, the `onboarding_completed` flag stays `false` and the client can resubmit.
+
+---
+
+## Architecture
+
+### How It Works (Data Flow)
+
+1. The mobile client presents 7 onboarding questions to the user after registration and collects their answers.
+2. The client sends `POST /api/v1/onboarding/complete` with all 7 Q&A pairs in the request body, along with `Authorization: Bearer <jwt>`.
+3. The route handler resolves the authenticated user via the `get_current_user` dependency, providing the `Profile` with `onboarding_completed`, `mem0_user_id`, and `name`.
+4. The service checks `profile.onboarding_completed`. If already `true`, it returns HTTP 409 Conflict immediately (no external calls are made).
+5. The service builds a prompt containing all 7 Q&A pairs and sends a single request to Claude Haiku via `AsyncAnthropic` (native async, no thread wrapping).
+6. Haiku returns a JSON array of 7 third-person memory statements. The service strips any markdown code block delimiters and parses the JSON.
+7. If Haiku returns unparseable output, the service falls back to deterministic template-based formatting (see Fallback Memory Formatting below).
+8. The service seeds the memory statements into Mem0 by calling `client.add()` with `user_id` only (no `agent_id`), wrapped in `asyncio.to_thread()` because the Mem0 SDK is synchronous. This stores them as global memories.
+9. The service updates `profile.onboarding_completed = True`. If the `preferred_name` answer differs from `profile.name` (case-insensitive comparison), the profile name is updated as well.
+10. The service commits the DB transaction and returns `{"onboarding_completed": true, "memories_seeded": N}`.
+
+### Memory Seeding Strategy
+
+Onboarding memories are seeded as **global memories** (`user_id` only, no `agent_id`). This is a deliberate design decision based on `docs/05-ai-bellek.md`:
+
+- Global memories contain "basic user information visible to all characters" -- name, profession, goals, sleep schedule, etc.
+- Onboarding answers are exactly this category of information.
+- If memories were scoped to the companion character's `agent_id`, other characters (English Teacher, Fitness Coach, etc.) would not see them in their character-scoped search.
+- The two-layer memory search in the chat flow (P01-06) searches both global (`user_id` only) and character-scoped (`user_id` + `agent_id`). Global memories are found by the global search path for all characters.
+
+The memories are passed to Mem0 as a list of `{"role": "user", "content": text}` dicts. The Mem0 SDK extracts and stores individual memory entries from this content.
+
+### Retry Safety (Operation Ordering)
+
+The order of operations is designed for safe retries:
+
+1. **Claude Haiku call** (stateless) -- can be retried any number of times with no side effects.
+2. **Mem0 seeding** (idempotent) -- Mem0 deduplicates, so reseeding the same memories is harmless.
+3. **DB flag update** (`onboarding_completed = true`) -- only set after both external calls succeed.
+
+If Mem0 fails at step 2, the flag stays `false` and the client retries the entire flow. If the DB commit fails at step 3, Mem0 already has the memories (harmless duplicates on retry) and the next retry sets the flag.
+
+### Claude Haiku Memory Conversion
+
+A single Haiku call converts all 7 answers at once (not 7 separate calls). This reduces latency, cost, and gives Haiku the full context. The prompt instructs Haiku to output a JSON array of 7 third-person factual statements, each under 100 characters.
+
+The service uses `AsyncAnthropic` (the Anthropic SDK's native async client) with `max_tokens=512` and `model=settings.claude_haiku_model`.
+
+### Fallback Memory Formatting
+
+If Haiku returns a response that cannot be parsed as a JSON array of non-empty strings, the service uses a deterministic template-based fallback:
+
+| Question Key | Fallback Format |
+|-------------|----------------|
+| `preferred_name` | `"Prefers to be called {answer}"` |
+| `occupation` | `"Works as {answer}"` |
+| `daily_rhythm` | `"Daily rhythm: {answer}"` |
+| `health_goal` | `"Health/fitness goal: {answer}"` |
+| `stress_management` | `"Stress management: {answer}"` |
+| `sleep_schedule` | `"Sleep schedule: {answer}"` |
+| `communication_style` | `"Communication preference: {answer}"` |
+
+The fallback memories are less natural-sounding but fully functional for Mem0 search. The user is not aware of which path was used.
+
+### Database Tables Involved
+
+| Table | Operation | Notes |
+|-------|-----------|-------|
+| `profiles` | UPDATE | Sets `onboarding_completed = true`; optionally updates `name` if preferred name differs |
+| `characters` | (none) | Not accessed by this feature. The default companion character already exists from registration (P01-04). |
+
+No new tables or columns are created by this feature.
+
+---
+
+## API Reference
+
+### POST /api/v1/onboarding/complete
+
+Completes the user onboarding by converting Q&A answers into structured Mem0 memories and marking the profile as onboarded.
+
+**Auth**: Bearer JWT required
+**Content-Type**: `application/json`
+
+**Request Body**:
+
+```json
+{
+  "answers": [
+    { "question_key": "preferred_name", "answer": "Alex" },
+    { "question_key": "occupation", "answer": "Software engineer at a startup" },
+    { "question_key": "daily_rhythm", "answer": "Morning person, I wake up at 6:30" },
+    { "question_key": "health_goal", "answer": "Lose 10 kg and run a half marathon" },
+    { "question_key": "stress_management", "answer": "I go for walks and listen to podcasts" },
+    { "question_key": "sleep_schedule", "answer": "Usually 11 PM to 6:30 AM" },
+    { "question_key": "communication_style", "answer": "I want someone who checks in on me but doesn't overwhelm me" }
+  ]
+}
+```
+
+**Request Fields**:
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `answers` | array | yes | Exactly 7 items |
+| `answers[].question_key` | string | yes | Must be one of the 7 valid keys (see below) |
+| `answers[].answer` | string | yes | Min 1 char, max 500 chars; whitespace-trimmed; blank-after-trim is rejected |
+
+**Valid `question_key` values**:
+
+| Key | Onboarding Question |
+|-----|---------------------|
+| `preferred_name` | "What should I call you?" |
+| `occupation` | "What do you do for work?" |
+| `daily_rhythm` | "Are you a morning person or a night owl?" |
+| `health_goal` | "What are your health/fitness goals?" |
+| `stress_management` | "What do you do for stress management?" |
+| `sleep_schedule` | "What is your sleep schedule like?" |
+| `communication_style` | "What kind of friendship do you expect from me?" |
+
+**Validation rules**:
+- All 7 question keys must be present. No duplicates, no missing keys. Order does not matter.
+- Each answer must be non-empty after whitespace trimming.
+- Pydantic validates `max_length=500` on the raw input string before the `strip()` field validator runs. An answer of 498 chars + 2 trailing spaces (500 total) is accepted, but 499 chars + 2 trailing spaces (501 total) is rejected before stripping.
+
+**Response 200 OK**:
+
+```json
+{
+  "onboarding_completed": true,
+  "memories_seeded": 7
+}
+```
+
+| Response Field | Type | Notes |
+|----------------|------|-------|
+| `onboarding_completed` | boolean | Always `true` on success |
+| `memories_seeded` | integer | Number of memory statements seeded to Mem0. Typically 7 but may vary if Haiku generates more or fewer statements. |
+
+**Error Responses**:
+
+| Status | Detail | When |
+|--------|--------|------|
+| 401 | `"Invalid or expired token"` | Missing or invalid JWT |
+| 409 | `"Onboarding already completed"` | `profiles.onboarding_completed` is already `true` |
+| 422 | Standard FastAPI validation error | Missing keys, duplicate keys, invalid key, empty/blank answer, answer > 500 chars |
+| 503 | `"AI service temporarily unavailable"` | Claude Haiku or Mem0 API error |
+
+**Notes**:
+- This endpoint is retry-safe. If Claude or Mem0 fails (503), the `onboarding_completed` flag remains `false` and the client can retry.
+- If the `preferred_name` answer differs from `profiles.name` (case-insensitive, whitespace-trimmed comparison), the profile name is updated in the same transaction. This lets a user who registered as "Alexander" be called "Alex" by the companion.
+- The 409 response is a safety net for race conditions or misbehaving clients. The mobile client checks `onboarding_completed` from the login/register response and only shows the onboarding flow when it is `false`.
+
+---
+
+## Configuration
+
+No new configuration values were introduced for this feature. All required settings already exist from prior features (P01-01, P01-06).
+
+| Setting | Source | Description |
+|---------|--------|-------------|
+| `anthropic_api_key` | `app/config.py` (AWS Secrets Manager) | API key for the Anthropic Claude API. Used by `AsyncAnthropic`. |
+| `claude_haiku_model` | `app/config.py` | Model identifier for Claude Haiku (e.g., `claude-haiku-4-5-20241022`). |
+| `mem0_api_key` | `app/config.py` (AWS Secrets Manager) | API key for Mem0.ai cloud. Used by `MemoryClient`. |
+
+No new packages were added. The `anthropic` and `mem0ai` Python packages were already dependencies from P01-06 (chat-streaming).
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `backend/app/routes/onboarding.py` | Route handler. Defines a single router with one endpoint (`POST /complete`). Delegates all business logic to `OnboardingService`. |
+| `backend/app/services/onboarding_service.py` | `OnboardingService` class with 5 methods: `complete_onboarding()` (public entry point), `_convert_answers_to_memories()` (Haiku call), `_parse_haiku_response()` (JSON parsing + fallback trigger), `_fallback_memories()` (deterministic formatter), `_seed_memories()` (Mem0 add call). |
+| `backend/app/schemas/onboarding.py` | `OnboardingAnswer`, `OnboardingRequest`, `OnboardingResponse` Pydantic models, plus the `VALID_QUESTION_KEYS` frozenset constant. |
+| `backend/app/main.py` | Modified to import `onboarding` module and register the router at `/api/v1/onboarding`. |
+
+### Router Registration
+
+```python
+# In main.py:
+from app.routes import auth, characters, chat, health, memories, onboarding
+
+app.include_router(onboarding.router, prefix="/api/v1/onboarding", tags=["onboarding"])
+```
+
+---
+
+## Testing
+
+### Coverage Summary
+
+| File | Tests (original + extended) | Line Coverage | Branch Coverage |
+|------|----------------------------|---------------|-----------------|
+| `test_onboarding_schemas.py` + `_extended.py` | 15 + 31 = 46 | 100% | 100% |
+| `test_onboarding_service.py` + `_extended.py` | 18 + 33 = 51 | 100% | 100% |
+| `test_onboarding_routes.py` + `_extended.py` | 16 + 18 = 34 | 100% | 100% |
+| **Total** | **131 passed, 0 failed** | **100%** (all 3 source files) | **100%** |
+
+Full backend suite after this feature: 1193 passed, 0 failed, 0 skipped.
+
+### Key Test Scenarios
+
+**Route tests** cover the complete HTTP integration: successful onboarding (200), already-completed guard (409), all Pydantic validation edge cases (422), missing auth (401), Claude Haiku failure (503), Mem0 failure (503), fallback on unparseable Haiku response (200), profile name update behavior, response content-type verification, and method-not-allowed (405 for GET).
+
+**Service tests** verify the business logic in isolation: idempotency guard (409 before external calls), correct Haiku prompt construction, JSON parsing of Haiku response, fallback trigger on malformed JSON, Mem0 called with `user_id` only (no `agent_id`), profile flag and name updates, DB commit ordering, 503 on Haiku/Mem0 failures, and the `HTTPException` re-raise path (line 148) that ensures HTTP errors from the Haiku call path are not wrapped as 503.
+
+**Schema tests** verify Pydantic validation: all 7 keys required, duplicate key detection, invalid keys, whitespace-only answers, boundary lengths (1 char, 500 chars, 501 chars), Unicode/CJK characters, special characters, and the `VALID_QUESTION_KEYS` constant.
+
+### Running Tests
+
+Onboarding tests only:
+
+```bash
+cd backend && python -m pytest tests/test_onboarding_schemas.py tests/test_onboarding_service.py tests/test_onboarding_routes.py -v
+```
+
+All onboarding tests (including extended edge cases):
+
+```bash
+cd backend && python -m pytest tests/test_onboarding_schemas.py tests/test_onboarding_schemas_extended.py tests/test_onboarding_service.py tests/test_onboarding_service_extended.py tests/test_onboarding_routes.py tests/test_onboarding_routes_extended.py -v
+```
+
+Full backend suite:
+
+```bash
+cd backend && python -m pytest tests/ -v --ignore=tests/test_migration.py
+```
+
+---
+
+## Known Limitations
+
+- **No partial onboarding**: All 7 answers must be submitted together in a single request. There is no "save progress" endpoint. If the user closes the app mid-onboarding, answers are lost and must be re-entered.
+- **No re-onboarding**: Once `onboarding_completed` is `true`, the endpoint returns 409. There is no way to re-do onboarding or update the seeded memories through this endpoint. Users can manage individual memories via the memory endpoints (P01-08).
+- **No mobile UI in this feature**: The mobile client owns the question presentation UI. This feature only provides the backend endpoint that the client submits answers to.
+- **Mem0 deduplication is assumed**: On retry after a DB commit failure, the same memories may be submitted to Mem0 again. The implementation assumes Mem0 deduplicates or handles duplicates gracefully.
+- **Pydantic max_length applies before strip**: The `max_length=500` constraint on answers is validated on the raw input string before the `strip()` field validator runs. This means an answer of 499 visible characters plus 2 trailing spaces (501 total) is rejected, even though the stripped content is only 499 characters.
+- **Haiku "not found" detection on HTTPException re-raise**: The service re-raises `HTTPException` instances from the Haiku call path without wrapping them as 503. If a rate-limit (429) or other HTTP error propagates from the Anthropic SDK as an `HTTPException`, it is passed through with its original status code rather than being normalized to 503.
+
+---
+
+## Design Decisions
+
+### Why Claude Haiku converts Q&A to structured memories
+
+Raw user answers are conversational and not ideal for Mem0 storage and retrieval. Claude Haiku converts them into concise, third-person factual statements that Mem0 can index and search more effectively. Haiku is chosen over Sonnet because this is a simple text transformation task that does not require complex reasoning, and Haiku is significantly cheaper and faster.
+
+### Why a single Haiku call (not 7 separate calls)
+
+Sending all 7 Q&A pairs in one prompt reduces latency (one round-trip instead of 7), reduces cost (one prompt overhead instead of 7), and allows Haiku to see the full context of the user when generating memories.
+
+### Why onboarding memories are seeded as global (no agent_id)
+
+Basic user facts from onboarding -- name, profession, goals, sleep schedule -- should be available to all characters, not just the companion. Global memories are found by every character's global memory search path.
+
+### Why onboarding runs in the foreground (not a background task)
+
+Unlike the chat flow (P01-06) where memory persistence happens in a background task so the user does not wait, onboarding is a one-time operation where the user expects a brief loading state. Running in the foreground allows the endpoint to report success or failure accurately and keeps the retry logic simple.
+
+### Why the profile name is updated from preferred_name
+
+During registration, users provide their full name. During onboarding, they may answer "What should I call you?" with a nickname. Updating `profiles.name` ensures the AI uses the preferred name consistently, not just in Mem0 memories.
+
+---
+
+## Extending This Feature
+
+**Adding more onboarding questions**: Add the new question key to the `VALID_QUESTION_KEYS` frozenset in `backend/app/schemas/onboarding.py`. Add a corresponding fallback template to `_FALLBACK_TEMPLATES` in `backend/app/services/onboarding_service.py`. Update the `_MEMORY_CONVERSION_PROMPT` to include the new Q&A pair. Update the `min_length` and `max_length` constraints on the `answers` field in `OnboardingRequest`. Update all tests that assert on the count of required keys.
+
+**Allowing re-onboarding**: Remove or modify the 409 guard in `OnboardingService.complete_onboarding()`. Consider clearing existing onboarding-related memories from Mem0 before reseeding to avoid duplicates.
+
+**Seeding character-scoped memories**: To seed memories that are visible only to a specific character, pass `agent_id=character.mem0_agent_id` in the `_seed_memories()` call alongside `user_id`. This would change the memory scope from global to character-specific.
+
+**Adding onboarding status to the profile API**: The mobile client currently checks `onboarding_completed` from the login/register response. If a separate profile endpoint is added, include this flag in the response schema.
+
+---
+
+## Related Documentation
+
+- [AI Memory System](../05-ai-bellek.md) -- Mem0 integration design, memory isolation, and the 7 onboarding questions
+- [Chat Streaming](./chat-streaming.md) -- P01-06, where the two-layer memory search uses the global memories seeded here
+- [Memory Endpoints](./memory-endpoints.md) -- P01-08, where users can view and delete the memories created by onboarding
+- [Auth Endpoints](./auth-endpoints.md) -- P01-04, where registration creates the default companion character and profile
+- [Database Schema and API Endpoints](../04-veri-api.md) -- profiles and characters table definitions

--- a/docs/pipeline/onboarding-endpoint-architect.handoff.md
+++ b/docs/pipeline/onboarding-endpoint-architect.handoff.md
@@ -1,0 +1,102 @@
+# Architect Handoff: Onboarding Endpoint
+
+**Date**: 2026-02-24
+**Agent**: architect
+**Status**: COMPLETE
+
+## What Was Designed
+
+A single POST /api/v1/onboarding/complete endpoint that receives answers to 7 onboarding questions, uses Claude Haiku to convert the raw Q&A pairs into structured third-person memory statements, seeds those memories into Mem0 as global memories (visible to all characters), and sets profiles.onboarding_completed=true in the database.
+
+## Spec Location
+
+`shared/feature-specs/onboarding-endpoint.md`
+
+## Layer
+
+backend
+
+## Key Decisions
+
+- **Global memory scope (no agent_id)**: Onboarding memories are seeded as global memories (user_id only, no agent_id) because they contain basic user facts (name, profession, goals, sleep schedule) that all characters should see. Per docs/05-ai-bellek.md, global memories are "basic user information visible to all characters."
+
+- **Single Claude Haiku call for all 7 answers**: One prompt with all Q&A pairs, not 7 separate calls. Cheaper, faster, and gives Haiku full context for generating coherent memory statements.
+
+- **Deterministic fallback when Haiku fails**: If Haiku returns unparseable output, a deterministic template-based formatter produces functional memories. Onboarding never blocks on LLM flakiness.
+
+- **409 Conflict for re-onboarding**: Once onboarding_completed=true, the endpoint rejects subsequent calls. Prevents duplicate memory seeding and simplifies client logic.
+
+- **Profile name update from preferred_name**: If the onboarding "preferred name" answer differs from profiles.name (set during registration), the name is updated. Users often register with full names but prefer nicknames.
+
+- **Retry-safe ordering**: Claude (stateless) -> Mem0 (idempotent) -> DB flag update. If Mem0 fails, flag stays false and client retries. If DB fails, Mem0 has memories (harmless duplicates) and next retry sets the flag.
+
+- **Not a background task**: Unlike chat memory persistence (P01-06), onboarding runs in the foreground so the endpoint can report success/failure accurately and the client can retry on 503.
+
+## File Manifest
+
+```
+Backend:
+  CREATE  backend/app/routes/onboarding.py
+  CREATE  backend/app/services/onboarding_service.py
+  CREATE  backend/app/schemas/onboarding.py
+  MODIFY  backend/app/main.py
+  CREATE  backend/tests/test_onboarding_routes.py
+  CREATE  backend/tests/test_onboarding_service.py
+  CREATE  backend/tests/test_onboarding_schemas.py
+
+Shared:
+  CREATE  shared/feature-specs/onboarding-endpoint.md
+  CREATE  docs/pipeline/onboarding-endpoint-architect.handoff.md
+```
+
+| Action | Count |
+|--------|-------|
+| CREATE | 6 backend + 2 shared = 8 |
+| MODIFY | 1 |
+| **Total** | **9** |
+
+## Assumptions Made
+
+- The 7 onboarding questions from docs/05-ai-bellek.md Section "Onboarding Memory Seed" are the definitive list. No questions have been added or removed since that doc was written.
+- The default "Ember" companion character (template=companion, is_default=true) already exists for every user, created during registration (P01-04).
+- Mem0's client.add() with user_id only (no agent_id) seeds global memories that are found by the two-layer search in the chat flow (P01-06 global search path).
+- The Mem0 SDK's add() method deduplicates or handles duplicate memory additions gracefully on retries.
+- Mobile clients check onboarding_completed from the login/register response and only show the onboarding flow when it is false.
+
+## Dependencies
+
+- Requires: P01-04 (auth-endpoints -- Profile with onboarding_completed, default Character, get_current_user)
+- Requires: P01-01 (project-setup -- FastAPI scaffold, config.py with anthropic_api_key, mem0_api_key, claude_haiku_model)
+- Requires: P01-02 (database-schema -- Profile and Character models)
+- Requires: P01-03 (cognito-auth-middleware -- JWT verification)
+- Blocks: No other Phase 1 features depend on this.
+
+## Notes for Developers
+
+### For backend-dev
+
+1. **No new config values needed.** anthropic_api_key, claude_haiku_model, and mem0_api_key already exist in config.py.
+
+2. **Claude pattern**: Use AsyncAnthropic (native async) like chat_service.py _extract_intent(). Do NOT wrap Claude calls in asyncio.to_thread -- the Anthropic SDK is already async.
+
+3. **Mem0 pattern**: Use MemoryClient wrapped in asyncio.to_thread() like chat_service.py _persist_exchange(). Pass user_id only (no agent_id) for global scope.
+
+4. **Haiku JSON parsing**: Strip markdown code block delimiters before json.loads(). LLMs sometimes wrap JSON responses in ```json ... ``` blocks.
+
+5. **main.py change**: Add `onboarding` to the existing import: `from app.routes import auth, characters, chat, health, memories, onboarding`. Register with prefix `/api/v1/onboarding`.
+
+6. **Profile name update**: Compare preferred_name case-insensitively with profile.name. Update in the same DB transaction as the onboarding_completed flag.
+
+### For backend-tester
+
+1. **Critical test**: When Mem0 fails, onboarding_completed must NOT be set to true. This is the most important correctness test.
+
+2. **Mock both services**: Patch AsyncAnthropic and MemoryClient at the service module level.
+
+3. **Fallback test**: Make Haiku return non-JSON and verify fallback memories are still seeded successfully.
+
+4. **Pydantic validation**: Test all edge cases (missing keys, duplicates, invalid keys, empty answers, whitespace-only answers, 501-char answers).
+
+## Next Steps
+
+backend-dev should read the spec and implement. backend-tester follows after implementation is complete.

--- a/docs/pipeline/onboarding-endpoint-backend-dev.handoff.md
+++ b/docs/pipeline/onboarding-endpoint-backend-dev.handoff.md
@@ -1,0 +1,57 @@
+# Backend Dev Handoff: Onboarding Endpoint
+
+**Date**: 2026-02-24
+**Agent**: backend-dev
+**Status**: COMPLETE
+
+## Implemented Files
+
+- `backend/app/schemas/onboarding.py` -- 3 schemas (OnboardingAnswer, OnboardingRequest, OnboardingResponse) + VALID_QUESTION_KEYS constant
+- `backend/app/services/onboarding_service.py` -- OnboardingService class with 5 methods (complete_onboarding, _convert_answers_to_memories, _parse_haiku_response, _fallback_memories, _seed_memories)
+- `backend/app/routes/onboarding.py` -- 1 endpoint (POST /complete)
+- `backend/app/main.py` -- MODIFIED: added onboarding router registration at /api/v1/onboarding
+
+## Endpoints Implemented
+
+- `POST /api/v1/onboarding/complete` -- Receives 7 Q&A answers, converts to structured memories via Claude Haiku, seeds into Mem0 (global scope), updates profile.onboarding_completed = true
+
+## Test Results
+
+- pytest: 49 onboarding tests passed, 0 failed (1111 total suite passed)
+- ruff: clean (0 errors)
+- All spec scenarios covered (R1-R14 route tests, S1-S14 service tests, T1-T8 schema tests)
+
+## Test Files
+
+- `backend/tests/test_onboarding_schemas.py` -- 15 tests covering Pydantic validation
+- `backend/tests/test_onboarding_service.py` -- 18 tests covering service logic
+- `backend/tests/test_onboarding_routes.py` -- 16 tests covering HTTP integration
+
+## Test Command
+
+```bash
+cd backend && python -m pytest tests/test_onboarding_schemas.py tests/test_onboarding_service.py tests/test_onboarding_routes.py -v
+```
+
+## Known Issues / Deviations from Spec
+
+- None. Implementation follows the spec exactly.
+
+## Key Design Decisions (Matching Spec)
+
+1. **Global memory scope**: Onboarding memories seeded with `user_id` only (no `agent_id`), visible to all characters
+2. **Retry-safe ordering**: Haiku (stateless) -> Mem0 (idempotent) -> DB flag update
+3. **Deterministic fallback**: If Haiku returns unparseable JSON, fallback templates generate functional memories
+4. **409 on re-onboarding**: Returns HTTP 409 Conflict if `onboarding_completed` is already `true`
+5. **Profile name update**: Compares `preferred_name` answer case-insensitively with `profile.name`; updates if different
+6. **Markdown code block stripping**: Strips `\`\`\`json` and `\`\`\`` delimiters from Haiku response before JSON parsing
+
+## Notes for Backend Tester
+
+- **Mock Claude at import level**: Patch `app.services.onboarding_service.AsyncAnthropic` -- Claude SDK is natively async (no `asyncio.to_thread` wrapper)
+- **Mock Mem0 at import level**: Patch `app.services.onboarding_service.MemoryClient` -- synchronous SDK, wrapped in `asyncio.to_thread()`
+- **Critical test**: When Mem0 fails (step 3), `onboarding_completed` must remain `False` and DB must NOT be committed. The Mem0 failure raises 503 before the DB flag update.
+- **Fallback test**: Make Haiku return non-JSON text and verify fallback memories are seeded. The `_parse_haiku_response` method handles this.
+- **Mem0 global scope verification**: Ensure `client.add()` is called with `user_id` kwarg only -- `agent_id` must NOT be present in the call kwargs
+- **Edge cases to cover**: whitespace-only answers (422), empty answers (422), 501-char answers (422), duplicate keys (422), missing keys (422)
+- **`asyncio.to_thread` mock**: For Mem0 failure tests, patch `app.services.onboarding_service.asyncio.to_thread` directly with `side_effect=Exception(...)` since the actual `to_thread` wraps the sync Mem0 call

--- a/docs/pipeline/onboarding-endpoint-backend-test.handoff.md
+++ b/docs/pipeline/onboarding-endpoint-backend-test.handoff.md
@@ -1,0 +1,101 @@
+# Backend Test Handoff: Onboarding Endpoint
+
+**Date**: 2026-02-24
+**Agent**: backend-tester
+**Status**: COMPLETE
+
+## Test Files Written
+
+### Original (by backend-dev) -- 49 tests
+- `backend/tests/test_onboarding_schemas.py` -- 15 tests
+- `backend/tests/test_onboarding_service.py` -- 18 tests
+- `backend/tests/test_onboarding_routes.py` -- 16 tests
+
+### Extended (by backend-tester) -- 82 tests
+- `backend/tests/test_onboarding_schemas_extended.py` -- 31 tests
+- `backend/tests/test_onboarding_service_extended.py` -- 33 tests
+- `backend/tests/test_onboarding_routes_extended.py` -- 18 tests
+
+### Total: 131 onboarding tests
+
+## Coverage Results
+- Lines: 100% (target: >= 80%)
+- Branches: 100% (target: >= 70%)
+- All 3 source files at 100%:
+  - `app/routes/onboarding.py` -- 100% (12/12 stmts, 0/0 branches)
+  - `app/schemas/onboarding.py` -- 100% (35/35 stmts, 6/6 branches)
+  - `app/services/onboarding_service.py` -- 100% (71/71 stmts, 10/10 branches)
+
+## Test Run Results
+- Passed: 131 (onboarding tests)
+- Failed: 0
+- Skipped: 0
+- Full suite: 1193 passed, 0 failed
+
+## Extended Tests Added (by backend-tester)
+
+### Schema Edge Cases (31 tests)
+- Unicode / accented / CJK characters in answers
+- Boundary lengths (1 char, 500 chars, 498+whitespace, 499+whitespace overflow)
+- Newline-only, tab-only, mixed-whitespace-only answers
+- Internal newlines preserved
+- Missing fields, null values, numeric values
+- Special characters (quotes, brackets, ampersands)
+- Empty answers list, single answer, null answers
+- All keys with whitespace trimmed
+- All answers at max length
+- Mixed valid/invalid keys
+- All same key (7 duplicates)
+- VALID_QUESTION_KEYS constant verification (7 keys, frozenset, expected values)
+- OnboardingResponse edge cases (0 memories, large number, false flag)
+
+### Service Edge Cases (33 tests)
+- Haiku response parsing: dict, numbers, mixed types, nested arrays, null, string
+- Code block without json qualifier
+- Valid JSON with leading whitespace
+- More/fewer than 7 memories returned by Haiku
+- Unicode in Haiku response
+- Fallback with special characters, very long answers, all empty, missing keys
+- Fallback templates cover all valid question keys
+- Fallback preserves template key order
+- Haiku called with max_tokens=512
+- Haiku called with single user message
+- **HTTPException re-raise (line 148)** -- previously uncovered, now tested
+- Profile name is None -> gets updated
+- Profile name case-insensitive: UPPER vs lower
+- Profile name with whitespace trimmed before comparison
+- DB commit NOT called on Haiku failure
+- DB commit NOT called on Mem0 failure
+- onboarding_completed remains False on Haiku failure
+- Mem0 messages format verification (list of user-role dicts)
+- Answer order invariance at service level
+- Return type is OnboardingResponse
+- Fallback memories seeded to Mem0 on non-JSON Haiku response
+- AsyncAnthropic created with api_key
+- MemoryClient created with api_key
+
+### Route Edge Cases (18 tests)
+- Response Content-Type is application/json
+- Response has exactly expected keys and types
+- Empty request body, null answers, non-list answers
+- Unicode answers via HTTP
+- Exactly 500-char answers via HTTP
+- Haiku returns empty list -> fallback
+- Haiku returns dict -> fallback
+- Profile name None -> updated via route
+- Profile name UPPER -> not updated (case-insensitive match)
+- GET method not allowed (405)
+- Special characters in all answers
+- 409 response detail format
+- 422 response has detail field
+- 503 on ConnectionError
+- 503 on TimeoutError
+- Haiku markdown code block via route
+
+## Issues Found During Testing
+- Line 148 (`except HTTPException: raise`) was not covered by the original test suite. Added `test_httpexception_re_raised_not_wrapped` to verify that HTTPExceptions raised inside the Haiku call path are re-raised with their original status code (e.g., 429) rather than being caught by the generic Exception handler and wrapped as 503. This is a correctness-critical code path.
+
+## Notes for Reviewer
+- Pydantic validates `max_length=500` on the raw input string BEFORE `field_validator` runs `strip()`. This means an answer of 498 chars + 2 spaces (500 total) is accepted and stripped, but 499 chars + 2 spaces (501 total) is rejected before strip. The test `test_499_chars_plus_whitespace_rejected_by_max_length` documents this behavior.
+- The `_make_client_fixture` factory pattern in routes_extended is available for future use but not currently used by the fixtures -- each fixture is explicit for clarity.
+- All extended test files follow the same env setup pattern (`os.environ.setdefault`) and import ordering as the original test files.

--- a/docs/pipeline/onboarding-endpoint-doc.handoff.md
+++ b/docs/pipeline/onboarding-endpoint-doc.handoff.md
@@ -1,0 +1,17 @@
+# Doc Writer Handoff: Onboarding Endpoint
+
+**Date**: 2026-02-24
+**Agent**: doc-writer
+**Status**: COMPLETE
+
+## Documents Written
+- `docs/features/onboarding-endpoint.md` -- main feature documentation
+- `CHANGELOG.md` -- added entry under [Unreleased]
+
+## Summary
+Documented the onboarding endpoint (P01-09), a backend-only feature that receives 7 Q&A answers from the mobile client, converts them to structured memory statements via Claude Haiku, seeds them as global Mem0 memories visible to all characters, and marks the user profile as onboarded. The documentation covers the complete data flow, API reference with request/response schemas, memory seeding strategy, fallback formatting, retry safety design, configuration, testing coverage (131 tests at 100% line and branch coverage), known limitations, and extension guidance.
+
+## Notes
+- No inconsistencies were found between the spec and the implementation. The backend-dev handoff explicitly confirmed "None" for deviations from spec.
+- The backend-tester handoff noted that line 148 (HTTPException re-raise in the Haiku call path) was not covered by the original test suite but was added in the extended tests. This behavior is documented in the Known Limitations section.
+- The Pydantic max_length-before-strip behavior (noted by the backend-tester) is documented in the API Reference validation rules section.

--- a/docs/pipeline/onboarding-endpoint-review.handoff.md
+++ b/docs/pipeline/onboarding-endpoint-review.handoff.md
@@ -1,0 +1,78 @@
+# Reviewer Handoff: Onboarding Endpoint
+
+**Date**: 2026-02-24
+**Agent**: reviewer
+**Status**: APPROVED
+
+## Review Summary
+
+| Category | Passed | Warnings | Issues |
+|----------|--------|----------|--------|
+| Architecture | 7 | 0 | 0 |
+| Code Quality | 5 | 0 | 0 |
+| Testing | 4 | 0 | 0 |
+| Security | 4 | 0 | 0 |
+| **Total** | **20** | **0** | **0** |
+
+## Checklist Results
+
+### Architecture
+
+- [x] **user_id from JWT only** -- PASS. Route handler (`backend/app/routes/onboarding.py`, line 24) uses `profile: Profile = Depends(get_current_user)`. The `OnboardingRequest` schema has no `user_id` field. Grep for `user_id.*body|body.*user_id` in routes returned zero matches.
+- [x] **Global memory scope (no agent_id in Mem0 seeding)** -- PASS. `_seed_memories()` (`backend/app/services/onboarding_service.py`, lines 215-218) passes only `user_id=mem0_user_id` to `client.add()`. No `agent_id` parameter. Grep for `agent_id` in the service file returned only a comment on line 206 documenting the design decision.
+- [x] **Retry-safe ordering (Haiku -> Mem0 -> DB flag)** -- PASS. `complete_onboarding()` (`backend/app/services/onboarding_service.py`, lines 89-123) executes: step 1 idempotency guard, step 2 Haiku call (line 100), step 3 Mem0 seed (lines 103-106), step 4 profile update (lines 109-115), step 5 DB commit (line 118). If Haiku or Mem0 fail, the 503 exception is raised before `onboarding_completed` is set or committed.
+- [x] **409 for already-completed onboarding** -- PASS. Lines 90-94 of `onboarding_service.py` check `profile.onboarding_completed` and raise `HTTPException(409, detail="Onboarding already completed")`.
+- [x] **Deterministic fallback when Haiku fails** -- PASS. `_parse_haiku_response()` (lines 156-187) catches `json.JSONDecodeError` and unexpected formats, logging warnings and delegating to `_fallback_memories()` (lines 189-197) which uses the `_FALLBACK_TEMPLATES` dict.
+- [x] **All Mem0 calls wrapped in asyncio.to_thread()** -- PASS. `_seed_memories()` (line 215) wraps the synchronous `client.add()` call in `asyncio.to_thread()`.
+- [x] **Claude Haiku used (not Sonnet)** -- PASS. `_convert_answers_to_memories()` (line 139) uses `model=settings.claude_haiku_model`, which resolves to `"claude-haiku-4-5"` per `backend/app/config.py` line 56.
+
+### Code Quality
+
+- [x] **No hardcoded secrets, API keys, or credentials** -- PASS. API keys are read from `settings.anthropic_api_key` and `settings.mem0_api_key` (sourced from environment variables or AWS Secrets Manager). Grep for hardcoded secret patterns returned zero matches across all `backend/app/` files.
+- [x] **Error messages are user-friendly** -- PASS. Error details are: `"Onboarding already completed"` (409), `"AI service temporarily unavailable"` (503). No raw exception messages or stack traces exposed. Pydantic 422 errors use FastAPI's standard formatting.
+- [x] **All API errors handled explicitly** -- PASS. The service handles: already-completed (409), Haiku API failure (503), unparseable Haiku response (fallback + continue), Mem0 failure (503). The `except HTTPException: raise` clause (line 147-148) correctly re-raises HTTP exceptions (e.g., rate limit 429) without wrapping them in 503.
+- [x] **No TODO/FIXME in production code** -- PASS. Grep for `TODO|FIXME` in all three production files returned zero matches.
+- [x] **async def on all routes** -- PASS. The single route handler `complete_onboarding` (`backend/app/routes/onboarding.py`, line 22) uses `async def`. Grep for synchronous `^def ` in `backend/app/routes/` returned zero matches across all route files.
+
+### Testing
+
+- [x] **Coverage >= 80%** -- PASS. Per the backend-test handoff, all three source files are at 100% line coverage and 100% branch coverage: `routes/onboarding.py` (12/12 stmts), `schemas/onboarding.py` (35/35 stmts, 6/6 branches), `services/onboarding_service.py` (71/71 stmts, 10/10 branches). 131 total onboarding tests, 0 failures.
+- [x] **Mocks/fakes used for Claude and Mem0** -- PASS. All tests mock `app.services.onboarding_service.AsyncAnthropic` (Claude) and `app.services.onboarding_service.MemoryClient` (Mem0) at the module level. No real API calls in any test. Mem0 failure tests patch `asyncio.to_thread` with side_effect exceptions.
+- [x] **All critical happy paths tested** -- PASS. Test R1/S3 cover the full happy path (7 answers -> Haiku -> Mem0 -> DB commit -> 200). Test R13/S4 cover the fallback path. Test R11/S7 cover profile name update. All 14 spec scenarios (R1-R14) and 14 service scenarios (S1-S14) are implemented.
+- [x] **At least one error case tested per endpoint** -- PASS. Error cases covered: 409 already completed (R2/S1), 422 missing keys (R3), 422 duplicate keys (R4), 422 invalid key (R5), 422 empty answer (R6), 422 over-length (R7), 401 no auth (R8), 503 Haiku failure (R9/S10), 503 Mem0 failure (R10/S11), 422 whitespace-only (R14). Extended tests add ConnectionError, TimeoutError, and HTTPException re-raise cases.
+
+### Security
+
+- [x] **No credentials in code** -- PASS. Grep for `api_key\s*=\s*['\"]`, `secret\s*=\s*['\"]`, `password\s*=\s*['\"]`, and `token\s*=\s*['\"]` all returned zero matches in `backend/app/`.
+- [x] **No user_id in request body** -- PASS. `OnboardingRequest` schema contains only `answers: list[OnboardingAnswer]`. No `user_id` field. The user identity comes exclusively from `Depends(get_current_user)`.
+- [x] **SQL injection prevention** -- PASS. No raw SQL in the onboarding code. The only DB operation is `await self.db.commit()` (SQLAlchemy ORM). Profile attribute updates use ORM attribute assignment (`profile.onboarding_completed = True`, `profile.name = preferred_name`).
+- [x] **No internal IDs exposed** -- PASS. Error responses contain only human-readable messages ("Onboarding already completed", "AI service temporarily unavailable"). No database IDs, stack traces, or system paths in any error response.
+
+## Files Reviewed
+
+**Backend**:
+- `backend/app/routes/onboarding.py` (41 lines) -- PASS. Clean route handler, delegates all logic to service, uses `async def`, correct dependency injection pattern.
+- `backend/app/services/onboarding_service.py` (229 lines) -- PASS. Clean separation of concerns with 5 methods, retry-safe operation ordering, proper error handling with `except HTTPException: raise` before generic catch, logging via `logging.getLogger("ember")`.
+- `backend/app/schemas/onboarding.py` (84 lines) -- PASS. Proper Pydantic v2 patterns: `Field(...)` with constraints, `@field_validator` with `@classmethod`, `@model_validator(mode="after")`, `VALID_QUESTION_KEYS` as `frozenset`.
+- `backend/app/main.py` (line 20, 60) -- PASS. Onboarding router correctly imported and registered at `prefix="/api/v1/onboarding"` with `tags=["onboarding"]`.
+- `backend/tests/test_onboarding_routes.py` (16 tests) -- PASS.
+- `backend/tests/test_onboarding_service.py` (18 tests) -- PASS.
+- `backend/tests/test_onboarding_schemas.py` (15 tests) -- PASS.
+- `backend/tests/test_onboarding_routes_extended.py` (18 tests) -- PASS.
+- `backend/tests/test_onboarding_service_extended.py` (33 tests) -- PASS.
+- `backend/tests/test_onboarding_schemas_extended.py` (31 tests) -- PASS.
+
+## Issues Resolved During Review
+
+- None (first-pass clean).
+
+## Warnings (Not Blocking)
+
+- None.
+
+## Notes
+
+- The `_parse_haiku_response` method correctly strips both `\`\`\`json` and bare `\`\`\`` markdown code block delimiters using regex before JSON parsing.
+- The `_fallback_memories` static method gracefully handles missing keys (returns fewer memories) and empty answers (skips them), though in normal flow all 7 keys are always present due to Pydantic validation.
+- The backend-tester identified and covered line 148 (`except HTTPException: raise`) which was not exercised by the original test suite. This is a correctness-critical code path that ensures HTTP exceptions (e.g., 429 rate limit from the Anthropic SDK) are not incorrectly wrapped as 503.
+- Total test count: 131 onboarding tests (49 original + 82 extended), all passing, 100% line and branch coverage.

--- a/shared/feature-specs/onboarding-endpoint.md
+++ b/shared/feature-specs/onboarding-endpoint.md
@@ -1,0 +1,767 @@
+# Feature Spec: P01-09 -- Onboarding Endpoint
+
+**Feature ID**: P01-09
+**Phase**: 1
+**Layer**: backend
+**GitHub Issue**: #11
+**Date**: 2026-02-24
+**Author**: architect
+
+---
+
+## 1. Overview
+
+### What This Feature Does
+
+This feature implements a single endpoint that completes the user onboarding flow:
+
+**POST /api/v1/onboarding/complete** -- Receives answers to 7 onboarding questions, uses Claude Haiku to convert the raw Q&A pairs into structured memory statements, seeds those memories into Mem0 for the user's default General Friend character (`agent_id = companion_{user_id}`), and sets `profiles.onboarding_completed = true` in the database.
+
+The 7 onboarding questions are defined in `docs/05-ai-bellek.md` Section "Onboarding Memory Seed":
+
+1. "What should I call you?" (preferred name)
+2. "What do you do for work?" (profession)
+3. "Are you a morning person or a night owl?" (daily rhythm)
+4. "What are your health/fitness goals?" (goals)
+5. "What do you do for stress management?" (coping)
+6. "What is your sleep schedule like?" (sleep pattern)
+7. "What kind of friendship do you expect from me?" (communication preference)
+
+The mobile client presents these questions during first launch (after registration) and submits all 7 answers in a single request.
+
+### Why It Exists
+
+Without onboarding, the AI companion starts every relationship with zero knowledge about the user. The first few conversations would be generic and impersonal. By seeding Mem0 with structured memories from onboarding answers, the General Friend character can be immediately personalized from the very first chat message. This directly supports Ember's core value proposition: a memory-first AI companion that "knows" the user.
+
+### Dependencies
+
+- **Requires**: P01-04 (auth-endpoints -- `get_current_user` dependency, Profile model with `onboarding_completed` column, default Character with `companion` template and `mem0_agent_id`)
+- **Requires**: P01-01 (project-setup -- FastAPI scaffold, config with `anthropic_api_key`, `mem0_api_key`, `claude_haiku_model`)
+- **Requires**: P01-02 (database-schema -- Profile and Character models)
+- **Requires**: P01-03 (cognito-auth-middleware -- JWT verification)
+- **Uses patterns from**: P01-06 (chat-streaming -- Claude Haiku calls via `AsyncAnthropic`, Mem0 `MemoryClient` with `asyncio.to_thread()`)
+
+### What This Feature Does NOT Do
+
+- It does not present the onboarding questions to the user. The mobile client owns the question UI and sends the collected answers.
+- It does not create new characters or conversations. The default "Ember" companion character already exists from registration (P01-04).
+- It does not allow partial onboarding. All 7 answers must be submitted together. There is no "save progress" endpoint.
+- It does not allow re-onboarding. Once `onboarding_completed` is `true`, calling the endpoint again returns 409 Conflict.
+
+---
+
+## 2. Data Models
+
+### No New Tables
+
+This feature does not create any new database tables.
+
+### No New Columns
+
+All required columns already exist:
+
+| Table | Column | Usage in This Feature |
+|-------|--------|----------------------|
+| `profiles.id` | UUID PK | Identifies the authenticated user |
+| `profiles.onboarding_completed` | BOOLEAN DEFAULT FALSE | Updated to `true` after successful memory seeding |
+| `profiles.mem0_user_id` | TEXT UNIQUE | Passed to Mem0 SDK as `user_id` for memory seeding |
+| `profiles.name` | TEXT | Potentially updated if the user provides a different preferred name |
+| `characters.user_id` | UUID FK -> profiles | Used to find the default character |
+| `characters.template` | TEXT | Filtered to `"companion"` to find the General Friend character |
+| `characters.is_default` | BOOLEAN | Filtered to `true` to find the General Friend character |
+| `characters.mem0_agent_id` | TEXT UNIQUE | Passed to Mem0 SDK as `agent_id` for memory seeding |
+| `characters.is_active` | BOOLEAN | Only active characters are used |
+
+### Mem0 Operations
+
+This feature performs a single Mem0 `add()` call to seed onboarding memories:
+
+```
+client.add(
+    messages=structured_memories,  # list of memory strings from Haiku
+    user_id=profile.mem0_user_id,
+    agent_id=character.mem0_agent_id,   # companion_{user_id}
+)
+```
+
+The memories are seeded to the General Friend character's memory space (scoped by `agent_id`). Per `docs/05-ai-bellek.md`, these are character-specific memories, not global memories, because they were generated in the context of the companion character.
+
+However, because the General Friend is the primary character and these are basic user facts (name, profession, goals), they will also be found by global memory searches that use `user_id` without `agent_id`. This is the correct behavior: all characters should be able to see basic user information from onboarding.
+
+**Important Mem0 behavior note**: When `client.add()` is called with both `user_id` and `agent_id`, Mem0 stores the memories as character-scoped. The parallel two-layer search in the chat flow (from P01-06) searches both global (`user_id` only) and character-scoped (`user_id` + `agent_id`). Onboarding memories will be found by the character-scoped search for the companion character. For other characters, these memories will NOT appear in their character-scoped search. To ensure all characters can access basic user facts, we seed onboarding memories WITHOUT an `agent_id` (global scope). This makes them visible to all characters' global memory search.
+
+**Decision**: Seed onboarding memories as global memories (`user_id` only, no `agent_id`). This aligns with `docs/05-ai-bellek.md` Section "Memory Isolation" which states that global memories contain "basic user information visible to all characters" -- name, profession, goals, etc. Onboarding answers are exactly this category of information.
+
+---
+
+## 3. API Endpoints
+
+All endpoints are under the `/api/v1` prefix.
+
+---
+
+### POST /api/v1/onboarding/complete
+
+Completes the user onboarding by converting Q&A answers into structured Mem0 memories and marking the profile as onboarded.
+
+```
+Auth: Bearer JWT required
+Content-Type: application/json
+```
+
+**Request Body:**
+
+```json
+{
+  "answers": [
+    {
+      "question_key": "preferred_name",
+      "answer": "Alex"
+    },
+    {
+      "question_key": "occupation",
+      "answer": "Software engineer at a startup"
+    },
+    {
+      "question_key": "daily_rhythm",
+      "answer": "Morning person, I wake up at 6:30"
+    },
+    {
+      "question_key": "health_goal",
+      "answer": "Lose 10 kg and run a half marathon"
+    },
+    {
+      "question_key": "stress_management",
+      "answer": "I go for walks and listen to podcasts"
+    },
+    {
+      "question_key": "sleep_schedule",
+      "answer": "Usually 11 PM to 6:30 AM"
+    },
+    {
+      "question_key": "communication_style",
+      "answer": "I want someone who checks in on me but doesn't overwhelm me"
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `answers` | array | yes | Exactly 7 items |
+| `answers[].question_key` | string | yes | Must be one of the 7 valid keys (see below) |
+| `answers[].answer` | string | yes | Min 1 char, max 500 chars, whitespace-trimmed |
+
+**Valid `question_key` values:**
+
+| Key | Maps to Onboarding Question |
+|-----|----------------------------|
+| `preferred_name` | "What should I call you?" |
+| `occupation` | "What do you do for work?" |
+| `daily_rhythm` | "Are you a morning person or a night owl?" |
+| `health_goal` | "What are your health/fitness goals?" |
+| `stress_management` | "What do you do for stress management?" |
+| `sleep_schedule` | "What is your sleep schedule like?" |
+| `communication_style` | "What kind of friendship do you expect from me?" |
+
+**Validation rules:**
+- All 7 question keys must be present (no duplicates, no missing keys).
+- Each answer must be a non-empty string after trimming.
+- Order of answers in the array does not matter.
+
+**Response 200 OK:**
+
+```json
+{
+  "onboarding_completed": true,
+  "memories_seeded": 7
+}
+```
+
+| Response Field | Type | Notes |
+|----------------|------|-------|
+| `onboarding_completed` | boolean | Always `true` on success |
+| `memories_seeded` | integer | Number of memory statements seeded to Mem0. May differ from 7 if Haiku generates fewer or more statements per answer. |
+
+**Error Responses:**
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| 401 | Missing or invalid JWT | `{"detail": "Invalid or expired token"}` |
+| 409 | `profiles.onboarding_completed` is already `true` | `{"detail": "Onboarding already completed"}` |
+| 422 | Pydantic validation failure (missing keys, invalid answer length, duplicate keys) | Standard FastAPI 422 response |
+| 503 | Claude Haiku or Mem0 API unavailable | `{"detail": "AI service temporarily unavailable"}` |
+
+**Notes:**
+- This endpoint is idempotent in the error case: if Claude or Mem0 fails, the client can retry. The `onboarding_completed` flag is only set to `true` after successful memory seeding.
+- If the `preferred_name` answer is different from `profiles.name`, the profile name is updated. This allows the user to choose a nickname during onboarding that overrides the name they entered during registration.
+
+---
+
+## 4. Backend Logic
+
+### OnboardingService Class
+
+A new `OnboardingService` class in `backend/app/services/onboarding_service.py` encapsulates all onboarding business logic. Route handlers delegate to this service.
+
+```
+class OnboardingService:
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def complete_onboarding(
+        self,
+        profile: Profile,
+        answers: list[OnboardingAnswer],
+    ) -> OnboardingResponse:
+        """Process onboarding answers: convert to memories, seed Mem0, update profile."""
+```
+
+### Complete Onboarding Flow (Step-by-Step)
+
+```
+Client sends: POST /api/v1/onboarding/complete
+Authorization: Bearer <jwt>
+    { answers: [ {question_key, answer}, ... ] }
+    |
+    v
+1. get_current_user extracts Profile from JWT
+    |
+    v
+2. Check profile.onboarding_completed
+    |
+    +--> true --> 409 "Onboarding already completed"
+    |
+    v
+3. Validate answers: all 7 keys present, no duplicates, all non-empty
+    |   (Pydantic model handles this validation)
+    |
+    v
+4. Build a prompt for Claude Haiku with Q&A pairs
+    |
+    v
+5. Call Claude Haiku to convert raw Q&A answers into structured memory statements
+    |
+    +--> Claude API error --> 503 "AI service temporarily unavailable"
+    |
+    v
+6. Parse Haiku's response (expect a JSON array of memory strings)
+    |
+    +--> Parse failure --> use fallback memory formatting (see below)
+    |
+    v
+7. Seed memories to Mem0 (global scope):
+    client = MemoryClient(api_key=settings.mem0_api_key)
+    for memory_text in structured_memories:
+        client.add(memory_text, user_id=profile.mem0_user_id)
+    |
+    +--> Mem0 API error --> 503 "AI service temporarily unavailable"
+    |
+    v
+8. Update profile:
+    profile.onboarding_completed = true
+    If preferred_name != profile.name:
+        profile.name = preferred_name
+    |
+    v
+9. Commit DB transaction
+    |
+    v
+10. Return 200 { onboarding_completed: true, memories_seeded: N }
+```
+
+### Claude Haiku Prompt for Memory Conversion
+
+The service sends a structured prompt to Claude Haiku that includes all 7 Q&A pairs and asks for structured memory statements. This is a single Haiku call (not 7 separate calls).
+
+```
+MEMORY_CONVERSION_PROMPT = """\
+You are a memory extraction system. Convert the following onboarding Q&A answers \
+into concise, factual memory statements about the user. Each statement should be a \
+single sentence that an AI companion can use to personalize conversations.
+
+Rules:
+- Output ONLY a JSON array of strings. No other text.
+- Each string is one factual memory statement.
+- Use third person ("Prefers to be called Alex", not "I prefer to be called Alex").
+- Keep each statement under 100 characters.
+- Generate exactly one memory statement per Q&A pair.
+- Do not add information that is not in the answers.
+
+Q&A Pairs:
+1. Preferred name: {preferred_name}
+2. Occupation: {occupation}
+3. Daily rhythm: {daily_rhythm}
+4. Health/fitness goal: {health_goal}
+5. Stress management: {stress_management}
+6. Sleep schedule: {sleep_schedule}
+7. Communication preference: {communication_style}
+
+Output the JSON array now:"""
+```
+
+**Expected Haiku response:**
+
+```json
+[
+  "Prefers to be called Alex",
+  "Works as a software engineer at a startup",
+  "Morning person, wakes up at 6:30",
+  "Goal: lose 10 kg and run a half marathon",
+  "Manages stress by going for walks and listening to podcasts",
+  "Sleeps from 11 PM to 6:30 AM",
+  "Wants an AI friend who checks in regularly but doesn't overwhelm"
+]
+```
+
+### Fallback Memory Formatting
+
+If Claude Haiku returns a response that cannot be parsed as a JSON array of strings (malformed JSON, unexpected format), the service falls back to a deterministic mapping:
+
+| Question Key | Fallback Format |
+|-------------|----------------|
+| `preferred_name` | `"Prefers to be called {answer}"` |
+| `occupation` | `"Works as {answer}"` |
+| `daily_rhythm` | `"Daily rhythm: {answer}"` |
+| `health_goal` | `"Health/fitness goal: {answer}"` |
+| `stress_management` | `"Stress management: {answer}"` |
+| `sleep_schedule` | `"Sleep schedule: {answer}"` |
+| `communication_style` | `"Communication preference: {answer}"` |
+
+This ensures onboarding always succeeds even if Haiku returns unexpected output. The fallback memories are less natural-sounding but still functional for Mem0 search.
+
+### Mem0 Seeding Strategy
+
+The service calls `client.add()` once with the full list of memory statements:
+
+```python
+client = MemoryClient(api_key=settings.mem0_api_key)
+await asyncio.to_thread(
+    client.add,
+    structured_memories,   # list of memory text strings
+    user_id=profile.mem0_user_id,
+)
+```
+
+**Key details:**
+- The call uses `user_id` only (no `agent_id`). This seeds them as global memories visible to all characters.
+- The `client.add()` method accepts either a string or a list of message dicts. For seeding, we pass the formatted memory strings as a single joined text or as a list of `{"role": "user", "content": text}` dicts. The Mem0 SDK will extract and store memories from the content.
+- All Mem0 SDK calls are synchronous and must be wrapped in `asyncio.to_thread()`.
+- On Mem0 failure, the service raises 503. The DB flag is NOT set, allowing the client to retry.
+
+### Profile Name Update
+
+If the `preferred_name` answer differs from the current `profiles.name`, the profile name is updated in the same transaction. This handles the case where a user registers as "Alexander" but wants to be called "Alex".
+
+The comparison is case-insensitive and stripped: `preferred_name.strip().lower() != profile.name.strip().lower()`.
+
+### Error Handling
+
+| Failure Point | Behavior |
+|--------------|----------|
+| Pydantic validation (missing keys, empty answers) | 422 -- standard FastAPI validation error |
+| `onboarding_completed` already `true` | 409 -- "Onboarding already completed" |
+| Claude Haiku API error | 503 -- "AI service temporarily unavailable"; DB not modified |
+| Claude Haiku returns unparseable response | Use fallback formatting; continue normally |
+| Mem0 `add()` failure | 503 -- "AI service temporarily unavailable"; DB not modified |
+| DB commit failure | 500 -- handled by global exception handler; Mem0 memories may already be written (acceptable -- they are harmless without the flag, and the client will retry) |
+
+### Transaction Safety
+
+The order of operations matters for idempotency:
+1. First, call Claude Haiku (stateless -- can be retried safely)
+2. Then, seed Mem0 (idempotent -- adding duplicate memories is harmless; Mem0 deduplicates)
+3. Finally, update `onboarding_completed` flag in the DB
+
+If step 2 fails, the flag stays `false` and the client can retry. If step 3 fails, Mem0 has the memories but the flag is `false`; on retry, Mem0 will deduplicate and the flag will be set. This ordering ensures the endpoint is retry-safe.
+
+---
+
+## 5. Pydantic Schemas
+
+All schemas are defined in `backend/app/schemas/onboarding.py`.
+
+### Request Schemas
+
+```
+VALID_QUESTION_KEYS = frozenset({
+    "preferred_name",
+    "occupation",
+    "daily_rhythm",
+    "health_goal",
+    "stress_management",
+    "sleep_schedule",
+    "communication_style",
+})
+
+
+class OnboardingAnswer(BaseModel):
+    """A single Q&A pair from the onboarding flow."""
+
+    question_key: str
+    answer: str = Field(..., min_length=1, max_length=500)
+
+    @field_validator("answer")
+    @classmethod
+    def strip_answer(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Answer must not be blank")
+        return stripped
+
+    @field_validator("question_key")
+    @classmethod
+    def validate_key(cls, v: str) -> str:
+        if v not in VALID_QUESTION_KEYS:
+            raise ValueError(f"Invalid question_key: {v}")
+        return v
+
+
+class OnboardingRequest(BaseModel):
+    """Request body for POST /onboarding/complete."""
+
+    answers: list[OnboardingAnswer] = Field(..., min_length=7, max_length=7)
+
+    @model_validator(mode="after")
+    def validate_all_keys_present(self) -> Self:
+        keys = {a.question_key for a in self.answers}
+        if keys != VALID_QUESTION_KEYS:
+            missing = VALID_QUESTION_KEYS - keys
+            raise ValueError(f"Missing question keys: {', '.join(sorted(missing))}")
+        return self
+```
+
+### Response Schemas
+
+```
+class OnboardingResponse(BaseModel):
+    """Response for POST /onboarding/complete."""
+
+    onboarding_completed: bool
+    memories_seeded: int
+```
+
+---
+
+## 6. Router Registration
+
+### Onboarding Router
+
+A new router in `backend/app/routes/onboarding.py`, registered under `/api/v1/onboarding`:
+
+```python
+router = APIRouter()
+
+@router.post("/complete", response_model=OnboardingResponse)
+async def complete_onboarding(
+    body: OnboardingRequest,
+    profile: Profile = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> OnboardingResponse:
+    service = OnboardingService(db)
+    return await service.complete_onboarding(profile=profile, answers=body.answers)
+```
+
+In `main.py`:
+
+```python
+from app.routes import onboarding
+
+app.include_router(onboarding.router, prefix="/api/v1/onboarding", tags=["onboarding"])
+```
+
+---
+
+## 7. Test Requirements
+
+### Route Tests (`backend/tests/test_onboarding_routes.py`)
+
+These tests use the FastAPI test client. The `get_current_user` dependency is overridden to return a fake Profile. Claude and Mem0 calls are mocked.
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| R1 | POST /onboarding/complete with all 7 valid answers | 200, `{"onboarding_completed": true, "memories_seeded": 7}` |
+| R2 | POST /onboarding/complete when onboarding already completed | 409, `{"detail": "Onboarding already completed"}` |
+| R3 | POST /onboarding/complete with missing question keys (only 5 of 7) | 422 (Pydantic validation) |
+| R4 | POST /onboarding/complete with duplicate question keys | 422 (Pydantic validation) |
+| R5 | POST /onboarding/complete with invalid question key | 422 (Pydantic validation) |
+| R6 | POST /onboarding/complete with empty answer string | 422 (Pydantic validation) |
+| R7 | POST /onboarding/complete with answer exceeding 500 chars | 422 (Pydantic validation) |
+| R8 | POST /onboarding/complete without auth header | 401 |
+| R9 | POST /onboarding/complete when Claude Haiku fails | 503, `{"detail": "AI service temporarily unavailable"}` |
+| R10 | POST /onboarding/complete when Mem0 fails | 503, `{"detail": "AI service temporarily unavailable"}` |
+| R11 | POST /onboarding/complete updates profile name when preferred_name differs | 200, profile.name updated to preferred_name |
+| R12 | POST /onboarding/complete does not update profile name when preferred_name matches | 200, profile.name unchanged |
+| R13 | POST /onboarding/complete when Claude returns unparseable response | 200, fallback memories used, `memories_seeded: 7` |
+| R14 | POST /onboarding/complete with answer that is only whitespace | 422 (Pydantic validation -- blank after strip) |
+
+### Service Tests (`backend/tests/test_onboarding_service.py`)
+
+These tests unit-test the `OnboardingService` class directly. The database session, Claude, and Mem0 are mocked.
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| S1 | `complete_onboarding()` raises 409 when `profile.onboarding_completed` is true | HTTPException(409) raised before any external calls |
+| S2 | `complete_onboarding()` calls Claude Haiku with the correct prompt containing all 7 answers | AsyncAnthropic called once with model=settings.claude_haiku_model |
+| S3 | `complete_onboarding()` parses Haiku JSON response into memory list | Correct list of 7 strings extracted |
+| S4 | `complete_onboarding()` falls back to deterministic format when Haiku returns invalid JSON | 7 fallback-formatted memories generated |
+| S5 | `complete_onboarding()` calls Mem0 add() with user_id only (no agent_id) | Mem0 called with correct user_id, no agent_id parameter |
+| S6 | `complete_onboarding()` sets `profile.onboarding_completed = True` after Mem0 success | Profile attribute updated |
+| S7 | `complete_onboarding()` updates `profile.name` when preferred_name differs | Profile name changed |
+| S8 | `complete_onboarding()` does NOT update `profile.name` when preferred_name matches (case-insensitive) | Profile name unchanged |
+| S9 | `complete_onboarding()` calls `db.commit()` exactly once on success | Commit called once |
+| S10 | `complete_onboarding()` raises 503 when Claude Haiku fails | HTTPException(503), no DB changes |
+| S11 | `complete_onboarding()` raises 503 when Mem0 add() fails | HTTPException(503), no DB changes |
+| S12 | `complete_onboarding()` does NOT set onboarding_completed if Mem0 fails | Profile.onboarding_completed remains False |
+| S13 | `_convert_answers_to_memories()` sends correct prompt format to Haiku | Prompt contains all 7 answer values in the correct format |
+| S14 | `_fallback_memories()` generates 7 correctly formatted strings | Each string matches the fallback template |
+
+### Schema Tests (`backend/tests/test_onboarding_schemas.py`)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| T1 | `OnboardingRequest` with all 7 valid keys and non-empty answers | Valid, no errors |
+| T2 | `OnboardingRequest` with 6 answers (missing one key) | ValidationError |
+| T3 | `OnboardingRequest` with 8 answers (duplicate key) | ValidationError |
+| T4 | `OnboardingRequest` with an invalid question_key | ValidationError |
+| T5 | `OnboardingAnswer` with answer that is whitespace only | ValidationError |
+| T6 | `OnboardingAnswer` with answer exceeding 500 chars | ValidationError |
+| T7 | `OnboardingAnswer.strip_answer()` trims whitespace | "  Alex  " becomes "Alex" |
+| T8 | `OnboardingResponse` serializes correctly | `{"onboarding_completed": true, "memories_seeded": 7}` |
+
+### How to Mock Claude Haiku
+
+```python
+from unittest.mock import AsyncMock, patch, MagicMock
+
+mock_response = MagicMock()
+mock_response.content = [MagicMock(text='["Prefers to be called Alex", "Works as a software engineer"]')]
+
+mock_client = AsyncMock()
+mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+with patch("app.services.onboarding_service.AsyncAnthropic") as mock_cls:
+    mock_cls.return_value = mock_client
+    # ... run test
+```
+
+### How to Mock Mem0
+
+```python
+from unittest.mock import patch, MagicMock
+
+mock_client = MagicMock()
+mock_client.add.return_value = None  # add() returns None on success
+
+with patch("app.services.onboarding_service.MemoryClient") as mock_cls:
+    mock_cls.return_value = mock_client
+    # ... run test
+
+# For Mem0 failure:
+mock_client.add.side_effect = Exception("Mem0 connection refused")
+```
+
+All Mem0 calls are wrapped in `asyncio.to_thread()`. The mock's methods are called synchronously within the thread pool, so standard `MagicMock` is sufficient.
+
+### How to Mock the Database
+
+Follow the same pattern as P01-04 and P01-08. Override `get_current_user` for route tests to return a Profile with `onboarding_completed=False`. For service tests, pass a mock `AsyncSession` directly to `OnboardingService(db=mock_db)`.
+
+---
+
+## 8. File Manifest
+
+Every file to be created or modified, grouped by purpose.
+
+### Route Handler
+
+```
+Backend:
+  CREATE  backend/app/routes/onboarding.py
+```
+
+Contains a single router with one route function (`complete_onboarding`). Delegates to `OnboardingService`.
+
+### Service Layer
+
+```
+Backend:
+  CREATE  backend/app/services/onboarding_service.py
+```
+
+Contains the `OnboardingService` class with `complete_onboarding()` and private helpers: `_convert_answers_to_memories()` (Claude Haiku call), `_fallback_memories()` (deterministic fallback), `_seed_memories()` (Mem0 add call).
+
+### Pydantic Schemas
+
+```
+Backend:
+  CREATE  backend/app/schemas/onboarding.py
+```
+
+Contains `OnboardingAnswer`, `OnboardingRequest`, `OnboardingResponse`, and the `VALID_QUESTION_KEYS` constant.
+
+### Application Wiring
+
+```
+Backend:
+  MODIFY  backend/app/main.py
+```
+
+Add import for `onboarding` module and register the router:
+
+```python
+from app.routes import auth, characters, chat, health, memories, onboarding
+
+app.include_router(onboarding.router, prefix="/api/v1/onboarding", tags=["onboarding"])
+```
+
+### Tests
+
+```
+Backend:
+  CREATE  backend/tests/test_onboarding_routes.py
+  CREATE  backend/tests/test_onboarding_service.py
+  CREATE  backend/tests/test_onboarding_schemas.py
+```
+
+### Documentation (Pipeline)
+
+```
+Shared:
+  CREATE  shared/feature-specs/onboarding-endpoint.md          (this file)
+  CREATE  docs/pipeline/onboarding-endpoint-architect.handoff.md
+```
+
+### Summary
+
+| Action | Count |
+|--------|-------|
+| CREATE | 6 |
+| MODIFY | 1 |
+| DELETE | 0 |
+| **Total** | **7** |
+
+### Files NOT Modified
+
+- `backend/app/config.py` -- `anthropic_api_key`, `claude_haiku_model`, and `mem0_api_key` already exist. No new config values needed.
+- `backend/app/dependencies.py` -- Uses the existing `get_current_user` and `get_db`. No changes needed.
+- `backend/app/models/` -- No model changes. Existing Profile and Character models are used as-is.
+- `backend/app/schemas/__init__.py` -- Not modified (follows direct import pattern from existing code).
+- `backend/app/services/__init__.py` -- Not modified (follows direct import pattern from existing code).
+- `backend/requirements.txt` -- `anthropic` and `mem0ai` are already dependencies.
+- `backend/app/db/session.py` -- No changes. The endpoint uses the request-scoped session from `get_db`, not `AsyncSessionLocal`.
+- `backend/app/routes/auth.py` -- Not modified. Registration still sets `onboarding_completed=false`.
+- `backend/app/services/auth_service.py` -- Not modified. The default companion character and profile are created during registration unchanged.
+- `backend/app/services/chat_service.py` -- Not modified. Claude and Mem0 patterns are referenced but the code is not changed.
+
+---
+
+## 9. Acceptance Criteria
+
+1. Given an authenticated user with `onboarding_completed=false` and all 7 valid Q&A answers, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 200 with `{"onboarding_completed": true, "memories_seeded": N}` where N is a positive integer.
+
+2. Given a successful onboarding completion, when the profile is inspected in the database, then `onboarding_completed` is `true`.
+
+3. Given a successful onboarding completion, when Mem0 is queried with the user's `mem0_user_id` (no agent_id), then the seeded memories are returned. Each memory is a structured, third-person factual statement derived from the onboarding answers.
+
+4. Given an authenticated user with `onboarding_completed=true`, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 409 with detail "Onboarding already completed".
+
+5. Given a request with fewer than 7 answers or missing question keys, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 422 with a Pydantic validation error indicating the missing keys.
+
+6. Given a request with duplicate question keys, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 422.
+
+7. Given a request with an invalid question_key value, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 422.
+
+8. Given a request with an answer that is empty or whitespace-only, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 422.
+
+9. Given a `preferred_name` answer that differs from the current `profiles.name`, when onboarding completes successfully, then `profiles.name` is updated to the preferred name value.
+
+10. Given that Claude Haiku is unavailable, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 503 with detail "AI service temporarily unavailable" and `onboarding_completed` remains `false`.
+
+11. Given that Mem0 is unavailable, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 503 with detail "AI service temporarily unavailable" and `onboarding_completed` remains `false`.
+
+12. Given that Claude Haiku returns a non-JSON or malformed response, when the client sends `POST /api/v1/onboarding/complete`, then the service falls back to deterministic memory formatting and the endpoint returns 200 with the fallback memories seeded.
+
+13. Given no `Authorization` header, when the client sends `POST /api/v1/onboarding/complete`, then the response is HTTP 401.
+
+14. Given the `OnboardingService` code, when a developer inspects it, then all Claude Haiku calls use `AsyncAnthropic` and all Mem0 calls are wrapped in `asyncio.to_thread()`.
+
+15. Given the route handler code, when a developer inspects it, then all business logic is in `OnboardingService` and the route handler only calls the service method and returns the response.
+
+16. Given the backend test suite, when a developer runs `pytest` on the new test files, then all tests pass with exit code 0.
+
+---
+
+## 10. Design Decisions and Rationale
+
+### Why Claude Haiku converts Q&A to structured memories
+
+Raw user answers ("I wake up at 6:30, love morning runs") are not ideal for Mem0 storage. Claude Haiku converts them into concise, third-person factual statements ("Morning person, wakes up at 6:30") that Mem0 can index and search more effectively. Haiku is chosen over Sonnet because this is a simple text transformation task that does not require complex reasoning, and Haiku is significantly cheaper and faster.
+
+### Why a single Haiku call (not 7 separate calls)
+
+Sending all 7 Q&A pairs in one prompt is more efficient than 7 separate API calls. It reduces latency (one round-trip instead of 7), reduces cost (one prompt overhead instead of 7), and allows Haiku to see the full context of the user when generating memories.
+
+### Why a deterministic fallback exists
+
+If Claude Haiku is temporarily down or returns malformed output, the onboarding flow should not block the user. The deterministic fallback produces functional (if less polished) memories that still allow the AI companion to personalize conversations. The user is not aware of which path was used.
+
+### Why onboarding memories are seeded as global (no agent_id)
+
+Per `docs/05-ai-bellek.md`, global memories contain "basic user information visible to all characters" -- name, profession, goals, sleep schedule, etc. Onboarding answers are exactly this category. If we seeded them with the companion's `agent_id`, only the companion character would see them in character-scoped searches. By seeding globally, all characters (English Teacher, Fitness Coach, etc.) benefit from the onboarding information.
+
+### Why the endpoint returns 409 for already-completed onboarding
+
+Re-running onboarding would add duplicate memories to Mem0 (Mem0 may or may not deduplicate). More importantly, it would be confusing for the user experience. The mobile client checks `onboarding_completed` from the login/register response and only shows the onboarding flow when it is `false`. The 409 is a safety net for race conditions or misbehaving clients.
+
+### Why the profile name is updated from preferred_name
+
+During registration, the user provides their full name. During onboarding, the "What should I call you?" question may yield a nickname ("Alex" instead of "Alexander"). Updating `profiles.name` ensures the AI uses the preferred name everywhere, not just in Mem0 memories.
+
+### Why Mem0 seeding happens before the DB flag update
+
+If Mem0 fails, the flag stays `false` and the client can retry. If the DB flag update fails after Mem0 succeeds, the memories are already in Mem0 (harmless duplicates on retry thanks to Mem0's deduplication) and the next retry will succeed in setting the flag. This ordering maximizes retry safety.
+
+### Why not use a background task for Mem0 seeding
+
+Unlike the chat flow (P01-06) where the user should not wait for memory persistence, the onboarding flow is a one-time operation where the user expects to wait briefly. The mobile client shows a loading state during onboarding. Running Mem0 seeding in the foreground ensures we can report success/failure accurately and keeps the retry logic simple.
+
+---
+
+## 11. Notes for Developers
+
+### For backend-dev
+
+- **Start with schemas** (`app/schemas/onboarding.py`), then the service (`app/services/onboarding_service.py`), then the route (`app/routes/onboarding.py`), then wire up in `main.py`.
+
+- **Claude Haiku call pattern**: Follow the same pattern as `ChatService._extract_intent()` in `chat_service.py` (lines 473-517). Use `AsyncAnthropic` (not `asyncio.to_thread` for Claude -- the Anthropic SDK has native async support via `AsyncAnthropic`). Set `max_tokens=512` (the response is a small JSON array).
+
+- **Mem0 add() call pattern**: Follow the pattern in `chat_service.py` `_persist_exchange()` (lines 584-596). Use `MemoryClient` wrapped in `asyncio.to_thread()`. The key difference: pass `user_id` only (no `agent_id`) for global scope.
+
+- **Mem0 add() input format**: The `client.add()` method can accept a string or a list of message dicts. For onboarding, the simplest approach is to pass the list of memory strings joined with newlines as a single string, or pass each memory as a separate `{"role": "user", "content": text}` dict in a list. Test both approaches to see which produces better Mem0 memory entries. The recommended approach is to pass each memory as a separate add() call or concatenate them into one add() call -- verify with the Mem0 SDK docs which approach produces distinct, searchable memories.
+
+- **Haiku JSON parsing**: Use `json.loads()` on the Haiku response text. Strip any markdown code block delimiters (` ```json ` and ` ``` `) before parsing -- LLMs sometimes wrap JSON in code blocks. If parsing fails, log a warning and use `_fallback_memories()`.
+
+- **Profile update for preferred_name**: Extract the answer with `question_key == "preferred_name"` before the Haiku call. Compare case-insensitively with `profile.name`. If different, update `profile.name` in the same DB transaction.
+
+- **Router prefix**: Register the router with `prefix="/api/v1/onboarding"` in `main.py`. The route function uses the relative path: `@router.post("/complete")`.
+
+- **Existing import in main.py**: The current `from app.routes import auth, characters, chat, health, memories` line needs to be extended with `onboarding`.
+
+- **No new config values needed**: `anthropic_api_key`, `claude_haiku_model`, and `mem0_api_key` all exist in `config.py`. Use `settings.claude_haiku_model` for the Haiku model name.
+
+### For backend-tester
+
+- **Mock Claude at the import level**: Patch `app.services.onboarding_service.AsyncAnthropic` to return a mock client with a mock `messages.create()` method that returns a mock response containing a JSON array of 7 strings.
+
+- **Mock Mem0 at the import level**: Patch `app.services.onboarding_service.MemoryClient` to return a mock client. Verify `add()` is called with the correct `user_id` parameter and no `agent_id` parameter.
+
+- **Test the 409 path**: Set `profile.onboarding_completed = True` in the mock profile and verify the endpoint returns 409 without making any Claude or Mem0 calls.
+
+- **Test the fallback path**: Make the mock Haiku response return non-JSON text (e.g., `"Here are the memories:\n- Prefers to be called Alex"`) and verify the service uses fallback formatting and still returns 200.
+
+- **Test profile name update**: Provide a `preferred_name` answer that differs from `profile.name` and verify `profile.name` is updated in the DB.
+
+- **Test Pydantic validation thoroughly**: Test missing keys, duplicate keys, invalid keys, empty answers, whitespace-only answers, and answers exceeding 500 characters.
+
+- **Verify ordering**: Ensure that when Mem0 fails, `onboarding_completed` is NOT set to `true`. Use mock side effects to simulate Mem0 failure after successful Haiku response.


### PR DESCRIPTION
## onboarding-endpoint

POST /onboarding/complete receives 7 onboarding Q&A answers, uses Claude Haiku to convert them to structured memory statements, seeds Mem0 globally, and sets profiles.onboarding_completed=true.

Closes #11

---

## Pipeline Summary

| Stage | Agent | Status |
|-------|-------|--------|
| Architecture | architect | ✅ |
| Backend Implementation | backend-dev | ✅ |
| Backend Tests | backend-tester | ✅ |
| Documentation | doc-writer | ✅ |
| Code Review | reviewer | ✅ Approved |

## Spec
`shared/feature-specs/onboarding-endpoint.md`

## Test Coverage
- **131 onboarding tests** — 100% line & branch coverage
- **1193 total tests** passing (0 failures)

## Key Features
- Claude Haiku converts Q&A to structured Mem0 memories
- Deterministic fallback when Haiku fails
- Global memory scope (all characters see onboarding data)
- Retry-safe ordering: Haiku → Mem0 → DB flag
- 409 idempotency for re-onboarding attempts
- Profile name update from preferred_name answer

🤖 Generated via `/pipeline-run P01-09`