### PR TITLE
feat(openapi-specs): openapi-specs [P1.5-06]

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -38,6 +38,16 @@ jobs:
           MEM0_API_KEY: test
           ANTHROPIC_API_KEY: test
 
+      - name: Validate OpenAPI specs
+        run: python scripts/validate_openapi.py
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/ember_test
+          COGNITO_USER_POOL_ID: test
+          COGNITO_CLIENT_ID: test
+          AWS_REGION: eu-west-1
+          MEM0_API_KEY: test
+          ANTHROPIC_API_KEY: test
+
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [P1.5-03] Observability stack: structured logging (structlog), request ID middleware, Sentry error tracking, external API call timing
 - [P1.5-04] Mem0 circuit breaker with local cache fallback and retry queue
 - [P1.5-05] LLM provider abstraction layer (ADR-006) with Anthropic/OpenAI providers and router
+- [P1.5-06] OpenAPI 3.1 specs for all 19 endpoints with drift detection CI
 
 ---
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,16 @@ def create_app() -> FastAPI:
         title="Ember API",
         version=settings.app_version,
         lifespan=lifespan,
+        openapi_tags=[
+            {"name": "health", "description": "Health check and dependency status"},
+            {"name": "auth", "description": "Authentication (register, login, refresh)"},
+            {"name": "characters", "description": "Character CRUD"},
+            {"name": "chat", "description": "Message sending (SSE) and history"},
+            {"name": "memories", "description": "Mem0 memory retrieval and deletion"},
+            {"name": "media", "description": "S3 presigned URL generation"},
+            {"name": "onboarding", "description": "Onboarding flow completion"},
+            {"name": "profile", "description": "User profile management"},
+        ],
     )
 
     # Middleware registration order: Starlette applies in reverse order.

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,3 +3,5 @@ pytest-asyncio>=0.25.0,<1.0.0
 httpx>=0.28.0,<1.0.0
 ruff>=0.9.0
 mypy>=1.14.0
+pyyaml>=6.0.0
+openapi-spec-validator>=0.7.0

--- a/backend/scripts/validate_openapi.py
+++ b/backend/scripts/validate_openapi.py
@@ -1,0 +1,380 @@
+"""Validate hand-written OpenAPI YAML specs against FastAPI auto-generated schema.
+
+Drift detection: ensures the YAML specs in shared/api-contracts/ match the
+actual FastAPI endpoint definitions. Exits with code 0 if specs match,
+code 1 if any differences are found.
+
+Usage:
+    python scripts/validate_openapi.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Add backend to path so we can import the FastAPI app
+backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(backend_dir))
+
+# The /api/v1 prefix used in FastAPI route registration
+API_PREFIX = "/api/v1"
+
+# Paths to skip comparison for specific methods (SSE streaming cannot be modelled)
+SSE_ENDPOINTS: set[tuple[str, str]] = {
+    ("/api/v1/characters/{character_id}/messages", "post"),
+}
+
+
+def load_yaml_specs(contracts_dir: Path) -> dict[str, Any]:
+    """Load and merge all YAML spec files, resolving $ref pointers manually."""
+    root_path = contracts_dir / "ember-api.yaml"
+    if not root_path.exists():
+        print(f"ERROR: Root spec file not found: {root_path}")
+        sys.exit(1)
+
+    with open(root_path) as f:
+        root = yaml.safe_load(f)
+
+    # Load all path files and schema files
+    paths: dict[str, Any] = {}
+    for path_key, ref_obj in root.get("paths", {}).items():
+        if "$ref" in ref_obj:
+            ref_str = ref_obj["$ref"]
+            file_part, fragment = ref_str.split("#", 1)
+            file_path = contracts_dir / file_part
+            with open(file_path) as f:
+                path_data = yaml.safe_load(f)
+
+            # Resolve the JSON pointer fragment (e.g., /~1health -> /health)
+            pointer = fragment.lstrip("/")
+            pointer = pointer.replace("~1", "/").replace("~0", "~")
+            if pointer in path_data:
+                paths[path_key] = path_data[pointer]
+            else:
+                print(f"WARNING: Could not resolve {ref_str} in {file_path}")
+        else:
+            paths[path_key] = ref_obj
+
+    return paths
+
+
+def get_fastapi_schema() -> dict[str, Any]:
+    """Get the auto-generated OpenAPI schema from FastAPI."""
+    from app.main import app  # noqa: E402
+
+    return app.openapi()
+
+
+def normalize_path(yaml_path: str) -> str:
+    """Convert a YAML spec path to the FastAPI equivalent by adding the /api/v1 prefix."""
+    return f"{API_PREFIX}{yaml_path}"
+
+
+def extract_field_names(schema: dict[str, Any]) -> set[str]:
+    """Extract property names from a JSON schema object."""
+    if not schema:
+        return set()
+    if "properties" in schema:
+        return set(schema["properties"].keys())
+    # Handle allOf, anyOf, oneOf
+    for combiner in ("allOf", "anyOf", "oneOf"):
+        if combiner in schema:
+            names: set[str] = set()
+            for sub in schema[combiner]:
+                names |= extract_field_names(sub)
+            return names
+    return set()
+
+
+def extract_required_fields(schema: dict[str, Any]) -> set[str]:
+    """Extract required field names from a JSON schema object."""
+    if not schema:
+        return set()
+    return set(schema.get("required", []))
+
+
+def resolve_ref(ref: str, full_schema: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a $ref pointer within the FastAPI schema."""
+    if not ref.startswith("#/"):
+        return {}
+    parts = ref[2:].split("/")
+    current = full_schema
+    for part in parts:
+        part = part.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return {}
+    return current if isinstance(current, dict) else {}
+
+
+def get_request_body_schema(
+    operation: dict[str, Any], full_schema: dict[str, Any]
+) -> dict[str, Any]:
+    """Extract the request body schema from an operation, resolving $ref."""
+    rb = operation.get("requestBody", {})
+    if not rb:
+        return {}
+    content = rb.get("content", {})
+    json_content = content.get("application/json", {})
+    schema = json_content.get("schema", {})
+    if "$ref" in schema:
+        return resolve_ref(schema["$ref"], full_schema)
+    return schema
+
+
+def get_response_codes(operation: dict[str, Any]) -> set[str]:
+    """Get the set of response status codes from an operation."""
+    return set(operation.get("responses", {}).keys())
+
+
+def get_query_params(operation: dict[str, Any]) -> dict[str, str]:
+    """Get query parameter names and their types."""
+    params = {}
+    for param in operation.get("parameters", []):
+        if param.get("in") == "query":
+            schema = param.get("schema", {})
+            param_type = schema.get("type", "unknown")
+            params[param["name"]] = param_type
+    return params
+
+
+def get_path_params(operation: dict[str, Any]) -> set[str]:
+    """Get path parameter names."""
+    params = set()
+    for param in operation.get("parameters", []):
+        if param.get("in") == "path":
+            params.add(param["name"])
+    return params
+
+
+def compare_schemas(
+    yaml_paths: dict[str, Any],
+    fastapi_schema: dict[str, Any],
+) -> list[str]:
+    """Compare YAML specs against FastAPI schema and return list of errors."""
+    errors: list[str] = []
+    fastapi_paths = fastapi_schema.get("paths", {})
+
+    # Check every YAML path exists in FastAPI
+    for yaml_path, yaml_ops in yaml_paths.items():
+        fastapi_path = normalize_path(yaml_path)
+        if fastapi_path not in fastapi_paths:
+            errors.append(
+                f"YAML spec references path {yaml_path} "
+                f"(-> {fastapi_path}) not found in FastAPI"
+            )
+            continue
+
+        fastapi_ops = fastapi_paths[fastapi_path]
+
+        for method, yaml_op in yaml_ops.items():
+            if method not in fastapi_ops:
+                errors.append(
+                    f"YAML spec references {method.upper()} {yaml_path} "
+                    f"not found in FastAPI"
+                )
+                continue
+
+            fastapi_op = fastapi_ops[method]
+            endpoint_label = f"{method.upper()} {yaml_path}"
+
+            # Skip response body comparison for SSE endpoints
+            is_sse = (fastapi_path, method) in SSE_ENDPOINTS
+
+            # Compare request body field names
+            if not is_sse:
+                yaml_rb = yaml_op.get("requestBody", {})
+                fastapi_rb = fastapi_op.get("requestBody", {})
+
+                yaml_has_body = bool(yaml_rb)
+                fastapi_has_body = bool(fastapi_rb)
+
+                if yaml_has_body != fastapi_has_body:
+                    errors.append(
+                        f"{endpoint_label}: request body mismatch -- "
+                        f"YAML={'present' if yaml_has_body else 'absent'}, "
+                        f"FastAPI={'present' if fastapi_has_body else 'absent'}"
+                    )
+                elif yaml_has_body and fastapi_has_body:
+                    yaml_rb_schema = _extract_json_schema(yaml_rb)
+                    fastapi_rb_schema = get_request_body_schema(
+                        fastapi_op, fastapi_schema
+                    )
+                    yaml_fields = extract_field_names(yaml_rb_schema)
+                    fastapi_fields = extract_field_names(fastapi_rb_schema)
+
+                    if yaml_fields and fastapi_fields:
+                        missing_in_yaml = fastapi_fields - yaml_fields
+                        extra_in_yaml = yaml_fields - fastapi_fields
+                        if missing_in_yaml:
+                            errors.append(
+                                f"{endpoint_label}: request body fields in FastAPI "
+                                f"but missing from YAML: {sorted(missing_in_yaml)}"
+                            )
+                        if extra_in_yaml:
+                            errors.append(
+                                f"{endpoint_label}: request body fields in YAML "
+                                f"but missing from FastAPI: {sorted(extra_in_yaml)}"
+                            )
+
+            # Compare response status codes
+            yaml_codes = get_response_codes(yaml_op)
+            fastapi_codes = get_response_codes(fastapi_op)
+
+            # Tolerate extra 422 in FastAPI (auto-generated)
+            fastapi_codes_for_compare = fastapi_codes.copy()
+            if "422" in yaml_codes:
+                pass  # both have it, fine
+            else:
+                fastapi_codes_for_compare.discard("422")
+
+            missing_codes = fastapi_codes_for_compare - yaml_codes
+            if missing_codes:
+                errors.append(
+                    f"{endpoint_label}: response codes in FastAPI but missing "
+                    f"from YAML: {sorted(missing_codes)}"
+                )
+
+            # We don't flag codes in YAML but not in FastAPI for 401/429
+            # since FastAPI doesn't auto-generate those but we document them.
+
+            # Compare query parameters
+            yaml_query = get_query_params(yaml_op)
+            fastapi_query = get_query_params(fastapi_op)
+
+            yaml_query_names = set(yaml_query.keys())
+            fastapi_query_names = set(fastapi_query.keys())
+
+            missing_query = fastapi_query_names - yaml_query_names
+            extra_query = yaml_query_names - fastapi_query_names
+            if missing_query:
+                errors.append(
+                    f"{endpoint_label}: query params in FastAPI but missing "
+                    f"from YAML: {sorted(missing_query)}"
+                )
+            if extra_query:
+                errors.append(
+                    f"{endpoint_label}: query params in YAML but missing "
+                    f"from FastAPI: {sorted(extra_query)}"
+                )
+
+            # Compare path parameters
+            yaml_path_params = get_path_params(yaml_op)
+            fastapi_path_params = get_path_params(fastapi_op)
+
+            if yaml_path_params != fastapi_path_params:
+                errors.append(
+                    f"{endpoint_label}: path params mismatch -- "
+                    f"YAML={sorted(yaml_path_params)}, "
+                    f"FastAPI={sorted(fastapi_path_params)}"
+                )
+
+            # Compare response body field names (200/201 only, skip SSE)
+            if not is_sse:
+                for code in ("200", "201"):
+                    if code in yaml_codes and code in fastapi_codes:
+                        yaml_resp = yaml_op["responses"][code]
+                        fastapi_resp = fastapi_op["responses"][code]
+
+                        yaml_resp_schema = _extract_json_schema_from_response(yaml_resp)
+                        fastapi_resp_schema = _extract_json_schema_from_response(
+                            fastapi_resp
+                        )
+
+                        if "$ref" in fastapi_resp_schema:
+                            fastapi_resp_schema = resolve_ref(
+                                fastapi_resp_schema["$ref"], fastapi_schema
+                            )
+
+                        yaml_resp_fields = extract_field_names(yaml_resp_schema)
+                        fastapi_resp_fields = extract_field_names(fastapi_resp_schema)
+
+                        if yaml_resp_fields and fastapi_resp_fields:
+                            missing = fastapi_resp_fields - yaml_resp_fields
+                            extra = yaml_resp_fields - fastapi_resp_fields
+                            if missing:
+                                errors.append(
+                                    f"{endpoint_label} [{code}]: response fields "
+                                    f"in FastAPI but missing from YAML: {sorted(missing)}"
+                                )
+                            if extra:
+                                errors.append(
+                                    f"{endpoint_label} [{code}]: response fields "
+                                    f"in YAML but missing from FastAPI: {sorted(extra)}"
+                                )
+
+    # Check every FastAPI path exists in YAML
+    for fastapi_path, fastapi_ops in fastapi_paths.items():
+        # Strip /api/v1 prefix to get the YAML path
+        if not fastapi_path.startswith(API_PREFIX):
+            continue
+        yaml_path = fastapi_path[len(API_PREFIX):]
+
+        # Skip test-only routes injected by the test suite
+        if "/_test" in yaml_path:
+            continue
+
+        if yaml_path not in yaml_paths:
+            errors.append(
+                f"FastAPI endpoint {fastapi_path} not documented in YAML specs"
+            )
+            continue
+
+        for method in fastapi_ops:
+            if method not in yaml_paths[yaml_path]:
+                errors.append(
+                    f"FastAPI endpoint {method.upper()} {fastapi_path} "
+                    f"not documented in YAML specs"
+                )
+
+    return errors
+
+
+def _extract_json_schema(request_body: dict[str, Any]) -> dict[str, Any]:
+    """Extract JSON schema from a request body object."""
+    content = request_body.get("content", {})
+    json_content = content.get("application/json", {})
+    return json_content.get("schema", {})
+
+
+def _extract_json_schema_from_response(response: dict[str, Any]) -> dict[str, Any]:
+    """Extract JSON schema from a response object."""
+    content = response.get("content", {})
+    json_content = content.get("application/json", {})
+    return json_content.get("schema", {})
+
+
+def main() -> int:
+    """Run the validation and return exit code."""
+    contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+
+    print(f"Loading YAML specs from {contracts_dir}")
+    yaml_paths = load_yaml_specs(contracts_dir)
+    print(f"Found {len(yaml_paths)} paths in YAML specs")
+
+    print("Loading FastAPI auto-generated schema")
+    fastapi_schema = get_fastapi_schema()
+    fastapi_paths = fastapi_schema.get("paths", {})
+    print(f"Found {len(fastapi_paths)} paths in FastAPI schema")
+
+    print("\nComparing specs...\n")
+    errors = compare_schemas(yaml_paths, fastapi_schema)
+
+    if errors:
+        print(f"FAILED: {len(errors)} difference(s) found:\n")
+        for i, error in enumerate(errors, 1):
+            print(f"  {i}. {error}")
+        print()
+        return 1
+
+    print("OK: All YAML specs match the FastAPI schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_openapi_validation.py
+++ b/backend/tests/test_openapi_validation.py
@@ -16,11 +16,15 @@ sys.path.insert(0, str(backend_dir))
 from scripts.validate_openapi import (  # noqa: E402
     compare_schemas,
     extract_field_names,
+    extract_required_fields,
     get_fastapi_schema,
+    get_path_params,
     get_query_params,
+    get_request_body_schema,
     get_response_codes,
     load_yaml_specs,
     normalize_path,
+    resolve_ref,
 )
 
 # ---------------------------------------------------------------------------
@@ -172,3 +176,777 @@ class TestHelperFunctions:
         }
         result = get_query_params(operation)
         assert result == {"cursor": "string", "limit": "integer"}
+
+    def test_get_query_params_empty(self) -> None:
+        """get_query_params returns empty dict when no parameters."""
+        assert get_query_params({}) == {}
+        assert get_query_params({"parameters": []}) == {}
+
+    def test_get_query_params_no_schema_type(self) -> None:
+        """get_query_params returns 'unknown' for params without explicit type."""
+        operation = {
+            "parameters": [
+                {"name": "foo", "in": "query", "schema": {}},
+            ]
+        }
+        result = get_query_params(operation)
+        assert result == {"foo": "unknown"}
+
+    def test_extract_required_fields_with_required_list(self) -> None:
+        """extract_required_fields returns required field names from schema."""
+        schema = {
+            "type": "object",
+            "required": ["email", "password"],
+            "properties": {
+                "email": {"type": "string"},
+                "password": {"type": "string"},
+                "name": {"type": "string"},
+            },
+        }
+        assert extract_required_fields(schema) == {"email", "password"}
+
+    def test_extract_required_fields_empty_schema(self) -> None:
+        """extract_required_fields returns empty set for missing required list."""
+        assert extract_required_fields({}) == set()
+        assert extract_required_fields(None) == set()  # type: ignore[arg-type]
+
+    def test_get_path_params(self) -> None:
+        """get_path_params returns path parameter names only."""
+        operation = {
+            "parameters": [
+                {"name": "character_id", "in": "path", "schema": {"type": "string"}},
+                {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+            ]
+        }
+        result = get_path_params(operation)
+        assert result == {"character_id"}
+
+    def test_get_path_params_empty(self) -> None:
+        """get_path_params returns empty set when no path params."""
+        assert get_path_params({}) == set()
+        assert get_path_params({"parameters": []}) == set()
+
+    def test_resolve_ref_valid(self) -> None:
+        """resolve_ref returns the nested dict at the given JSON pointer."""
+        full_schema = {
+            "components": {
+                "schemas": {
+                    "Foo": {"type": "object", "properties": {"bar": {"type": "string"}}}
+                }
+            }
+        }
+        result = resolve_ref("#/components/schemas/Foo", full_schema)
+        assert result == {"type": "object", "properties": {"bar": {"type": "string"}}}
+
+    def test_resolve_ref_missing_path_returns_empty(self) -> None:
+        """resolve_ref returns empty dict when path does not exist."""
+        result = resolve_ref("#/components/schemas/DoesNotExist", {"components": {}})
+        assert result == {}
+
+    def test_resolve_ref_non_internal_ref_returns_empty(self) -> None:
+        """resolve_ref returns empty dict for non-internal refs (not starting with #/)."""
+        result = resolve_ref("../schemas/auth.yaml#/RegisterRequest", {})
+        assert result == {}
+
+    def test_get_response_codes_empty(self) -> None:
+        """get_response_codes returns empty set for operation with no responses."""
+        assert get_response_codes({}) == set()
+        assert get_response_codes({"responses": {}}) == set()
+
+    def test_get_request_body_schema_empty_operation(self) -> None:
+        """get_request_body_schema returns empty dict when operation has no requestBody."""
+        result = get_request_body_schema({}, {})
+        assert result == {}
+
+    def test_get_request_body_schema_with_direct_schema(self) -> None:
+        """get_request_body_schema returns the inline schema from application/json."""
+        operation = {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {"properties": {"field": {"type": "string"}}}
+                    }
+                }
+            }
+        }
+        result = get_request_body_schema(operation, {})
+        assert result == {"properties": {"field": {"type": "string"}}}
+
+    def test_get_request_body_schema_resolves_ref(self) -> None:
+        """get_request_body_schema resolves $ref to the component schema."""
+        full_schema = {
+            "components": {
+                "schemas": {
+                    "MyRequest": {
+                        "properties": {"name": {"type": "string"}}
+                    }
+                }
+            }
+        }
+        operation = {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/MyRequest"}
+                    }
+                }
+            }
+        }
+        result = get_request_body_schema(operation, full_schema)
+        assert result == {"properties": {"name": {"type": "string"}}}
+
+    def test_extract_field_names_with_anyof_combiner(self) -> None:
+        """extract_field_names unions fields from all anyOf branches."""
+        schema = {
+            "anyOf": [
+                {"properties": {"foo": {"type": "string"}}},
+                {"properties": {"bar": {"type": "integer"}}},
+            ]
+        }
+        result = extract_field_names(schema)
+        assert result == {"foo", "bar"}
+
+    def test_extract_field_names_with_allof_combiner(self) -> None:
+        """extract_field_names unions fields from all allOf branches."""
+        schema = {
+            "allOf": [
+                {"properties": {"alpha": {"type": "string"}}},
+                {"properties": {"beta": {"type": "integer"}}},
+            ]
+        }
+        result = extract_field_names(schema)
+        assert result == {"alpha", "beta"}
+
+    def test_extract_field_names_with_oneof_combiner(self) -> None:
+        """extract_field_names unions fields from all oneOf branches."""
+        schema = {
+            "oneOf": [
+                {"properties": {"x": {"type": "string"}}},
+                {"type": "null"},
+            ]
+        }
+        result = extract_field_names(schema)
+        assert result == {"x"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: drift detection (compare_schemas)
+# ---------------------------------------------------------------------------
+
+
+class TestDriftDetection:
+    """compare_schemas must detect spec drift between YAML and FastAPI schemas."""
+
+    def _make_fastapi_schema(self, paths: dict) -> dict:
+        """Build a minimal FastAPI schema dict around the given paths."""
+        return {"paths": paths}
+
+    def test_yaml_path_not_in_fastapi_returns_error(self) -> None:
+        """An error is returned when a YAML path has no matching FastAPI path."""
+        yaml_paths = {"/nonexistent": {"get": {"responses": {"200": {}}}}}
+        fastapi_schema = self._make_fastapi_schema({})
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("nonexistent" in e for e in errors)
+
+    def test_yaml_method_not_in_fastapi_returns_error(self) -> None:
+        """An error is returned when a YAML method has no matching FastAPI method."""
+        yaml_paths = {"/health": {"delete": {"responses": {"204": {}}}}}
+        fastapi_schema = self._make_fastapi_schema(
+            {"/api/v1/health": {"get": {"responses": {"200": {}}}}}
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("DELETE /health" in e for e in errors)
+
+    def test_fastapi_path_not_in_yaml_returns_error(self) -> None:
+        """An error is returned when a FastAPI path is not in the YAML specs."""
+        yaml_paths = {}
+        fastapi_schema = self._make_fastapi_schema(
+            {"/api/v1/undocumented": {"get": {"responses": {"200": {}}}}}
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("undocumented" in e for e in errors)
+
+    def test_fastapi_method_not_in_yaml_returns_error(self) -> None:
+        """An error is returned when a FastAPI method is missing from YAML."""
+        yaml_paths = {"/health": {"get": {"responses": {"200": {}}}}}
+        fastapi_schema = self._make_fastapi_schema(
+            {"/api/v1/health": {"get": {}, "post": {}}}
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("POST" in e and "health" in e for e in errors)
+
+    def test_request_body_field_missing_in_yaml_returns_error(self) -> None:
+        """An error is returned when a FastAPI request body field is missing from YAML."""
+        yaml_paths = {
+            "/test": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {"email": {"type": "string"}},
+                                }
+                            }
+                        }
+                    },
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/test": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {
+                                            "email": {"type": "string"},
+                                            "password": {"type": "string"},
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"200": {}},
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("request body" in e.lower() and "password" in e for e in errors)
+
+    def test_extra_yaml_request_body_field_returns_error(self) -> None:
+        """An error is returned when YAML documents a field not in FastAPI."""
+        yaml_paths = {
+            "/test": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "email": {"type": "string"},
+                                        "ghost_field": {"type": "string"},
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/test": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {"email": {"type": "string"}}
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"200": {}},
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("ghost_field" in e for e in errors)
+
+    def test_missing_response_code_in_yaml_returns_error(self) -> None:
+        """An error is returned when FastAPI returns a code not in YAML (not 422)."""
+        yaml_paths = {
+            "/test": {
+                "get": {
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/test": {
+                    "get": {
+                        "responses": {
+                            "200": {},
+                            "400": {"description": "Bad request"},
+                        }
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("response code" in e.lower() and "400" in e for e in errors)
+
+    def test_extra_422_in_fastapi_is_tolerated_when_yaml_omits_it(self) -> None:
+        """Auto-generated 422 in FastAPI is not flagged when YAML omits it."""
+        yaml_paths = {
+            "/test": {
+                "post": {
+                    "requestBody": {},
+                    "responses": {"201": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/test": {
+                    "post": {
+                        "requestBody": {},
+                        "responses": {
+                            "201": {},
+                            "422": {"description": "Validation Error"},
+                        },
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        response_code_errors = [e for e in errors if "response code" in e.lower()]
+        assert not response_code_errors, (
+            "422 should be tolerated but got errors: "
+            + ", ".join(response_code_errors)
+        )
+
+    def test_test_only_routes_skipped_in_fastapi_check(self) -> None:
+        """FastAPI routes containing /_test are skipped during comparison."""
+        yaml_paths = {}
+        fastapi_schema = self._make_fastapi_schema(
+            {"/api/v1/_test_protected": {"get": {}}}
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        # Should not flag the _test route
+        assert not any("_test" in e for e in errors)
+
+    def test_query_param_missing_in_yaml_returns_error(self) -> None:
+        """An error is returned when FastAPI has a query param not in YAML."""
+        yaml_paths = {
+            "/test": {
+                "get": {
+                    "parameters": [],
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/test": {
+                    "get": {
+                        "parameters": [
+                            {"name": "limit", "in": "query", "schema": {"type": "integer"}}
+                        ],
+                        "responses": {"200": {}},
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("query param" in e.lower() and "limit" in e for e in errors)
+
+    def test_extra_yaml_query_param_returns_error(self) -> None:
+        """An error is returned when YAML has a query param not in FastAPI."""
+        yaml_paths = {
+            "/test": {
+                "get": {
+                    "parameters": [
+                        {"name": "ghost_param", "in": "query", "schema": {"type": "string"}}
+                    ],
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {"/api/v1/test": {"get": {"parameters": [], "responses": {"200": {}}}}}
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("query param" in e.lower() and "ghost_param" in e for e in errors)
+
+    def test_path_param_mismatch_returns_error(self) -> None:
+        """An error is returned when path parameter names differ."""
+        yaml_paths = {
+            "/items/{item_id}": {
+                "get": {
+                    "parameters": [
+                        {"name": "item_id", "in": "path", "schema": {"type": "string"}}
+                    ],
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/items/{item_id}": {
+                    "get": {
+                        "parameters": [
+                            {"name": "wrong_id", "in": "path", "schema": {"type": "string"}}
+                        ],
+                        "responses": {"200": {}},
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("path param" in e.lower() for e in errors)
+
+    def test_no_errors_when_schemas_match(self) -> None:
+        """compare_schemas returns no errors when YAML and FastAPI are in sync."""
+        yaml_paths = {
+            "/health": {
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "check_dependencies",
+                            "in": "query",
+                            "schema": {"type": "boolean"},
+                        }
+                    ],
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/health": {
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "check_dependencies",
+                                "in": "query",
+                                "schema": {"type": "boolean"},
+                            }
+                        ],
+                        "responses": {"200": {}},
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert errors == []
+
+    def test_yaml_has_body_but_fastapi_does_not_returns_error(self) -> None:
+        """An error is returned when YAML has a request body but FastAPI does not."""
+        yaml_paths = {
+            "/test": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"properties": {"field": {"type": "string"}}}
+                            }
+                        }
+                    },
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {"/api/v1/test": {"post": {"responses": {"200": {}}}}}
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("request body" in e.lower() for e in errors)
+
+    def test_fastapi_has_body_but_yaml_does_not_returns_error(self) -> None:
+        """An error is returned when FastAPI has a request body but YAML does not."""
+        yaml_paths = {
+            "/test": {
+                "post": {
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/test": {
+                    "post": {
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {"field": {"type": "string"}}
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"200": {}},
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any("request body" in e.lower() for e in errors)
+
+    def test_response_body_field_missing_in_yaml_returns_error(self) -> None:
+        """An error is returned when a FastAPI 200 response field is missing from YAML."""
+        yaml_paths = {
+            "/test": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {"name": {"type": "string"}}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "properties": {
+                                                "name": {"type": "string"},
+                                                "secret_field": {"type": "string"},
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any(
+            "response fields" in e.lower() and "secret_field" in e for e in errors
+        )
+
+    def test_extra_yaml_response_body_field_returns_error(self) -> None:
+        """An error is returned when YAML documents a response field not in FastAPI."""
+        yaml_paths = {
+            "/test": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "phantom_field": {"type": "string"},
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "properties": {"name": {"type": "string"}}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert any(
+            "response fields" in e.lower() and "phantom_field" in e for e in errors
+        )
+
+    def test_fastapi_paths_without_api_prefix_are_skipped(self) -> None:
+        """FastAPI paths not under /api/v1 are silently ignored."""
+        yaml_paths = {}
+        fastapi_schema = self._make_fastapi_schema(
+            {"/openapi.json": {"get": {}}, "/docs": {"get": {}}}
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        # No errors about /openapi.json or /docs
+        assert not any("/openapi.json" in e or "/docs" in e for e in errors)
+
+    def test_sse_endpoint_request_body_skipped(self) -> None:
+        """Response body comparison is skipped for SSE endpoints."""
+        # The SSE endpoint at POST /characters/{character_id}/messages should not
+        # flag response body mismatches since FastAPI returns StreamingResponse.
+        yaml_paths = {
+            "/characters/{character_id}/messages": {
+                "post": {
+                    "parameters": [
+                        {
+                            "name": "character_id",
+                            "in": "path",
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {"content": {"type": "string"}}
+                                }
+                            }
+                        }
+                    },
+                    "responses": {"200": {}},
+                }
+            }
+        }
+        fastapi_schema = self._make_fastapi_schema(
+            {
+                "/api/v1/characters/{character_id}/messages": {
+                    "post": {
+                        "parameters": [
+                            {
+                                "name": "character_id",
+                                "in": "path",
+                                "schema": {"type": "string"},
+                            }
+                        ],
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {"content": {"type": "string"}}
+                                    }
+                                }
+                            }
+                        },
+                        # No response schema (StreamingResponse)
+                        "responses": {"200": {}},
+                    }
+                }
+            }
+        )
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        # Response body mismatch errors should not appear for the SSE endpoint
+        response_body_errors = [e for e in errors if "response fields" in e.lower()]
+        assert not response_body_errors
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_yaml_specs error handling
+# ---------------------------------------------------------------------------
+
+
+class TestLoadYamlSpecs:
+    """load_yaml_specs must handle missing files gracefully."""
+
+    def test_missing_root_spec_exits(self, tmp_path: Path) -> None:
+        """load_yaml_specs calls sys.exit when root spec is not found."""
+        import pytest
+
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        with pytest.raises(SystemExit) as exc_info:
+            load_yaml_specs(empty_dir)
+        assert exc_info.value.code == 1
+
+    def test_valid_contracts_dir_loads_paths(self) -> None:
+        """load_yaml_specs loads all 14 path keys from the real contracts directory.
+
+        Note: 14 path keys cover 19 endpoint+method combinations
+        (some paths like /characters have both GET and POST operations).
+        """
+        contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+        yaml_paths = load_yaml_specs(contracts_dir)
+        assert len(yaml_paths) == 14, (
+            f"Expected 14 path keys from YAML specs, got {len(yaml_paths)}"
+        )
+
+    def test_unresolvable_pointer_prints_warning_and_skips(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """load_yaml_specs prints a WARNING and skips refs with unresolvable pointers."""
+        import yaml
+
+        # Build a minimal contracts dir with a root spec referencing a bad pointer
+        contracts_dir = tmp_path / "contracts"
+        contracts_dir.mkdir()
+        paths_dir = contracts_dir / "paths"
+        paths_dir.mkdir()
+
+        # Write a paths file that exists but lacks the referenced pointer
+        path_data = {"/existing": {"get": {"responses": {"200": {}}}}}
+        with open(paths_dir / "fake.yaml", "w") as f:
+            yaml.dump(path_data, f)
+
+        # Root spec references a pointer that does NOT exist in the file
+        root_data = {
+            "openapi": "3.1.0",
+            "paths": {
+                "/broken": {"$ref": "paths/fake.yaml#/~1does~1not~1exist"}
+            },
+        }
+        with open(contracts_dir / "ember-api.yaml", "w") as f:
+            yaml.dump(root_data, f)
+
+        yaml_paths = load_yaml_specs(contracts_dir)
+        captured = capsys.readouterr()
+
+        # The broken path is skipped (not included in returned dict)
+        assert "/broken" not in yaml_paths
+        # A warning is printed
+        assert "WARNING" in captured.out
+
+    def test_inline_path_without_ref_is_loaded(self, tmp_path: Path) -> None:
+        """load_yaml_specs handles paths defined inline (no $ref) in the root spec."""
+        import yaml
+
+        contracts_dir = tmp_path / "contracts"
+        contracts_dir.mkdir()
+
+        # Root spec with a path defined inline (not using $ref)
+        inline_op = {
+            "get": {
+                "description": "Inline endpoint",
+                "responses": {"200": {"description": "OK"}},
+            }
+        }
+        root_data = {
+            "openapi": "3.1.0",
+            "paths": {"/inline": inline_op},
+        }
+        with open(contracts_dir / "ember-api.yaml", "w") as f:
+            yaml.dump(root_data, f)
+
+        yaml_paths = load_yaml_specs(contracts_dir)
+        assert "/inline" in yaml_paths
+        assert "get" in yaml_paths["/inline"]
+
+    def test_loaded_paths_include_all_endpoint_groups(self) -> None:
+        """load_yaml_specs returns paths from all endpoint groups."""
+        contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+        yaml_paths = load_yaml_specs(contracts_dir)
+
+        # Spot-check one path from each group
+        expected_paths = [
+            "/health",
+            "/auth/register",
+            "/characters",
+            "/characters/{character_id}/messages",
+            "/memories",
+            "/media/upload-url",
+            "/onboarding/complete",
+            "/profile",
+            "/profile/account",
+        ]
+        missing = [p for p in expected_paths if p not in yaml_paths]
+        assert not missing, f"Paths not loaded: {missing}"

--- a/backend/tests/test_openapi_validation.py
+++ b/backend/tests/test_openapi_validation.py
@@ -1,0 +1,174 @@
+"""Tests for the OpenAPI validation script (drift detection).
+
+Verifies that the validation script correctly identifies when the
+hand-written YAML specs match the FastAPI auto-generated schema.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add scripts to path
+backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(backend_dir))
+
+from scripts.validate_openapi import (  # noqa: E402
+    compare_schemas,
+    extract_field_names,
+    get_fastapi_schema,
+    get_query_params,
+    get_response_codes,
+    load_yaml_specs,
+    normalize_path,
+)
+
+# ---------------------------------------------------------------------------
+# Tests: validation against current codebase
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentCodebase:
+    """Run validation against the actual current codebase."""
+
+    def test_validation_passes(self) -> None:
+        """The validation script must find zero differences."""
+        contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+        yaml_paths = load_yaml_specs(contracts_dir)
+        fastapi_schema = get_fastapi_schema()
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+        assert errors == [], (
+            f"Validation found {len(errors)} difference(s):\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    def test_all_fastapi_paths_in_yaml(self) -> None:
+        """Every FastAPI path must be documented in the YAML specs."""
+        contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+        yaml_paths = load_yaml_specs(contracts_dir)
+        fastapi_schema = get_fastapi_schema()
+        fastapi_paths = fastapi_schema.get("paths", {})
+
+        missing: list[str] = []
+        for fpath in fastapi_paths:
+            if fpath.startswith("/api/v1"):
+                yaml_path = fpath[len("/api/v1"):]
+                # Skip test-only routes injected by the test suite
+                if "/_test" in yaml_path:
+                    continue
+                if yaml_path not in yaml_paths:
+                    missing.append(fpath)
+
+        assert not missing, (
+            "Undocumented endpoints:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    def test_all_yaml_paths_in_fastapi(self) -> None:
+        """Every YAML spec path must exist in the FastAPI schema."""
+        contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+        yaml_paths = load_yaml_specs(contracts_dir)
+        fastapi_schema = get_fastapi_schema()
+        fastapi_paths = fastapi_schema.get("paths", {})
+
+        missing: list[str] = []
+        for yaml_path in yaml_paths:
+            fastapi_path = f"/api/v1{yaml_path}"
+            if fastapi_path not in fastapi_paths:
+                missing.append(yaml_path)
+
+        assert not missing, (
+            "YAML paths not in FastAPI:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    def test_request_body_fields_match(self) -> None:
+        """Request body field names must match between YAML and FastAPI for all endpoints."""
+        contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+        yaml_paths = load_yaml_specs(contracts_dir)
+        fastapi_schema = get_fastapi_schema()
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+
+        body_errors = [e for e in errors if "request body" in e.lower()]
+        assert not body_errors, (
+            "Request body mismatches:\n"
+            + "\n".join(f"  - {e}" for e in body_errors)
+        )
+
+    def test_response_codes_match(self) -> None:
+        """Response status codes must match between YAML and FastAPI."""
+        contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+        yaml_paths = load_yaml_specs(contracts_dir)
+        fastapi_schema = get_fastapi_schema()
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+
+        code_errors = [e for e in errors if "response code" in e.lower()]
+        assert not code_errors, (
+            "Response code mismatches:\n"
+            + "\n".join(f"  - {e}" for e in code_errors)
+        )
+
+    def test_query_params_match(self) -> None:
+        """Query parameter names must match between YAML and FastAPI."""
+        contracts_dir = backend_dir.parent / "shared" / "api-contracts"
+        yaml_paths = load_yaml_specs(contracts_dir)
+        fastapi_schema = get_fastapi_schema()
+        errors = compare_schemas(yaml_paths, fastapi_schema)
+
+        param_errors = [e for e in errors if "query param" in e.lower()]
+        assert not param_errors, (
+            "Query parameter mismatches:\n"
+            + "\n".join(f"  - {e}" for e in param_errors)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelperFunctions:
+    """Unit tests for validation helper functions."""
+
+    def test_normalize_path(self) -> None:
+        """normalize_path adds /api/v1 prefix."""
+        assert normalize_path("/health") == "/api/v1/health"
+        assert normalize_path("/auth/login") == "/api/v1/auth/login"
+
+    def test_extract_field_names_simple(self) -> None:
+        """extract_field_names gets property names from a schema."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+        }
+        assert extract_field_names(schema) == {"name", "age"}
+
+    def test_extract_field_names_empty(self) -> None:
+        """extract_field_names returns empty set for empty schema."""
+        assert extract_field_names({}) == set()
+        assert extract_field_names(None) == set()  # type: ignore[arg-type]
+
+    def test_get_response_codes(self) -> None:
+        """get_response_codes extracts status codes."""
+        operation = {
+            "responses": {
+                "200": {"description": "OK"},
+                "404": {"description": "Not Found"},
+            }
+        }
+        assert get_response_codes(operation) == {"200", "404"}
+
+    def test_get_query_params(self) -> None:
+        """get_query_params extracts query parameter names and types."""
+        operation = {
+            "parameters": [
+                {"name": "cursor", "in": "query", "schema": {"type": "string"}},
+                {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+                {"name": "id", "in": "path", "schema": {"type": "string"}},
+            ]
+        }
+        result = get_query_params(operation)
+        assert result == {"cursor": "string", "limit": "integer"}

--- a/backend/tests/test_openapi_yaml.py
+++ b/backend/tests/test_openapi_yaml.py
@@ -1,0 +1,310 @@
+"""Tests for OpenAPI YAML spec syntax and completeness.
+
+Validates that all YAML files parse correctly, $ref pointers resolve,
+the merged spec is valid OpenAPI 3.1, and every endpoint has proper
+documentation and security configuration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+CONTRACTS_DIR = Path(__file__).resolve().parent.parent.parent / "shared" / "api-contracts"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml(path: Path) -> dict:
+    """Load a YAML file and return its contents."""
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _get_all_yaml_files() -> list[Path]:
+    """Get all .yaml files in the api-contracts directory."""
+    return sorted(CONTRACTS_DIR.rglob("*.yaml"))
+
+
+def _load_root_spec() -> dict:
+    """Load the root ember-api.yaml."""
+    return _load_yaml(CONTRACTS_DIR / "ember-api.yaml")
+
+
+def _resolve_path_ref(ref_str: str) -> tuple[Path, str]:
+    """Parse a $ref string into a file path and a JSON pointer."""
+    file_part, fragment = ref_str.split("#", 1)
+    file_path = CONTRACTS_DIR / file_part
+    pointer = fragment.lstrip("/")
+    pointer = pointer.replace("~1", "/").replace("~0", "~")
+    return file_path, pointer
+
+
+def _load_all_paths(root: dict) -> dict:
+    """Load and resolve all path references from the root spec."""
+    paths = {}
+    for path_key, ref_obj in root.get("paths", {}).items():
+        if "$ref" in ref_obj:
+            file_path, pointer = _resolve_path_ref(ref_obj["$ref"])
+            data = _load_yaml(file_path)
+            if pointer in data:
+                paths[path_key] = data[pointer]
+        else:
+            paths[path_key] = ref_obj
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Tests: YAML syntax
+# ---------------------------------------------------------------------------
+
+
+class TestYamlSyntax:
+    """All YAML files must parse without syntax errors."""
+
+    @pytest.mark.parametrize("yaml_file", _get_all_yaml_files(), ids=lambda p: p.name)
+    def test_yaml_parses(self, yaml_file: Path) -> None:
+        """Each YAML file must parse without errors."""
+        data = _load_yaml(yaml_file)
+        assert data is not None, f"{yaml_file.name} parsed as empty"
+
+
+# ---------------------------------------------------------------------------
+# Tests: $ref resolution
+# ---------------------------------------------------------------------------
+
+
+class TestRefResolution:
+    """All $ref pointers in the root spec must resolve."""
+
+    def test_all_path_refs_resolve(self) -> None:
+        """Every $ref in the root paths section resolves to an existing key."""
+        root = _load_root_spec()
+        for path_key, ref_obj in root.get("paths", {}).items():
+            if "$ref" in ref_obj:
+                file_path, pointer = _resolve_path_ref(ref_obj["$ref"])
+                assert file_path.exists(), (
+                    f"Referenced file does not exist: {file_path} "
+                    f"(from path {path_key})"
+                )
+                data = _load_yaml(file_path)
+                assert pointer in data, (
+                    f"Pointer '{pointer}' not found in {file_path.name} "
+                    f"(from path {path_key})"
+                )
+
+    def test_schema_refs_in_paths_resolve(self) -> None:
+        """All $ref pointers in path operation schemas resolve to existing files."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        broken_refs: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                refs = _collect_refs(operation)
+                for ref in refs:
+                    if ref.startswith("#/"):
+                        continue  # internal ref within same file — skip
+                    if "#" in ref:
+                        file_part, fragment = ref.split("#", 1)
+                        # Refs in path files are relative to paths/ dir
+                        ref_path = CONTRACTS_DIR / "paths" / file_part
+                        if not ref_path.exists():
+                            broken_refs.append(
+                                f"{method.upper()} {path_key}: {ref} -> "
+                                f"file not found: {ref_path}"
+                            )
+                            continue
+                        data = _load_yaml(ref_path)
+                        pointer = fragment.lstrip("/")
+                        if pointer not in data:
+                            broken_refs.append(
+                                f"{method.upper()} {path_key}: {ref} -> "
+                                f"pointer '{pointer}' not found in {ref_path.name}"
+                            )
+
+        assert not broken_refs, (
+            "Broken $ref pointers:\n" + "\n".join(f"  - {r}" for r in broken_refs)
+        )
+
+
+def _collect_refs(obj: object) -> list[str]:
+    """Recursively collect all $ref values from a nested structure."""
+    refs: list[str] = []
+    if isinstance(obj, dict):
+        if "$ref" in obj:
+            refs.append(obj["$ref"])
+        for value in obj.values():
+            refs.extend(_collect_refs(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            refs.extend(_collect_refs(item))
+    return refs
+
+
+# ---------------------------------------------------------------------------
+# Tests: content completeness
+# ---------------------------------------------------------------------------
+
+
+class TestContentCompleteness:
+    """Every endpoint must have required documentation fields."""
+
+    def test_every_path_has_responses(self) -> None:
+        """Every path operation must have at least one response defined."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        missing: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                responses = operation.get("responses", {})
+                if not responses:
+                    missing.append(f"{method.upper()} {path_key}")
+
+        assert not missing, (
+            "Endpoints without responses:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    def test_every_endpoint_has_description(self) -> None:
+        """Every path operation must have a description."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        missing: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                if not operation.get("description"):
+                    missing.append(f"{method.upper()} {path_key}")
+
+        assert not missing, (
+            "Endpoints without description:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    def test_endpoint_count(self) -> None:
+        """The spec must document all 19 endpoint+method combinations."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+
+        count = 0
+        for operations in paths.values():
+            for method, op in operations.items():
+                if isinstance(op, dict):
+                    count += 1
+
+        assert count == 19, f"Expected 19 endpoints, found {count}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: security
+# ---------------------------------------------------------------------------
+
+
+class TestSecurity:
+    """Auth endpoints must have correct security configuration."""
+
+    # These endpoints must have security: [] (no auth)
+    PUBLIC_ENDPOINTS = {
+        ("get", "/health"),
+        ("post", "/auth/register"),
+        ("post", "/auth/login"),
+        ("post", "/auth/refresh"),
+    }
+
+    def test_public_endpoints_have_empty_security(self) -> None:
+        """Health, register, login, refresh must have security: []."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        errors: list[str] = []
+
+        for method, path_key in self.PUBLIC_ENDPOINTS:
+            if path_key not in paths:
+                errors.append(f"Missing path: {path_key}")
+                continue
+            operation = paths[path_key].get(method, {})
+            security = operation.get("security")
+            if security != []:
+                errors.append(
+                    f"{method.upper()} {path_key}: expected security: [], "
+                    f"got {security}"
+                )
+
+        assert not errors, "\n".join(errors)
+
+    def test_protected_endpoints_inherit_global_security(self) -> None:
+        """All non-public endpoints must not have security: [] override."""
+        root = _load_root_spec()
+
+        # Verify global security is set
+        global_security = root.get("security")
+        assert global_security, "Root spec must have global security defined"
+
+        paths = _load_all_paths(root)
+        errors: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                if (method, path_key) in self.PUBLIC_ENDPOINTS:
+                    continue  # skip public endpoints
+                security = operation.get("security")
+                if security == []:
+                    errors.append(
+                        f"{method.upper()} {path_key}: has security: [] "
+                        f"but should inherit global auth"
+                    )
+
+        assert not errors, "\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# Tests: root spec structure
+# ---------------------------------------------------------------------------
+
+
+class TestRootSpec:
+    """The root ember-api.yaml must have correct structure."""
+
+    def test_openapi_version(self) -> None:
+        """Root spec must declare OpenAPI 3.1.0."""
+        root = _load_root_spec()
+        assert root.get("openapi") == "3.1.0"
+
+    def test_info_section(self) -> None:
+        """Root spec must have info with title and version."""
+        root = _load_root_spec()
+        info = root.get("info", {})
+        assert info.get("title") == "Ember API"
+        assert info.get("version") == "1.0.0"
+
+    def test_security_schemes(self) -> None:
+        """Root spec must define bearerAuth security scheme."""
+        root = _load_root_spec()
+        schemes = root.get("components", {}).get("securitySchemes", {})
+        assert "bearerAuth" in schemes
+        assert schemes["bearerAuth"]["type"] == "http"
+        assert schemes["bearerAuth"]["scheme"] == "bearer"
+
+    def test_tags_defined(self) -> None:
+        """Root spec must define all expected tags."""
+        root = _load_root_spec()
+        tag_names = {t["name"] for t in root.get("tags", [])}
+        expected = {
+            "health", "auth", "characters", "chat",
+            "memories", "media", "onboarding", "profile",
+        }
+        assert tag_names == expected, f"Missing tags: {expected - tag_names}"

--- a/backend/tests/test_openapi_yaml.py
+++ b/backend/tests/test_openapi_yaml.py
@@ -308,3 +308,658 @@ class TestRootSpec:
             "memories", "media", "onboarding", "profile",
         }
         assert tag_names == expected, f"Missing tags: {expected - tag_names}"
+
+    def test_servers_defined(self) -> None:
+        """Root spec must define production and local development servers."""
+        root = _load_root_spec()
+        servers = root.get("servers", [])
+        urls = {s["url"] for s in servers}
+        assert "https://api.ember.com/api/v1" in urls, "Production server URL missing"
+        assert "http://localhost:8000/api/v1" in urls, "Local dev server URL missing"
+
+    def test_global_security_references_bearer_auth(self) -> None:
+        """Global security must reference bearerAuth."""
+        root = _load_root_spec()
+        global_security = root.get("security", [])
+        assert global_security, "Global security is not defined"
+        scheme_names = set()
+        for entry in global_security:
+            scheme_names.update(entry.keys())
+        assert "bearerAuth" in scheme_names, "Global security must reference bearerAuth"
+
+    def test_bearer_auth_format_is_jwt(self) -> None:
+        """bearerAuth security scheme must specify bearerFormat: JWT."""
+        root = _load_root_spec()
+        bearer = root.get("components", {}).get("securitySchemes", {}).get("bearerAuth", {})
+        assert bearer.get("bearerFormat") == "JWT", (
+            f"bearerAuth.bearerFormat expected 'JWT', got {bearer.get('bearerFormat')}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: operation IDs
+# ---------------------------------------------------------------------------
+
+
+class TestOperationIds:
+    """All operationIds must be unique across the entire spec."""
+
+    def test_operation_ids_are_unique(self) -> None:
+        """No two operations may share the same operationId."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        seen: dict[str, str] = {}
+        duplicates: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                op_id = operation.get("operationId")
+                if not op_id:
+                    continue
+                label = f"{method.upper()} {path_key}"
+                if op_id in seen:
+                    duplicates.append(
+                        f"'{op_id}' used by both {seen[op_id]} and {label}"
+                    )
+                else:
+                    seen[op_id] = label
+
+        assert not duplicates, (
+            "Duplicate operationIds:\n"
+            + "\n".join(f"  - {d}" for d in duplicates)
+        )
+
+    def test_all_operations_have_operation_id(self) -> None:
+        """Every operation should have an operationId."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        missing: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                if not operation.get("operationId"):
+                    missing.append(f"{method.upper()} {path_key}")
+
+        assert not missing, (
+            "Endpoints without operationId:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: endpoint tags
+# ---------------------------------------------------------------------------
+
+
+EXPECTED_ENDPOINT_TAGS: dict[tuple[str, str], str] = {
+    ("get", "/health"): "health",
+    ("post", "/auth/register"): "auth",
+    ("post", "/auth/login"): "auth",
+    ("post", "/auth/refresh"): "auth",
+    ("get", "/characters"): "characters",
+    ("post", "/characters"): "characters",
+    ("put", "/characters/{character_id}"): "characters",
+    ("delete", "/characters/{character_id}"): "characters",
+    ("post", "/characters/{character_id}/messages"): "chat",
+    ("get", "/characters/{character_id}/messages"): "chat",
+    ("get", "/memories"): "memories",
+    ("get", "/characters/{character_id}/memories"): "memories",
+    ("delete", "/characters/{character_id}/memories"): "memories",
+    ("delete", "/characters/{character_id}/memories/{memory_id}"): "memories",
+    ("post", "/media/upload-url"): "media",
+    ("post", "/onboarding/complete"): "onboarding",
+    ("get", "/profile"): "profile",
+    ("put", "/profile"): "profile",
+    ("delete", "/profile/account"): "profile",
+}
+
+
+class TestEndpointTags:
+    """Each endpoint must be tagged with the correct group."""
+
+    def test_each_endpoint_has_correct_tag(self) -> None:
+        """Every endpoint must carry its expected tag."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        errors: list[str] = []
+
+        for (method, path_key), expected_tag in EXPECTED_ENDPOINT_TAGS.items():
+            operations = paths.get(path_key, {})
+            operation = operations.get(method)
+            if not isinstance(operation, dict):
+                errors.append(f"{method.upper()} {path_key}: operation not found")
+                continue
+            tags = operation.get("tags", [])
+            if expected_tag not in tags:
+                errors.append(
+                    f"{method.upper()} {path_key}: expected tag '{expected_tag}', "
+                    f"got {tags}"
+                )
+
+        assert not errors, "\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# Tests: 401 coverage for authenticated endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestUnauthorizedCoverage:
+    """All authenticated endpoints must document a 401 response."""
+
+    PUBLIC_ENDPOINTS = {
+        ("get", "/health"),
+        ("post", "/auth/register"),
+        ("post", "/auth/login"),
+        ("post", "/auth/refresh"),
+    }
+
+    def test_authenticated_endpoints_document_401(self) -> None:
+        """Every non-public endpoint must have a 401 response defined."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        missing: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                if (method, path_key) in self.PUBLIC_ENDPOINTS:
+                    continue
+                responses = operation.get("responses", {})
+                if "401" not in responses:
+                    missing.append(f"{method.upper()} {path_key}")
+
+        assert not missing, (
+            "Authenticated endpoints missing 401 response:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: 429 rate-limit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitCoverage:
+    """All authenticated endpoints must document a 429 response with Retry-After header."""
+
+    PUBLIC_ENDPOINTS = {
+        ("get", "/health"),
+        ("post", "/auth/register"),
+        ("post", "/auth/login"),
+        ("post", "/auth/refresh"),
+    }
+
+    def test_authenticated_endpoints_document_429(self) -> None:
+        """Every non-public endpoint must have a 429 response defined."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        missing: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                if (method, path_key) in self.PUBLIC_ENDPOINTS:
+                    continue
+                responses = operation.get("responses", {})
+                if "429" not in responses:
+                    missing.append(f"{method.upper()} {path_key}")
+
+        assert not missing, (
+            "Authenticated endpoints missing 429 response:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    def test_429_responses_include_retry_after_header(self) -> None:
+        """All 429 responses must define a Retry-After response header."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        missing: list[str] = []
+
+        for path_key, operations in paths.items():
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                if (method, path_key) in self.PUBLIC_ENDPOINTS:
+                    continue
+                responses = operation.get("responses", {})
+                resp_429 = responses.get("429", {})
+                if not resp_429:
+                    continue
+                headers = resp_429.get("headers", {})
+                if "Retry-After" not in headers:
+                    missing.append(f"{method.upper()} {path_key}")
+
+        assert not missing, (
+            "429 responses missing Retry-After header:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: path parameter format
+# ---------------------------------------------------------------------------
+
+
+class TestPathParameters:
+    """Path parameters representing UUIDs must declare format: uuid."""
+
+    # Endpoints that have character_id in path (should be uuid format)
+    UUID_PATH_PARAMS = {
+        "/characters/{character_id}",
+        "/characters/{character_id}/messages",
+        "/characters/{character_id}/memories",
+        "/characters/{character_id}/memories/{memory_id}",
+    }
+
+    def test_character_id_path_params_have_uuid_format(self) -> None:
+        """character_id path parameters must have format: uuid."""
+        root = _load_root_spec()
+        paths = _load_all_paths(root)
+        errors: list[str] = []
+
+        for path_key in self.UUID_PATH_PARAMS:
+            operations = paths.get(path_key, {})
+            for method, operation in operations.items():
+                if not isinstance(operation, dict):
+                    continue
+                for param in operation.get("parameters", []):
+                    if (
+                        param.get("in") == "path"
+                        and param.get("name") == "character_id"
+                    ):
+                        schema = param.get("schema", {})
+                        if schema.get("format") != "uuid":
+                            errors.append(
+                                f"{method.upper()} {path_key}: character_id path "
+                                f"param missing format: uuid (got {schema.get('format')})"
+                            )
+
+        assert not errors, "\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# Tests: schema field completeness
+# ---------------------------------------------------------------------------
+
+
+SCHEMAS_DIR = CONTRACTS_DIR / "schemas"
+
+
+def _load_schema(schema_file: str) -> dict:
+    """Load a schema YAML file from the schemas directory."""
+    return _load_yaml(SCHEMAS_DIR / schema_file)
+
+
+class TestSchemaFieldCompleteness:
+    """Verify that each schema contains all fields required by the spec."""
+
+    def test_register_request_fields(self) -> None:
+        """RegisterRequest must have email, password, and name fields."""
+        schema = _load_schema("auth.yaml")["RegisterRequest"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"email", "password", "name"} <= props
+        assert {"email", "password", "name"} == required
+
+    def test_login_request_fields(self) -> None:
+        """LoginRequest must have email and password fields."""
+        schema = _load_schema("auth.yaml")["LoginRequest"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"email", "password"} <= props
+        assert {"email", "password"} == required
+
+    def test_auth_response_fields(self) -> None:
+        """AuthResponse must have token, refresh_token, and user fields."""
+        schema = _load_schema("auth.yaml")["AuthResponse"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"token", "refresh_token", "user"} <= props
+        assert {"token", "refresh_token", "user"} == required
+
+    def test_user_response_fields(self) -> None:
+        """UserResponse must have all required user fields."""
+        schema = _load_schema("auth.yaml")["UserResponse"]
+        required = set(schema.get("required", []))
+        expected_required = {
+            "id", "email", "name", "onboarding_completed",
+            "subscription_tier", "preferred_language", "timezone", "created_at",
+        }
+        assert expected_required == required
+
+    def test_refresh_response_fields(self) -> None:
+        """RefreshResponse must have token field."""
+        schema = _load_schema("auth.yaml")["RefreshResponse"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert "token" in props
+        assert "token" in required
+
+    def test_send_message_request_fields(self) -> None:
+        """SendMessageRequest must have content (required) and media_url (optional)."""
+        schema = _load_schema("chat.yaml")["SendMessageRequest"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"content", "media_url"} <= props
+        assert required == {"content"}
+
+    def test_message_item_fields(self) -> None:
+        """MessageItem must have id, role, content, media_url, metadata, created_at."""
+        schema = _load_schema("chat.yaml")["MessageItem"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"id", "role", "content", "media_url", "metadata", "created_at"} <= props
+        assert {"id", "role", "content", "created_at"} == required
+
+    def test_message_list_response_fields(self) -> None:
+        """MessageListResponse must have items, next_cursor, has_more."""
+        schema = _load_schema("chat.yaml")["MessageListResponse"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"items", "next_cursor", "has_more"} <= props
+        assert {"items", "next_cursor", "has_more"} == required
+
+    def test_memory_item_fields(self) -> None:
+        """MemoryItem must have id and memory fields."""
+        schema = _load_schema("memory.yaml")["MemoryItem"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"id", "memory", "created_at"} <= props
+        assert {"id", "memory"} == required
+
+    def test_memory_list_response_fields(self) -> None:
+        """MemoryListResponse must have memories field (required)."""
+        schema = _load_schema("memory.yaml")["MemoryListResponse"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert "memories" in props
+        assert "memories" in required
+
+    def test_upload_url_request_fields(self) -> None:
+        """UploadUrlRequest must have filename, content_type, type fields."""
+        schema = _load_schema("media.yaml")["UploadUrlRequest"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"filename", "content_type", "type"} <= props
+        assert {"filename", "content_type", "type"} == required
+
+    def test_upload_url_response_fields(self) -> None:
+        """UploadUrlResponse must have upload_url and file_url."""
+        schema = _load_schema("media.yaml")["UploadUrlResponse"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"upload_url", "file_url"} == props
+        assert {"upload_url", "file_url"} == required
+
+    def test_onboarding_answer_fields(self) -> None:
+        """OnboardingAnswer must have question_key and answer fields."""
+        schema = _load_schema("onboarding.yaml")["OnboardingAnswer"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"question_key", "answer"} == props
+        assert {"question_key", "answer"} == required
+
+    def test_onboarding_request_fields(self) -> None:
+        """OnboardingRequest must have answers field (required, exactly 7 items)."""
+        schema = _load_schema("onboarding.yaml")["OnboardingRequest"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert "answers" in props
+        assert "answers" in required
+        answers_schema = schema["properties"]["answers"]
+        assert answers_schema.get("minItems") == 7
+        assert answers_schema.get("maxItems") == 7
+
+    def test_onboarding_response_fields(self) -> None:
+        """OnboardingResponse must have onboarding_completed and memories_seeded."""
+        schema = _load_schema("onboarding.yaml")["OnboardingResponse"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"onboarding_completed", "memories_seeded"} == props
+        assert {"onboarding_completed", "memories_seeded"} == required
+
+    def test_profile_response_fields(self) -> None:
+        """ProfileResponse must include all profile fields per spec."""
+        schema = _load_schema("profile.yaml")["ProfileResponse"]
+        props = set(schema.get("properties", {}).keys())
+        expected_props = {
+            "id", "email", "name", "timezone", "avatar_url",
+            "preferred_language", "onboarding_completed", "subscription_tier",
+            "subscription_expires_at", "created_at",
+        }
+        assert expected_props <= props
+
+    def test_profile_update_request_fields(self) -> None:
+        """ProfileUpdateRequest must have name, timezone, avatar_url, preferred_language."""
+        schema = _load_schema("profile.yaml")["ProfileUpdateRequest"]
+        props = set(schema.get("properties", {}).keys())
+        assert {"name", "timezone", "avatar_url", "preferred_language"} <= props
+
+    def test_account_delete_request_fields(self) -> None:
+        """AccountDeleteRequest must have confirmation field (required)."""
+        schema = _load_schema("profile.yaml")["AccountDeleteRequest"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert "confirmation" in props
+        assert "confirmation" in required
+
+    def test_character_list_item_fields(self) -> None:
+        """CharacterListItem must have all required fields per spec."""
+        schema = _load_schema("character.yaml")["CharacterListItem"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"id", "name", "template", "avatar_style", "is_default", "created_at"} <= required
+        assert {"description", "last_message_at"} <= props
+
+    def test_character_detail_fields(self) -> None:
+        """CharacterDetail must include system_prompt."""
+        schema = _load_schema("character.yaml")["CharacterDetail"]
+        required = set(schema.get("required", []))
+        assert "system_prompt" in required
+
+    def test_health_response_fields(self) -> None:
+        """HealthResponse must have status and version (required), plus optional deps."""
+        schema = _load_schema("health.yaml")["HealthResponse"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"status", "version"} == required
+        assert {"dependencies", "circuit_breaker"} <= props
+
+    def test_error_response_has_detail_field(self) -> None:
+        """ErrorResponse must have a required detail field."""
+        schema = _load_schema("common.yaml")["ErrorResponse"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert "detail" in props
+        assert "detail" in required
+
+    def test_error_response_detail_is_oneof_string_or_array(self) -> None:
+        """ErrorResponse.detail must be oneOf string | array (for 422 vs HTTPException)."""
+        schema = _load_schema("common.yaml")["ErrorResponse"]
+        detail_schema = schema["properties"]["detail"]
+        one_of = detail_schema.get("oneOf", [])
+        assert len(one_of) == 2, f"Expected 2 variants in oneOf, got {len(one_of)}"
+        types = {v.get("type") for v in one_of}
+        assert "string" in types
+        assert "array" in types
+
+    def test_rate_limit_error_has_detail_field(self) -> None:
+        """RateLimitError must have a required detail field."""
+        schema = _load_schema("common.yaml")["RateLimitError"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert "detail" in props
+        assert "detail" in required
+
+
+# ---------------------------------------------------------------------------
+# Tests: SSE event schema completeness
+# ---------------------------------------------------------------------------
+
+
+class TestSSEEventSchemas:
+    """SSE event schemas must define all fields per spec."""
+
+    def test_chunk_event_fields(self) -> None:
+        """ChunkEvent must have type (const: chunk) and content fields."""
+        schema = _load_schema("chat.yaml")["ChunkEvent"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"type", "content"} == props
+        assert {"type", "content"} == required
+        assert schema["properties"]["type"].get("const") == "chunk"
+
+    def test_action_event_fields(self) -> None:
+        """ActionEvent must have type (const: action), action, and payload fields."""
+        schema = _load_schema("chat.yaml")["ActionEvent"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"type", "action", "payload"} == props
+        assert {"type", "action", "payload"} == required
+        assert schema["properties"]["type"].get("const") == "action"
+
+    def test_done_event_fields(self) -> None:
+        """DoneEvent must have type (const: done) and message_id fields."""
+        schema = _load_schema("chat.yaml")["DoneEvent"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"type", "message_id"} == props
+        assert {"type", "message_id"} == required
+        assert schema["properties"]["type"].get("const") == "done"
+
+    def test_error_event_fields(self) -> None:
+        """ErrorEvent must have type (const: error) and message fields."""
+        schema = _load_schema("chat.yaml")["ErrorEvent"]
+        props = set(schema.get("properties", {}).keys())
+        required = set(schema.get("required", []))
+        assert {"type", "message"} == props
+        assert {"type", "message"} == required
+        assert schema["properties"]["type"].get("const") == "error"
+
+
+# ---------------------------------------------------------------------------
+# Tests: key schema constraints match spec
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaConstraints:
+    """Field constraints (minLength, maxLength, enum) must match spec."""
+
+    def test_register_request_password_min_length(self) -> None:
+        """RegisterRequest.password must have minLength: 8."""
+        schema = _load_schema("auth.yaml")["RegisterRequest"]
+        pw = schema["properties"]["password"]
+        assert pw.get("minLength") == 8
+
+    def test_register_request_name_max_length(self) -> None:
+        """RegisterRequest.name must have maxLength: 100."""
+        schema = _load_schema("auth.yaml")["RegisterRequest"]
+        name = schema["properties"]["name"]
+        assert name.get("maxLength") == 100
+
+    def test_register_request_email_format(self) -> None:
+        """RegisterRequest.email must have format: email."""
+        schema = _load_schema("auth.yaml")["RegisterRequest"]
+        email = schema["properties"]["email"]
+        assert email.get("format") == "email"
+
+    def test_send_message_content_max_length(self) -> None:
+        """SendMessageRequest.content must have maxLength: 4000."""
+        schema = _load_schema("chat.yaml")["SendMessageRequest"]
+        content = schema["properties"]["content"]
+        assert content.get("maxLength") == 4000
+        assert content.get("minLength") == 1
+
+    def test_onboarding_answer_enum_values(self) -> None:
+        """OnboardingAnswer.question_key must enumerate exactly the 7 expected keys."""
+        schema = _load_schema("onboarding.yaml")["OnboardingAnswer"]
+        enum_values = set(schema["properties"]["question_key"]["enum"])
+        expected = {
+            "preferred_name", "occupation", "daily_rhythm", "health_goal",
+            "stress_management", "sleep_schedule", "communication_style",
+        }
+        assert enum_values == expected
+
+    def test_onboarding_answer_max_length(self) -> None:
+        """OnboardingAnswer.answer must have maxLength: 500."""
+        schema = _load_schema("onboarding.yaml")["OnboardingAnswer"]
+        answer = schema["properties"]["answer"]
+        assert answer.get("maxLength") == 500
+        assert answer.get("minLength") == 1
+
+    def test_upload_url_request_type_enum(self) -> None:
+        """UploadUrlRequest.type must enumerate photo, audio, tts."""
+        schema = _load_schema("media.yaml")["UploadUrlRequest"]
+        enum_values = set(schema["properties"]["type"]["enum"])
+        assert enum_values == {"photo", "audio", "tts"}
+
+    def test_upload_url_request_filename_constraints(self) -> None:
+        """UploadUrlRequest.filename must have minLength: 1, maxLength: 255."""
+        schema = _load_schema("media.yaml")["UploadUrlRequest"]
+        filename = schema["properties"]["filename"]
+        assert filename.get("minLength") == 1
+        assert filename.get("maxLength") == 255
+
+    def test_message_item_role_enum(self) -> None:
+        """MessageItem.role must enumerate user and assistant."""
+        schema = _load_schema("chat.yaml")["MessageItem"]
+        role = schema["properties"]["role"]
+        assert set(role.get("enum", [])) == {"user", "assistant"}
+
+    def test_character_system_prompt_max_length(self) -> None:
+        """UpdateCharacterRequest.system_prompt must have maxLength: 10000."""
+        schema = _load_schema("character.yaml")["UpdateCharacterRequest"]
+        system_prompt_schema = schema["properties"]["system_prompt"]
+        # system_prompt is oneOf: [{type: string, ...}, {type: null}]
+        one_of = system_prompt_schema.get("oneOf", [])
+        string_variant = next((v for v in one_of if v.get("type") == "string"), None)
+        assert string_variant is not None, "system_prompt must have a string variant"
+        assert string_variant.get("maxLength") == 10000
+
+
+# ---------------------------------------------------------------------------
+# Tests: CI workflow
+# ---------------------------------------------------------------------------
+
+
+class TestCIWorkflow:
+    """The backend CI workflow must include the OpenAPI validation step."""
+
+    CI_WORKFLOW_PATH = (
+        Path(__file__).resolve().parent.parent.parent
+        / ".github" / "workflows" / "backend-ci.yml"
+    )
+
+    def test_ci_workflow_exists(self) -> None:
+        """The backend-ci.yml file must exist."""
+        assert self.CI_WORKFLOW_PATH.exists(), (
+            f"CI workflow not found at {self.CI_WORKFLOW_PATH}"
+        )
+
+    def test_ci_workflow_has_validate_openapi_step(self) -> None:
+        """The CI workflow must contain a step that runs validate_openapi.py."""
+        content = self.CI_WORKFLOW_PATH.read_text()
+        assert "validate_openapi.py" in content, (
+            "CI workflow does not include validate_openapi.py step"
+        )
+
+    def test_ci_workflow_validate_step_has_name(self) -> None:
+        """The validate step must have a descriptive name."""
+        workflow = _load_yaml(self.CI_WORKFLOW_PATH)
+        jobs = workflow.get("jobs", {})
+        found = False
+        for job in jobs.values():
+            for step in job.get("steps", []):
+                name = step.get("name", "")
+                run = step.get("run", "")
+                if "validate_openapi.py" in run and name:
+                    found = True
+                    break
+        assert found, "validate_openapi.py step must have a 'name' field"

--- a/docs/features/openapi-specs.md
+++ b/docs/features/openapi-specs.md
@@ -1,0 +1,357 @@
+# OpenAPI Specs
+
+> Machine-readable OpenAPI 3.1 contracts for all 19 Ember API endpoints, with a drift-detection validation script that fails CI whenever the hand-written YAML diverges from the FastAPI implementation.
+
+**Status**: Released
+**Added in**: Phase 1.5 (P1.5-06)
+**Platforms**: Backend
+**GitHub Issue**: #88
+
+---
+
+## Overview
+
+Before this feature, mobile developers (iOS and Android) had to read Python route handlers and Pydantic schemas to understand the API contract. This was error-prone and time-consuming. P1.5-06 introduces a complete set of OpenAPI 3.1 YAML specification files in `shared/api-contracts/` that document every implemented endpoint with request/response schemas, authentication requirements, error codes, path and query parameters, and SSE streaming event formats.
+
+The specs are hand-written rather than generated from FastAPI's auto-generated schema. FastAPI's built-in OpenAPI output lacks SSE event documentation, meaningful descriptions, and mobile-developer-friendly organization. Hand-written specs can document the SSE event sequence with full type definitions and can be organized by domain group so a mobile developer can open only the file they need.
+
+To prevent the hand-written specs from drifting as the backend evolves, a validation script at `backend/scripts/validate_openapi.py` is run in CI after every backend change. It imports the live FastAPI app, calls `app.openapi()`, and compares the result against the YAML files structurally — field names, status codes, query parameters, path parameters. If any endpoint in either direction is undocumented or mismatched, CI fails with a clear per-endpoint error message. This creates a continuous guarantee: the YAML files always describe what the API actually does.
+
+---
+
+## Architecture
+
+### File Organization
+
+```
+shared/api-contracts/
+  ember-api.yaml              Root spec: openapi version, servers, global security, $ref composition
+  paths/
+    auth.yaml                 POST /auth/register, /auth/login, /auth/refresh
+    characters.yaml           GET+POST /characters, PUT+DELETE /characters/{character_id}
+    chat.yaml                 POST /characters/{character_id}/messages (SSE), GET (cursor pagination)
+    health.yaml               GET /health
+    media.yaml                POST /media/upload-url
+    memories.yaml             GET /memories, GET+DELETE /characters/{id}/memories, DELETE /{id}/memories/{mid}
+    onboarding.yaml           POST /onboarding/complete
+    profile.yaml              GET+PUT /profile, DELETE /profile/account
+  schemas/
+    auth.yaml                 RegisterRequest, LoginRequest, RefreshRequest, AuthResponse, UserResponse, RefreshResponse
+    character.yaml            CreateCharacterRequest, UpdateCharacterRequest, CharacterListItem, CharacterListResponse, CharacterDetail
+    chat.yaml                 SendMessageRequest, MessageItem, MessageListResponse, ChunkEvent, ActionEvent, DoneEvent, ErrorEvent
+    common.yaml               ErrorResponse, RateLimitError
+    health.yaml               HealthResponse, DependencyStatus, CircuitBreakerReport, CircuitBreakerStatus
+    media.yaml                UploadUrlRequest, UploadUrlResponse
+    memory.yaml               MemoryItem, MemoryListResponse
+    onboarding.yaml           OnboardingAnswer, OnboardingRequest, OnboardingResponse
+    profile.yaml              ProfileResponse, ProfileUpdateRequest, AccountDeleteRequest
+```
+
+A monolithic YAML file would exceed 1000 lines. Split files let a mobile developer open only the path group they are working on. The root `ember-api.yaml` uses `$ref` to compose everything into a single logical spec. Path references use JSON pointer encoding (e.g., `/characters/{character_id}` becomes `~1characters~1{character_id}` in the `$ref` fragment).
+
+### Security Model
+
+Global security is set at the root level: `security: [{bearerAuth: []}]`. Every endpoint inherits Bearer JWT auth by default. The four public endpoints — `GET /health`, `POST /auth/register`, `POST /auth/login`, `POST /auth/refresh` — override this with `security: []`. This means adding a new authenticated endpoint requires no security configuration: the global default applies automatically.
+
+The `bearerAuth` security scheme is defined in `ember-api.yaml` components:
+
+```yaml
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: AWS Cognito ID token
+```
+
+### SSE Documentation Pattern
+
+OpenAPI 3.1 cannot natively model Server-Sent Events. The chat streaming endpoint (`POST /characters/{character_id}/messages`) is documented with `content-type: text/event-stream` and a prose description of the event sequence. The individual SSE event schemas (`ChunkEvent`, `ActionEvent`, `DoneEvent`, `ErrorEvent`) are defined separately in `schemas/chat.yaml` for reference and potential mobile client code generation, even though they are not directly wired to the response schema.
+
+This is an explicit design decision: the `text/event-stream` response body is modelled as `type: string` with a `description` block that explains each event type. The validation script skips response body comparison for the SSE endpoint (`POST /api/v1/characters/{character_id}/messages`) because FastAPI exposes `StreamingResponse` which produces no usable schema for comparison.
+
+### Drift Detection: How the Validation Script Works
+
+`backend/scripts/validate_openapi.py` performs a structural comparison in five dimensions:
+
+1. **Path coverage (YAML → FastAPI)**: Every path in the YAML specs must exist in the FastAPI routing table. Missing paths are reported as errors.
+2. **Path coverage (FastAPI → YAML)**: Every path FastAPI exposes (with the `/api/v1` prefix stripped) must appear in the YAML. Undocumented endpoints are reported as errors. Routes containing `/_test` are excluded — these are injected by the auth dependency test suite and are not real endpoints.
+3. **Request body fields**: For each path+method, the JSON schema field names in the YAML `requestBody` are compared against the FastAPI-generated schema (resolving `$ref` pointers). Missing or extra fields are reported.
+4. **Response status codes**: The set of documented status codes is compared. FastAPI auto-generates `422` for all POST/PUT endpoints; if the YAML omits `422`, the validator drops `422` from the FastAPI set before comparing, treating the omission as tolerated.
+5. **Query and path parameters**: Parameter names (and types for query params) are compared between YAML and FastAPI.
+
+The script exits with code 0 on success, code 1 on any difference. Output identifies every mismatch by `METHOD /path`.
+
+`jsonref` (mentioned as a potential dependency in the original spec) was not needed. The script resolves `$ref` pointers manually inside `resolve_ref()`, which is simpler and avoids an extra dependency.
+
+### CI Integration
+
+The validation step runs in `.github/workflows/backend-ci.yml` after the pytest suite passes:
+
+```yaml
+- name: Validate OpenAPI specs
+  run: python scripts/validate_openapi.py
+```
+
+The step requires the same environment variables as the test suite (database URL, Cognito IDs, AWS region) because it imports the FastAPI app to call `app.openapi()`.
+
+### FastAPI Tags
+
+`backend/app/main.py` was updated to add `openapi_tags` to the `FastAPI` constructor. This populates the tag descriptions visible in FastAPI's built-in `/docs` (Swagger UI) and `/redoc` routes:
+
+| Tag | Description |
+|-----|-------------|
+| `health` | Health check and dependency status |
+| `auth` | Authentication (register, login, refresh) |
+| `characters` | Character CRUD |
+| `chat` | Message sending (SSE) and history |
+| `memories` | Mem0 memory retrieval and deletion |
+| `media` | S3 presigned URL generation |
+| `onboarding` | Onboarding flow completion |
+| `profile` | User profile management |
+
+---
+
+## Endpoint Catalog
+
+All 19 endpoint+method combinations are documented. The table below is the authoritative inventory:
+
+| # | Method | Path | Auth | Tags |
+|---|--------|------|------|------|
+| 1 | GET | `/health` | No | health |
+| 2 | POST | `/auth/register` | No | auth |
+| 3 | POST | `/auth/login` | No | auth |
+| 4 | POST | `/auth/refresh` | No | auth |
+| 5 | GET | `/characters` | Yes | characters |
+| 6 | POST | `/characters` | Yes | characters |
+| 7 | PUT | `/characters/{character_id}` | Yes | characters |
+| 8 | DELETE | `/characters/{character_id}` | Yes | characters |
+| 9 | POST | `/characters/{character_id}/messages` | Yes | chat |
+| 10 | GET | `/characters/{character_id}/messages` | Yes | chat |
+| 11 | GET | `/memories` | Yes | memories |
+| 12 | GET | `/characters/{character_id}/memories` | Yes | memories |
+| 13 | DELETE | `/characters/{character_id}/memories/{memory_id}` | Yes | memories |
+| 14 | DELETE | `/characters/{character_id}/memories` | Yes | memories |
+| 15 | POST | `/media/upload-url` | Yes | media |
+| 16 | POST | `/onboarding/complete` | Yes | onboarding |
+| 17 | GET | `/profile` | Yes | profile |
+| 18 | PUT | `/profile` | Yes | profile |
+| 19 | DELETE | `/profile/account` | Yes | profile |
+
+All endpoints use the base URL `https://api.ember.com/api/v1` in production and `http://localhost:8000/api/v1` locally.
+
+---
+
+## API Reference
+
+This feature documents existing endpoints — it does not introduce new ones. The YAML specs are the machine-readable source of truth. The key behaviors documented are described below.
+
+### Common Response Headers (All Authenticated Endpoints)
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `X-RateLimit-Limit` | integer | Maximum requests per minute for this endpoint group |
+| `X-RateLimit-Remaining` | integer | Remaining requests in the current window |
+| `X-RateLimit-Reset` | integer | Unix timestamp when the limit window resets |
+
+### 429 Too Many Requests
+
+All authenticated endpoints include a `429` response code in their spec:
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 4
+Content-Type: application/json
+
+{"detail": "Rate limit exceeded"}
+```
+
+The `Retry-After` header is always present and is an integer (seconds until the next request is accepted).
+
+### Common Error Schema
+
+All error responses use `ErrorResponse`, defined in `schemas/common.yaml`. The `detail` field is either a string (application-raised `HTTPException`) or an array of Pydantic validation error objects (422 responses):
+
+```json
+{"detail": "Character not found"}
+```
+
+or
+
+```json
+{
+  "detail": [
+    {"loc": ["body", "content"], "msg": "field required", "type": "value_error.missing"}
+  ]
+}
+```
+
+### SSE Streaming Endpoint
+
+`POST /api/v1/characters/{character_id}/messages` returns `text/event-stream`. The event sequence is:
+
+```
+data: {"type": "chunk", "content": "Hello"}
+data: {"type": "chunk", "content": " there!"}
+data: {"type": "action", "action": "SET_ALARM", "payload": {"time": "07:00", "label": "Wake up"}}
+data: {"type": "done", "message_id": "uuid-string"}
+```
+
+On error mid-stream:
+```
+data: {"type": "error", "message": "description"}
+```
+
+The stream always ends with either a `done` or `error` event. The response also carries `Cache-Control: no-cache` and `X-Accel-Buffering: no` headers.
+
+SSE event type schemas (defined in `schemas/chat.yaml`):
+
+| Schema | Fields |
+|--------|--------|
+| `ChunkEvent` | `type: const "chunk"`, `content: string` |
+| `ActionEvent` | `type: const "action"`, `action: string`, `payload: object` |
+| `DoneEvent` | `type: const "done"`, `message_id: string (uuid)` |
+| `ErrorEvent` | `type: const "error"`, `message: string` |
+
+The `type` field uses `const` as a discriminator, which allows mobile clients to generate discriminated union types from these schemas.
+
+---
+
+## Validation Script Reference
+
+### Running Locally
+
+```bash
+cd backend && python scripts/validate_openapi.py
+```
+
+Output on success:
+```
+Loading YAML specs from .../shared/api-contracts
+Found 14 paths in YAML specs
+Loading FastAPI auto-generated schema
+Found N paths in FastAPI schema
+
+Comparing specs...
+
+OK: All YAML specs match the FastAPI schema.
+```
+
+Note: `14 paths` is correct — the YAML has 14 path keys. The 19 count refers to endpoint+method combinations, since some paths (e.g., `/characters`) define both GET and POST.
+
+Output on drift:
+```
+FAILED: 2 difference(s) found:
+
+  1. PUT /characters/{character_id}: request body fields in FastAPI but missing from YAML: ['new_field']
+  2. GET /profile: response fields in YAML but missing from FastAPI: ['old_field']
+```
+
+### Dev Dependencies
+
+The validation script requires packages that are already in `backend/requirements-dev.txt`:
+
+```
+pyyaml>=6.0.0
+openapi-spec-validator>=0.7.0
+```
+
+These are dev-only and must not be added to the production `requirements.txt`.
+
+---
+
+## Testing
+
+### Coverage Summary
+
+| File | Tests | Line Coverage |
+|------|-------|--------------|
+| `tests/test_openapi_yaml.py` | 69 | — |
+| `tests/test_openapi_validation.py` | 62 | 91% on `scripts/validate_openapi.py` |
+| **Total** | **131** | — |
+
+Coverage target (>= 80%) is met. The only uncovered lines are 354–380: the `if __name__ == "__main__"` CLI entry block, which wraps already-tested functions. Testing it would require subprocess invocation, which adds flakiness for no benefit.
+
+### Running Tests
+
+OpenAPI tests only:
+
+```bash
+cd backend && python -m pytest tests/test_openapi_yaml.py tests/test_openapi_validation.py -v
+```
+
+Full backend suite:
+
+```bash
+cd backend && python -m pytest tests/ -v
+```
+
+### Test Coverage by Class
+
+**`tests/test_openapi_yaml.py`** — YAML syntax, structure, and completeness (no FastAPI import required):
+
+| Class | Tests | What it verifies |
+|-------|-------|-----------------|
+| `TestRootSpec` | +3 | Server URLs (production + local), global `bearerAuth` reference, `bearerFormat: JWT` |
+| `TestOperationIds` | 2 | All `operationId`s are unique; every operation has one |
+| `TestEndpointTags` | 1 | All 19 endpoint+tag pairs are correctly assigned |
+| `TestUnauthorizedCoverage` | 1 | Every authenticated endpoint documents a `401` response |
+| `TestRateLimitCoverage` | 2 | Every authenticated endpoint documents `429`; every `429` has `Retry-After` header |
+| `TestPathParameters` | 1 | `character_id` path params declare `format: uuid` |
+| `TestSchemaFieldCompleteness` | 23 | Every request/response schema has all required fields per spec |
+| `TestSSEEventSchemas` | 4 | `ChunkEvent`, `ActionEvent`, `DoneEvent`, `ErrorEvent` field and `const` type values |
+| `TestSchemaConstraints` | 10 | `minLength`, `maxLength`, `enum` values, and `format` constraints match spec |
+| `TestCIWorkflow` | 3 | CI workflow file exists and includes a step that runs `validate_openapi.py` |
+
+**`tests/test_openapi_validation.py`** — Structural comparison logic (imports FastAPI app):
+
+| Class | Tests | What it verifies |
+|-------|-------|-----------------|
+| `TestHelperFunctions` | +13 | `get_query_params` edge cases, `extract_required_fields`, `get_path_params`, `resolve_ref`, `get_request_body_schema`, `anyOf`/`allOf`/`oneOf` field extraction |
+| `TestDriftDetection` | 16 | `compare_schemas` catches: missing paths, missing methods, request body presence mismatch, missing/extra fields, response code drift, `422` tolerance, query/path param mismatches, `/_test` route exclusion, SSE endpoint skip, FastAPI paths without `/api/v1` prefix |
+| `TestLoadYamlSpecs` | 5 | `sys.exit(1)` on missing root spec, correct path count (14 keys), warning on unresolvable pointer, inline (non-`$ref`) path handling, all endpoint groups present |
+
+### Testing Drift Detection Manually
+
+To verify the script catches drift, temporarily rename a field in any schema YAML and run the script:
+
+```bash
+# Edit shared/api-contracts/schemas/auth.yaml: rename "email" to "email_address" in RegisterRequest
+python backend/scripts/validate_openapi.py
+# Expected: FAILED with "POST /auth/register: request body fields in YAML but missing from FastAPI: ['email_address']"
+```
+
+---
+
+## Known Limitations
+
+- **SSE response body is not structurally validated**: The validation script skips response body comparison for `POST /characters/{character_id}/messages`. FastAPI's `StreamingResponse` produces no schema, so drift in SSE event field names cannot be caught automatically. Content accuracy relies on the manual review items in the test plan and the SSE event schema tests in `test_openapi_yaml.py`.
+- **Response schema depth is limited to top-level fields**: `compare_schemas` compares field names at the top level of request/response schemas. Nested object schemas are not recursively compared. A change to a field type or a nested object's shape will not be caught automatically.
+- **`jsonref` not used**: The architect spec listed `jsonref` as a required dependency. The implementation handles `$ref` resolution with a custom `resolve_ref()` function, which covers the FastAPI schema's internal `$ref`s. The YAML path files reference each other only through the root `ember-api.yaml` composition, which is resolved by `load_yaml_specs()`. The `jsonref` package was not added to `requirements-dev.txt`.
+- **No Swagger UI or Redoc page exposed**: FastAPI's built-in `/docs` and `/redoc` are available in development mode only. This is a separate concern not addressed by this feature.
+
+---
+
+## Extending This Feature
+
+**Adding a new endpoint**: When a new route is added to any file in `backend/app/routes/`, the validator will fail CI with `"FastAPI endpoint <path> not documented in YAML specs"`. To fix: add the path entry to the appropriate `paths/*.yaml` file and add any new request/response schemas to the corresponding `schemas/*.yaml` file. Reference the new path from `ember-api.yaml` using the `$ref` pattern already established there.
+
+**Adding a new schema to an existing endpoint**: Update the relevant `schemas/*.yaml` file. If the new field is required in the Pydantic model, the validator will report it as missing from the YAML on the next CI run. Add the field with its type and constraints to match the Pydantic validator rules.
+
+**Adding a new path file for a new domain**: Create `shared/api-contracts/paths/{domain}.yaml` and `shared/api-contracts/schemas/{domain}.yaml`, then add the `$ref` entries for each new path to `ember-api.yaml`. Follow the existing JSON pointer encoding pattern for URL characters: `/` encodes as `~1`, `{` and `}` are used literally in path templates.
+
+**Documenting a new SSE endpoint**: Add the endpoint path to the `SSE_ENDPOINTS` set at the top of `validate_openapi.py` to prevent false response-body drift errors. Document the event schemas in the relevant schema YAML and describe the event sequence in prose in the path YAML, following the pattern in `paths/chat.yaml`.
+
+**Upgrading the schema comparison depth**: To catch nested field drift, extend `extract_field_names()` to recurse into `properties` sub-objects and update `compare_schemas()` to call it recursively with a path prefix. Add corresponding tests to `TestDriftDetection`.
+
+---
+
+## Related Documentation
+
+- [Database Schema and API Endpoints](../04-veri-api.md) — human-readable API contract in Turkish (this feature is the machine-readable English complement)
+- [AI Memory System](../05-ai-bellek.md) — Mem0 integration referenced in memory endpoint schemas
+- [Security and Performance](../08-guvenlik-performans.md) — auth and rate limit behavior documented in the specs
+- [Chat Streaming](./chat-streaming.md) — P01-06, the SSE endpoint whose event format is documented here
+- [Rate Limiting Middleware](./rate-limiting-middleware.md) — P1.5-01, the source of the 429 / `Retry-After` responses documented in every authenticated endpoint spec
+- [Mem0 Circuit Breaker](./mem0-circuit-breaker.md) — P1.5-04, whose `CircuitBreakerStatus` schema is documented in `schemas/health.yaml`

--- a/docs/pipeline/openapi-specs-architect.handoff.md
+++ b/docs/pipeline/openapi-specs-architect.handoff.md
@@ -1,0 +1,29 @@
+# Architect Handoff: OpenAPI Specs
+
+**Date**: 2026-03-13
+**Agent**: architect
+**Status**: COMPLETE
+
+## What Was Designed
+OpenAPI 3.1 YAML specification files for all 19 implemented API endpoints, organized into split path and schema files under `shared/api-contracts/`. Includes a drift-detection validation script that compares hand-written YAML specs against FastAPI's auto-generated OpenAPI schema, with CI integration to prevent spec drift.
+
+## Key Decisions
+- **Split file organization**: One YAML file per route group (auth, characters, chat, etc.) and one per schema domain, composed via `$ref` from a root `ember-api.yaml`. Rationale: a monolithic file would exceed 1000 lines and be difficult for mobile developers to navigate.
+- **Validation, not generation**: The specs are hand-written for clarity and mobile-developer readability, then validated against FastAPI's auto-generated schema rather than generated from it. Rationale: auto-generated OpenAPI from FastAPI lacks SSE documentation, meaningful descriptions, and mobile-friendly organization.
+- **SSE documentation pattern**: Since OpenAPI 3.1 cannot natively model SSE, the streaming endpoint is documented with `text/event-stream` content type and a prose description of the event format. The SSE event schemas (ChunkEvent, ActionEvent, DoneEvent, ErrorEvent) are defined separately for reference and potential code generation.
+- **Dev-only validation dependencies**: pyyaml, openapi-spec-validator, and jsonref are added to dev dependencies only, not production requirements.
+
+## Spec Location
+`shared/feature-specs/openapi-specs.md`
+
+## Assumptions Made
+- All 19 endpoints listed in the spec are currently implemented and stable. The endpoint catalog was built by reading every route file in `backend/app/routes/`.
+- The existing `.gitkeep` in `shared/api-contracts/` can be removed once real files are added.
+- The `backend-ci.yml` workflow supports adding a new step without restructuring.
+
+## Dependencies
+- Requires: P01-10 (media-upload), P1.5-01 (rate-limiting-middleware) -- both already implemented
+- Blocks: backend-dev (implements the YAML files and validation script)
+
+## Next Steps
+backend-dev should read the spec and implement: (1) all YAML spec files, (2) the validation script, (3) the CI step, and (4) the `openapi_tags` update to `main.py`.

--- a/docs/pipeline/openapi-specs-backend-dev.handoff.md
+++ b/docs/pipeline/openapi-specs-backend-dev.handoff.md
@@ -1,0 +1,73 @@
+# Backend Dev Handoff: OpenAPI Specs
+
+**Date**: 2026-03-13
+**Agent**: backend-dev
+**Status**: COMPLETE
+
+## Implemented Files
+
+### Shared (YAML specs)
+- `shared/api-contracts/ember-api.yaml` -- root OpenAPI 3.1 spec with $ref composition
+- `shared/api-contracts/paths/auth.yaml` -- 3 auth endpoint paths
+- `shared/api-contracts/paths/characters.yaml` -- 4 character CRUD paths
+- `shared/api-contracts/paths/chat.yaml` -- 2 chat paths (SSE + history)
+- `shared/api-contracts/paths/health.yaml` -- 1 health check path
+- `shared/api-contracts/paths/media.yaml` -- 1 media upload path
+- `shared/api-contracts/paths/memories.yaml` -- 4 memory paths
+- `shared/api-contracts/paths/onboarding.yaml` -- 1 onboarding path
+- `shared/api-contracts/paths/profile.yaml` -- 3 profile paths
+- `shared/api-contracts/schemas/auth.yaml` -- RegisterRequest, LoginRequest, RefreshRequest, AuthResponse, UserResponse, RefreshResponse
+- `shared/api-contracts/schemas/character.yaml` -- CreateCharacterRequest, UpdateCharacterRequest, CharacterListItem, CharacterListResponse, CharacterDetail
+- `shared/api-contracts/schemas/chat.yaml` -- SendMessageRequest, MessageItem, MessageListResponse, ChunkEvent, ActionEvent, DoneEvent, ErrorEvent
+- `shared/api-contracts/schemas/common.yaml` -- ErrorResponse, RateLimitError
+- `shared/api-contracts/schemas/health.yaml` -- HealthResponse, DependencyStatus, CircuitBreakerReport, CircuitBreakerStatus
+- `shared/api-contracts/schemas/media.yaml` -- UploadUrlRequest, UploadUrlResponse
+- `shared/api-contracts/schemas/memory.yaml` -- MemoryItem, MemoryListResponse
+- `shared/api-contracts/schemas/onboarding.yaml` -- OnboardingAnswer, OnboardingRequest, OnboardingResponse
+- `shared/api-contracts/schemas/profile.yaml` -- ProfileResponse, ProfileUpdateRequest, AccountDeleteRequest
+
+### Backend
+- `backend/app/main.py` -- added openapi_tags to FastAPI constructor
+- `backend/scripts/validate_openapi.py` -- drift detection script (compares YAML vs FastAPI)
+- `backend/tests/test_openapi_yaml.py` -- 15 tests (YAML syntax, $ref resolution, completeness, security)
+- `backend/tests/test_openapi_validation.py` -- 11 tests (validation against current codebase, helper unit tests)
+- `backend/requirements-dev.txt` -- added pyyaml, openapi-spec-validator
+
+### CI
+- `.github/workflows/backend-ci.yml` -- added "Validate OpenAPI specs" step after tests
+
+## Endpoints Documented (19 total)
+- `GET /health` -- health check (public)
+- `POST /auth/register` -- user registration (public)
+- `POST /auth/login` -- user login (public)
+- `POST /auth/refresh` -- token refresh (public)
+- `GET /characters` -- list characters
+- `POST /characters` -- create character
+- `PUT /characters/{character_id}` -- update character
+- `DELETE /characters/{character_id}` -- delete character
+- `POST /characters/{character_id}/messages` -- send message (SSE streaming)
+- `GET /characters/{character_id}/messages` -- message history (cursor pagination)
+- `GET /memories` -- global memories
+- `GET /characters/{character_id}/memories` -- character memories
+- `DELETE /characters/{character_id}/memories/{memory_id}` -- delete single memory
+- `DELETE /characters/{character_id}/memories` -- delete all character memories
+- `POST /media/upload-url` -- presigned upload URL
+- `POST /onboarding/complete` -- complete onboarding
+- `GET /profile` -- get profile
+- `PUT /profile` -- update profile
+- `DELETE /profile/account` -- delete account
+
+## Test Results
+- pytest: 1792 passed, 13 skipped, 0 failed
+- ruff: clean
+- validation script: exit code 0 (all specs match)
+
+## Known Issues / Deviations from Spec
+- Test routes (e.g., `_test_protected`) injected by auth dependency tests are excluded from validation via `/_test` path filter. This is expected and intentional.
+- The spec mentions `jsonref` as a dependency but it was not needed -- YAML $ref resolution is handled manually in the validation script, which is simpler and avoids an extra dependency.
+
+## Notes for Backend Tester
+- The validation script at `backend/scripts/validate_openapi.py` can be run standalone: `python scripts/validate_openapi.py`
+- YAML spec tests in `tests/test_openapi_yaml.py` do not require the FastAPI app -- they only parse YAML files
+- Validation tests in `tests/test_openapi_validation.py` import the FastAPI app to compare schemas
+- To test drift detection: temporarily rename a field in a YAML schema and verify the validation script catches it

--- a/docs/pipeline/openapi-specs-backend-test.handoff.md
+++ b/docs/pipeline/openapi-specs-backend-test.handoff.md
@@ -1,0 +1,59 @@
+# Backend Test Handoff: OpenAPI Specs
+
+**Date**: 2026-03-13
+**Agent**: backend-tester
+**Status**: COMPLETE
+
+## Test Files Written
+
+- `backend/tests/test_openapi_yaml.py` — 69 tests (15 original + 54 added)
+- `backend/tests/test_openapi_validation.py` — 62 tests (11 original + 51 added)
+
+## Coverage Results
+
+- Lines: 91% on `scripts/validate_openapi.py` (target: >= 80%)
+- Only uncovered: lines 354-376, 380 — the `main()` CLI entry point (`if __name__ == "__main__"` block), which is intentional CLI boilerplate
+
+## Test Run Results
+
+- Passed: 131
+- Failed: 0
+- Skipped: 0
+
+## New Test Classes Added
+
+### test_openapi_yaml.py
+
+| Class | Tests | What it verifies |
+|-------|-------|-----------------|
+| `TestRootSpec` (extended) | +3 | Server URLs (production + local), global bearerAuth reference, bearerFormat: JWT |
+| `TestOperationIds` | 2 | All operationIds are unique; all operations have an operationId |
+| `TestEndpointTags` | 1 | Every endpoint carries its correct tag (19 endpoint+tag pairs) |
+| `TestUnauthorizedCoverage` | 1 | All authenticated endpoints document a 401 response |
+| `TestRateLimitCoverage` | 2 | All authenticated endpoints document 429; all 429 responses include Retry-After header |
+| `TestPathParameters` | 1 | character_id path params declare format: uuid |
+| `TestSchemaFieldCompleteness` | 23 | Every request/response schema has all required fields per spec |
+| `TestSSEEventSchemas` | 4 | ChunkEvent, ActionEvent, DoneEvent, ErrorEvent fields and type constants |
+| `TestSchemaConstraints` | 10 | minLength, maxLength, enum values, format constraints match spec |
+| `TestCIWorkflow` | 3 | CI workflow file exists, includes validate_openapi.py step with a name |
+
+### test_openapi_validation.py
+
+| Class | Tests | What it verifies |
+|-------|-------|-----------------|
+| `TestHelperFunctions` (extended) | +13 | get_query_params edge cases, extract_required_fields, get_path_params, resolve_ref, get_request_body_schema, anyOf/allOf/oneOf field extraction |
+| `TestDriftDetection` | 16 | compare_schemas detects: missing paths, missing methods, request body presence mismatch, missing/extra fields, response code drift, 422 tolerance, query/path param mismatches, /_test route exclusion, SSE endpoint skip, FastAPI paths without /api/v1 prefix |
+| `TestLoadYamlSpecs` | 5 | sys.exit(1) on missing root spec, loads correct path count (14 keys / 19 endpoints), warning on unresolvable pointer, inline (non-$ref) path handling, all endpoint groups present |
+
+## Issues Found During Testing
+
+None. The implementation matches the spec. All 26 original tests continued to pass after adding new coverage.
+
+One observation documented: `load_yaml_specs` returns 14 path keys (some paths like `/characters` contain both GET and POST). The 19 count from the spec refers to endpoint+method combinations. Tests clarify this distinction.
+
+## Notes for Reviewer
+
+- The `main()` function (CLI entry point) is intentionally not tested — it is an `if __name__ == "__main__"` block that wraps the already-tested `compare_schemas` + `load_yaml_specs` + `get_fastapi_schema` calls. Testing it would require subprocess invocation which adds flakiness.
+- The `TestDriftDetection` class uses a `_make_fastapi_schema()` helper to build minimal synthetic FastAPI schemas, avoiding dependency on the real FastAPI app in unit tests.
+- SSE event schema tests verify the `const` field value on the `type` property (e.g., `const: chunk`), which is the discriminator pattern used by the spec.
+- `TestEndpointTags` uses a module-level dict of all 19 `(method, path) -> tag` mappings for exhaustive verification.

--- a/docs/pipeline/openapi-specs-doc.handoff.md
+++ b/docs/pipeline/openapi-specs-doc.handoff.md
@@ -1,0 +1,19 @@
+# Doc Writer Handoff: OpenAPI Specs
+
+**Date**: 2026-03-13
+**Agent**: doc-writer
+**Status**: COMPLETE
+
+## Documents Written
+- `docs/features/openapi-specs.md` — main feature documentation
+- `CHANGELOG.md` — added `[P1.5-06]` entry under `[Unreleased]`
+
+## Summary
+
+Documented the OpenAPI 3.1 specification feature (P1.5-06), which introduces hand-written YAML specs for all 19 Ember API endpoints organized in a split-file structure under `shared/api-contracts/`. Documentation covers the file organization, security model, SSE documentation pattern, drift-detection validation script mechanics, the full endpoint catalog, test coverage (131 tests, 91% line coverage on the validation script), known limitations, and an extension guide for future developers adding new endpoints or schema domains.
+
+## Notes
+
+- The spec listed `jsonref` as a required dependency. The implementation resolved `$ref` manually without it. This deviation is noted under Known Limitations.
+- The backend-dev handoff clarified that `load_yaml_specs` returns 14 path keys (not 19), because some paths define multiple methods. This distinction is called out in both the Testing section and the Validation Script Reference section to prevent confusion.
+- The SSE endpoint skip in the validation script is documented with the exact set constant (`SSE_ENDPOINTS`) so future developers know to add new SSE endpoints to that set.

--- a/docs/pipeline/openapi-specs-review.handoff.md
+++ b/docs/pipeline/openapi-specs-review.handoff.md
@@ -1,0 +1,87 @@
+# Reviewer Handoff: OpenAPI Specs
+
+**Date**: 2026-03-13
+**Agent**: reviewer
+**Status**: APPROVED
+
+## Review Summary
+
+| Category | Passed | Warnings | Issues |
+|----------|--------|----------|--------|
+| Architecture | 6 | 0 | 0 |
+| Backend | 5 | 0 | 0 |
+| Testing | 5 | 0 | 0 |
+| Security | 4 | 0 | 0 |
+| **Total** | **20** | **0** | **0** |
+
+## Checklist Results
+
+### Architecture Compliance
+
+- [x] **All 19 endpoints documented**: Verified all 19 method+endpoint combinations from the spec's Appendix A are present in the YAML path files (14 path keys covering 19 operations).
+- [x] **Single conversation per character**: No `/conversations` path segment appears in any API endpoint. All messaging routes through `POST /characters/{character_id}/messages`.
+- [x] **Cursor-based pagination**: GET /characters/{character_id}/messages documents cursor and limit query params with correct types. No OFFSET or page parameters anywhere.
+- [x] **Spec adherence**: Root `ember-api.yaml` uses `$ref` composition to include all path files. All paths, schemas, and security settings match the architect spec exactly.
+- [x] **SSE streaming documented**: POST /characters/{character_id}/messages documents `text/event-stream` response with Cache-Control and X-Accel-Buffering headers. All four SSE event types (ChunkEvent, ActionEvent, DoneEvent, ErrorEvent) defined in schemas/chat.yaml with `const` discriminators.
+- [x] **Auth documented on all protected endpoints**: All 15 authenticated endpoints inherit global `bearerAuth` security and document 401 responses. All 4 public endpoints (health, register, login, refresh) override with `security: []`.
+
+### Backend Code Quality
+
+- [x] **Validation script works**: `backend/scripts/validate_openapi.py` correctly loads YAML specs, resolves `$ref` pointers, compares against FastAPI auto-generated schema, and reports drift. SSE endpoint response body comparison is properly skipped. Test routes (`/_test`) are excluded.
+- [x] **CI integration correct**: `backend-ci.yml` includes "Validate OpenAPI specs" step after tests, with proper environment variables. Step runs `python scripts/validate_openapi.py`.
+- [x] **main.py updated**: `openapi_tags` added to FastAPI constructor with all 8 tag groups matching the root spec.
+- [x] **No hardcoded secrets**: Grep for `api_key=`, `secret=`, `password=` patterns found only test-value assignments in test files, nothing in production or script code.
+- [x] **Dev-only dependencies**: `pyyaml` and `openapi-spec-validator` added to `requirements-dev.txt` only, not production requirements.
+
+### Test Quality
+
+- [x] **Coverage >= 80%**: Backend tester reports 91% line coverage on `validate_openapi.py`. Only uncovered lines are the CLI `main()` entry point boilerplate.
+- [x] **131 tests passing**: 69 in `test_openapi_yaml.py` + 62 in `test_openapi_validation.py`, 0 failures.
+- [x] **YAML syntax tests**: All YAML files parse without errors, all `$ref` pointers resolve, endpoint count verified at 19.
+- [x] **Drift detection tests**: `TestDriftDetection` class covers 16 scenarios including missing paths, missing methods, field mismatches, response code drift, 422 tolerance, query/path param mismatches, test route exclusion, SSE endpoint skipping.
+- [x] **Schema completeness tests**: 23 tests verify every request/response schema has all required fields per spec, including field constraints (minLength, maxLength, enum values, format).
+
+### Security
+
+- [x] **No credentials in code**: No hardcoded API keys, tokens, passwords, or connection strings in any new files.
+- [x] **No user_id in request body**: No YAML schema accepts user_id as a request field. All endpoints use Bearer JWT auth.
+- [x] **Rate limit documented**: All 15 authenticated endpoints document 429 responses with Retry-After header and RateLimitError schema.
+- [x] **No internal IDs exposed**: Error schemas use the standard `ErrorResponse` format with `detail` field only.
+
+## Files Reviewed
+
+**Shared (YAML specs)**:
+- `shared/api-contracts/ember-api.yaml` -- PASS (root spec, 14 path refs, security, tags)
+- `shared/api-contracts/paths/auth.yaml` -- PASS (3 endpoints, all public)
+- `shared/api-contracts/paths/characters.yaml` -- PASS (4 endpoints, UUID path params)
+- `shared/api-contracts/paths/chat.yaml` -- PASS (SSE streaming + cursor pagination)
+- `shared/api-contracts/paths/health.yaml` -- PASS (public, check_dependencies param)
+- `shared/api-contracts/paths/media.yaml` -- PASS (upload-url)
+- `shared/api-contracts/paths/memories.yaml` -- PASS (4 endpoints, ownership checks)
+- `shared/api-contracts/paths/onboarding.yaml` -- PASS (503 for upstream failures)
+- `shared/api-contracts/paths/profile.yaml` -- PASS (3 endpoints, account deletion)
+- `shared/api-contracts/schemas/auth.yaml` -- PASS (all fields match spec)
+- `shared/api-contracts/schemas/character.yaml` -- PASS (all fields match spec)
+- `shared/api-contracts/schemas/chat.yaml` -- PASS (SSE events with const discriminators)
+- `shared/api-contracts/schemas/common.yaml` -- PASS (ErrorResponse oneOf, RateLimitError)
+- `shared/api-contracts/schemas/health.yaml` -- PASS (dependency + circuit breaker status)
+- `shared/api-contracts/schemas/media.yaml` -- PASS (upload request/response)
+- `shared/api-contracts/schemas/memory.yaml` -- PASS (MemoryItem, MemoryListResponse)
+- `shared/api-contracts/schemas/onboarding.yaml` -- PASS (7-item constraint, enums)
+- `shared/api-contracts/schemas/profile.yaml` -- PASS (all fields match spec)
+
+**Backend**:
+- `backend/app/main.py` -- PASS (openapi_tags added)
+- `backend/scripts/validate_openapi.py` -- PASS (drift detection script)
+- `backend/tests/test_openapi_yaml.py` -- PASS (69 tests)
+- `backend/tests/test_openapi_validation.py` -- PASS (62 tests)
+- `backend/requirements-dev.txt` -- PASS (dev-only deps)
+
+**CI**:
+- `.github/workflows/backend-ci.yml` -- PASS (validate step after tests)
+
+## Issues Resolved During Review
+- None (first-pass clean)
+
+## Warnings (Not Blocking)
+- None

--- a/shared/api-contracts/ember-api.yaml
+++ b/shared/api-contracts/ember-api.yaml
@@ -1,0 +1,81 @@
+openapi: "3.1.0"
+info:
+  title: Ember API
+  version: "1.0.0"
+  description: >
+    REST API for the Ember AI companion app. All endpoints are under /api/v1/.
+    Authentication uses AWS Cognito JWTs (Bearer token).
+  contact:
+    name: Ember Engineering
+
+servers:
+  - url: https://api.ember.com/api/v1
+    description: Production
+  - url: http://localhost:8000/api/v1
+    description: Local development
+
+tags:
+  - name: health
+    description: Health check and dependency status
+  - name: auth
+    description: Authentication (register, login, refresh)
+  - name: characters
+    description: Character CRUD
+  - name: chat
+    description: Message sending (SSE) and history
+  - name: memories
+    description: Mem0 memory retrieval and deletion
+  - name: media
+    description: S3 presigned URL generation
+  - name: onboarding
+    description: Onboarding flow completion
+  - name: profile
+    description: User profile management
+
+security:
+  - bearerAuth: []
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: AWS Cognito ID token
+
+paths:
+  /health:
+    $ref: "paths/health.yaml#/~1health"
+
+  /auth/register:
+    $ref: "paths/auth.yaml#/~1auth~1register"
+  /auth/login:
+    $ref: "paths/auth.yaml#/~1auth~1login"
+  /auth/refresh:
+    $ref: "paths/auth.yaml#/~1auth~1refresh"
+
+  /characters:
+    $ref: "paths/characters.yaml#/~1characters"
+  /characters/{character_id}:
+    $ref: "paths/characters.yaml#/~1characters~1{character_id}"
+
+  /characters/{character_id}/messages:
+    $ref: "paths/chat.yaml#/~1characters~1{character_id}~1messages"
+
+  /memories:
+    $ref: "paths/memories.yaml#/~1memories"
+  /characters/{character_id}/memories:
+    $ref: "paths/memories.yaml#/~1characters~1{character_id}~1memories"
+  /characters/{character_id}/memories/{memory_id}:
+    $ref: "paths/memories.yaml#/~1characters~1{character_id}~1memories~1{memory_id}"
+
+  /media/upload-url:
+    $ref: "paths/media.yaml#/~1media~1upload-url"
+
+  /onboarding/complete:
+    $ref: "paths/onboarding.yaml#/~1onboarding~1complete"
+
+  /profile:
+    $ref: "paths/profile.yaml#/~1profile"
+  /profile/account:
+    $ref: "paths/profile.yaml#/~1profile~1account"

--- a/shared/api-contracts/paths/auth.yaml
+++ b/shared/api-contracts/paths/auth.yaml
@@ -1,0 +1,104 @@
+/auth/register:
+  post:
+    operationId: register
+    summary: Register a new user
+    description: >
+      Create a new user account. Registers the user in AWS Cognito,
+      creates a profile row, initialises a default companion character,
+      and returns tokens plus user data.
+    tags:
+      - auth
+    security: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/auth.yaml#/RegisterRequest"
+    responses:
+      "201":
+        description: Account created successfully
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/auth.yaml#/AuthResponse"
+      "409":
+        description: Email already exists
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+
+/auth/login:
+  post:
+    operationId: login
+    summary: Log in
+    description: Authenticate an existing user and return tokens plus profile.
+    tags:
+      - auth
+    security: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/auth.yaml#/LoginRequest"
+    responses:
+      "200":
+        description: Login successful
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/auth.yaml#/AuthResponse"
+      "401":
+        description: Invalid credentials
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+
+/auth/refresh:
+  post:
+    operationId: refresh
+    summary: Refresh access token
+    description: Exchange a refresh token for a new access (ID) token.
+    tags:
+      - auth
+    security: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/auth.yaml#/RefreshRequest"
+    responses:
+      "200":
+        description: Token refreshed
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/auth.yaml#/RefreshResponse"
+      "401":
+        description: Invalid or expired refresh token
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"

--- a/shared/api-contracts/paths/characters.yaml
+++ b/shared/api-contracts/paths/characters.yaml
@@ -1,0 +1,194 @@
+/characters:
+  get:
+    operationId: list_characters
+    summary: List characters
+    description: >
+      List all active characters for the authenticated user.
+      Characters are ordered by last_message_at DESC (NULLS LAST),
+      then by created_at DESC.
+    tags:
+      - characters
+    responses:
+      "200":
+        description: List of characters
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/character.yaml#/CharacterListResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+  post:
+    operationId: create_character
+    summary: Create a character
+    description: >
+      Create a new AI character with an auto-generated system prompt.
+      Auto-creates the corresponding conversation row. Uses Claude Haiku
+      for system prompt generation.
+    tags:
+      - characters
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/character.yaml#/CreateCharacterRequest"
+    responses:
+      "201":
+        description: Character created
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/character.yaml#/CharacterDetail"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+/characters/{character_id}:
+  put:
+    operationId: update_character
+    summary: Update a character
+    description: >
+      Update a character's mutable fields (name, system_prompt, avatar_style).
+      Enforces ownership: the character must belong to the authenticated user.
+    tags:
+      - characters
+    parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/character.yaml#/UpdateCharacterRequest"
+    responses:
+      "200":
+        description: Character updated
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/character.yaml#/CharacterDetail"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "403":
+        description: Not owner
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "404":
+        description: Character not found
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+  delete:
+    operationId: delete_character
+    summary: Delete a character
+    description: >
+      Soft-delete a character by setting is_active=false.
+      The default character cannot be deleted and returns 403.
+      Enforces ownership.
+    tags:
+      - characters
+    parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      "204":
+        description: Character deleted (no content)
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "403":
+        description: Cannot delete default character, or not owner
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "404":
+        description: Character not found
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"

--- a/shared/api-contracts/paths/chat.yaml
+++ b/shared/api-contracts/paths/chat.yaml
@@ -1,0 +1,163 @@
+/characters/{character_id}/messages:
+  post:
+    operationId: send_message
+    summary: Send a message (SSE streaming)
+    description: >
+      Send a message to a character and stream the AI response via
+      Server-Sent Events. The response content type is text/event-stream.
+      Validation (character lookup, ownership check) runs before streaming
+      begins, so HTTP errors (403, 404) are returned as standard JSON.
+    tags:
+      - chat
+    parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/chat.yaml#/SendMessageRequest"
+    responses:
+      "200":
+        description: AI response streamed as Server-Sent Events
+        content:
+          text/event-stream:
+            schema:
+              type: string
+              description: |
+                Stream of SSE events. Each event has `data:` prefix followed by JSON.
+
+                Event types:
+                - chunk: { "type": "chunk", "content": "text fragment" }
+                - action: { "type": "action", "action": "SET_ALARM", "payload": { ... } }
+                - done: { "type": "done", "message_id": "uuid" }
+                - error: { "type": "error", "message": "description" }
+
+                The stream always ends with either a "done" or "error" event.
+
+                See schemas/chat.yaml for individual event type definitions:
+                ChunkEvent, ActionEvent, DoneEvent, ErrorEvent.
+        headers:
+          Cache-Control:
+            schema:
+              type: string
+              example: "no-cache"
+          X-Accel-Buffering:
+            schema:
+              type: string
+              example: "no"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "403":
+        description: Not owner
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "404":
+        description: Character not found
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+  get:
+    operationId: get_messages
+    summary: Get message history
+    description: >
+      Retrieve paginated message history for a character's conversation.
+      Uses cursor-based pagination with composite (created_at, id) cursors
+      encoded as base64 URL-safe JSON. Messages are returned newest-first.
+      Pass the next_cursor from a previous response as the cursor query
+      parameter to load the next page.
+    tags:
+      - chat
+    parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: cursor
+        in: query
+        required: false
+        description: Base64-encoded composite cursor from previous response
+        schema:
+          type: string
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 20
+          minimum: 1
+          maximum: 100
+    responses:
+      "200":
+        description: Paginated message list
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/chat.yaml#/MessageListResponse"
+      "400":
+        description: Invalid cursor format
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "403":
+        description: Not owner
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "404":
+        description: Character not found
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"

--- a/shared/api-contracts/paths/health.yaml
+++ b/shared/api-contracts/paths/health.yaml
@@ -1,0 +1,26 @@
+/health:
+  get:
+    operationId: health_check
+    summary: Health check
+    description: >
+      Return application health status, version, and optional dependency status.
+      Without check_dependencies: fast response for ECS probes (no external calls).
+      With check_dependencies=true: probes database, Mem0, and Claude (for dashboards).
+      Also includes circuit breaker status when check_dependencies=true.
+    tags:
+      - health
+    security: []
+    parameters:
+      - name: check_dependencies
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+    responses:
+      "200":
+        description: Health status
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/health.yaml#/HealthResponse"

--- a/shared/api-contracts/paths/media.yaml
+++ b/shared/api-contracts/paths/media.yaml
@@ -1,0 +1,54 @@
+/media/upload-url:
+  post:
+    operationId: create_upload_url
+    summary: Generate a presigned upload URL
+    description: >
+      Generate a presigned S3 PUT URL for the client to upload a file.
+      The client sends a filename, content type, and media type (photo/audio/tts).
+      The backend validates the content type, generates an S3 key, creates a
+      5-minute presigned PUT URL, and returns both the upload URL and the
+      permanent file URL.
+    tags:
+      - media
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/media.yaml#/UploadUrlRequest"
+    responses:
+      "200":
+        description: Presigned URL generated
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/media.yaml#/UploadUrlResponse"
+      "400":
+        description: Unsupported content type
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"

--- a/shared/api-contracts/paths/memories.yaml
+++ b/shared/api-contracts/paths/memories.yaml
@@ -1,0 +1,187 @@
+/memories:
+  get:
+    operationId: get_global_memories
+    summary: Get global memories
+    description: >
+      Retrieve global (non-character-scoped) memories from Mem0.
+      Returns memories stored without an agent_id, visible to all characters.
+    tags:
+      - memories
+    responses:
+      "200":
+        description: List of global memories
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/memory.yaml#/MemoryListResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+/characters/{character_id}/memories:
+  get:
+    operationId: get_character_memories
+    summary: Get character memories
+    description: Retrieve all memories stored in Mem0 for a specific character.
+    tags:
+      - memories
+    parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      "200":
+        description: List of character memories
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/memory.yaml#/MemoryListResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "403":
+        description: Not owner
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "404":
+        description: Character not found
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+  delete:
+    operationId: delete_all_character_memories
+    summary: Delete all character memories
+    description: >
+      Delete ALL memories for a specific character from Mem0.
+      Only deletes memories scoped to this character's mem0_agent_id.
+      Does not affect global memories.
+    tags:
+      - memories
+    parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      "204":
+        description: All memories deleted (no content)
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "403":
+        description: Not owner
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "404":
+        description: Character not found
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+/characters/{character_id}/memories/{memory_id}:
+  delete:
+    operationId: delete_character_memory
+    summary: Delete a single character memory
+    description: >
+      Delete a single memory from Mem0. Idempotent: returns 204
+      even if the memory_id does not exist in Mem0.
+    tags:
+      - memories
+    parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: memory_id
+        in: path
+        required: true
+        schema:
+          type: string
+    responses:
+      "204":
+        description: Memory deleted (no content)
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "403":
+        description: Not owner
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "404":
+        description: Character not found
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"

--- a/shared/api-contracts/paths/onboarding.yaml
+++ b/shared/api-contracts/paths/onboarding.yaml
@@ -1,0 +1,58 @@
+/onboarding/complete:
+  post:
+    operationId: complete_onboarding
+    summary: Complete onboarding
+    description: >
+      Complete the user onboarding flow. Accepts 7 Q&A pairs, converts
+      them to structured memory statements via Claude Haiku, seeds them
+      into Mem0 as global memories, and sets onboarding_completed to true.
+    tags:
+      - onboarding
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/onboarding.yaml#/OnboardingRequest"
+    responses:
+      "200":
+        description: Onboarding completed
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/onboarding.yaml#/OnboardingResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "409":
+        description: Onboarding already completed
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+      "503":
+        description: Claude or Mem0 unavailable
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"

--- a/shared/api-contracts/paths/profile.yaml
+++ b/shared/api-contracts/paths/profile.yaml
@@ -1,0 +1,123 @@
+/profile:
+  get:
+    operationId: get_profile
+    summary: Get user profile
+    description: Return the authenticated user's profile data.
+    tags:
+      - profile
+    responses:
+      "200":
+        description: Profile data
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/profile.yaml#/ProfileResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+  put:
+    operationId: update_profile
+    summary: Update user profile
+    description: Update mutable profile fields. Only provided fields are changed.
+    tags:
+      - profile
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/profile.yaml#/ProfileUpdateRequest"
+    responses:
+      "200":
+        description: Profile updated
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/profile.yaml#/ProfileResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+
+/profile/account:
+  delete:
+    operationId: delete_account
+    summary: Delete user account
+    description: >
+      GDPR-compliant full account deletion. Requires the confirmation
+      text "DELETE MY ACCOUNT" in the request body. Permanently removes
+      all user data across DB, Mem0, S3, and Cognito.
+    tags:
+      - profile
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/profile.yaml#/AccountDeleteRequest"
+    responses:
+      "204":
+        description: Account deleted (no content)
+      "400":
+        description: Incorrect confirmation text
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"

--- a/shared/api-contracts/schemas/auth.yaml
+++ b/shared/api-contracts/schemas/auth.yaml
@@ -1,0 +1,95 @@
+RegisterRequest:
+  type: object
+  required:
+    - email
+    - password
+    - name
+  properties:
+    email:
+      type: string
+      format: email
+    password:
+      type: string
+      minLength: 8
+    name:
+      type: string
+      minLength: 1
+      maxLength: 100
+
+LoginRequest:
+  type: object
+  required:
+    - email
+    - password
+  properties:
+    email:
+      type: string
+      format: email
+    password:
+      type: string
+      minLength: 1
+
+RefreshRequest:
+  type: object
+  required:
+    - refresh_token
+  properties:
+    refresh_token:
+      type: string
+      minLength: 1
+
+AuthResponse:
+  type: object
+  required:
+    - token
+    - refresh_token
+    - user
+  properties:
+    token:
+      type: string
+    refresh_token:
+      type: string
+    user:
+      $ref: "#/UserResponse"
+
+UserResponse:
+  type: object
+  required:
+    - id
+    - email
+    - name
+    - onboarding_completed
+    - subscription_tier
+    - preferred_language
+    - timezone
+    - created_at
+  properties:
+    id:
+      type: string
+    email:
+      type: string
+    name:
+      type: string
+    onboarding_completed:
+      type: boolean
+    subscription_tier:
+      type: string
+    preferred_language:
+      type: string
+    timezone:
+      type: string
+    avatar_url:
+      oneOf:
+        - type: string
+        - type: "null"
+    created_at:
+      type: string
+      format: date-time
+
+RefreshResponse:
+  type: object
+  required:
+    - token
+  properties:
+    token:
+      type: string

--- a/shared/api-contracts/schemas/character.yaml
+++ b/shared/api-contracts/schemas/character.yaml
@@ -1,0 +1,112 @@
+CreateCharacterRequest:
+  type: object
+  required:
+    - name
+    - template
+  properties:
+    name:
+      type: string
+      minLength: 1
+      maxLength: 100
+    template:
+      type: string
+    description:
+      oneOf:
+        - type: string
+          maxLength: 1000
+        - type: "null"
+
+UpdateCharacterRequest:
+  type: object
+  properties:
+    name:
+      oneOf:
+        - type: string
+          minLength: 1
+          maxLength: 100
+        - type: "null"
+    system_prompt:
+      oneOf:
+        - type: string
+          minLength: 1
+          maxLength: 10000
+        - type: "null"
+    avatar_style:
+      oneOf:
+        - type: string
+          maxLength: 50
+        - type: "null"
+
+CharacterListItem:
+  type: object
+  required:
+    - id
+    - name
+    - template
+    - avatar_style
+    - is_default
+    - created_at
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    template:
+      type: string
+    description:
+      oneOf:
+        - type: string
+        - type: "null"
+    avatar_style:
+      type: string
+    is_default:
+      type: boolean
+    last_message_at:
+      oneOf:
+        - type: string
+          format: date-time
+        - type: "null"
+    created_at:
+      type: string
+      format: date-time
+
+CharacterListResponse:
+  type: object
+  required:
+    - characters
+  properties:
+    characters:
+      type: array
+      items:
+        $ref: "#/CharacterListItem"
+
+CharacterDetail:
+  type: object
+  required:
+    - id
+    - name
+    - template
+    - system_prompt
+    - avatar_style
+    - is_default
+    - created_at
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    template:
+      type: string
+    description:
+      oneOf:
+        - type: string
+        - type: "null"
+    system_prompt:
+      type: string
+    avatar_style:
+      type: string
+    is_default:
+      type: boolean
+    created_at:
+      type: string
+      format: date-time

--- a/shared/api-contracts/schemas/chat.yaml
+++ b/shared/api-contracts/schemas/chat.yaml
@@ -1,0 +1,114 @@
+SendMessageRequest:
+  type: object
+  required:
+    - content
+  properties:
+    content:
+      type: string
+      minLength: 1
+      maxLength: 4000
+    media_url:
+      oneOf:
+        - type: string
+          maxLength: 2048
+        - type: "null"
+
+MessageItem:
+  type: object
+  required:
+    - id
+    - role
+    - content
+    - created_at
+  properties:
+    id:
+      type: string
+    role:
+      type: string
+      enum:
+        - user
+        - assistant
+    content:
+      type: string
+    media_url:
+      oneOf:
+        - type: string
+        - type: "null"
+    metadata:
+      oneOf:
+        - type: object
+        - type: "null"
+    created_at:
+      type: string
+      format: date-time
+
+MessageListResponse:
+  type: object
+  required:
+    - items
+    - next_cursor
+    - has_more
+  properties:
+    items:
+      type: array
+      items:
+        $ref: "#/MessageItem"
+    next_cursor:
+      oneOf:
+        - type: string
+        - type: "null"
+    has_more:
+      type: boolean
+
+# SSE Event schemas (for reference -- not directly used in response schema)
+
+ChunkEvent:
+  type: object
+  required:
+    - type
+    - content
+  properties:
+    type:
+      type: string
+      const: chunk
+    content:
+      type: string
+
+ActionEvent:
+  type: object
+  required:
+    - type
+    - action
+    - payload
+  properties:
+    type:
+      type: string
+      const: action
+    action:
+      type: string
+    payload:
+      type: object
+
+DoneEvent:
+  type: object
+  required:
+    - type
+    - message_id
+  properties:
+    type:
+      type: string
+      const: done
+    message_id:
+      type: string
+
+ErrorEvent:
+  type: object
+  required:
+    - type
+    - message
+  properties:
+    type:
+      type: string
+      const: error
+    message:
+      type: string

--- a/shared/api-contracts/schemas/common.yaml
+++ b/shared/api-contracts/schemas/common.yaml
@@ -1,0 +1,31 @@
+ErrorResponse:
+  type: object
+  required:
+    - detail
+  properties:
+    detail:
+      oneOf:
+        - type: string
+        - type: array
+          items:
+            type: object
+            properties:
+              loc:
+                type: array
+                items:
+                  oneOf:
+                    - type: string
+                    - type: integer
+              msg:
+                type: string
+              type:
+                type: string
+
+RateLimitError:
+  type: object
+  required:
+    - detail
+  properties:
+    detail:
+      type: string
+      example: "Rate limit exceeded"

--- a/shared/api-contracts/schemas/health.yaml
+++ b/shared/api-contracts/schemas/health.yaml
@@ -1,0 +1,75 @@
+HealthResponse:
+  type: object
+  required:
+    - status
+    - version
+  properties:
+    status:
+      type: string
+      example: "ok"
+    version:
+      type: string
+      example: "1.0.0"
+    dependencies:
+      oneOf:
+        - $ref: "#/DependencyStatus"
+        - type: "null"
+      default: null
+    circuit_breaker:
+      oneOf:
+        - $ref: "#/CircuitBreakerReport"
+        - type: "null"
+      default: null
+
+DependencyStatus:
+  type: object
+  required:
+    - database
+    - mem0
+    - claude
+  properties:
+    database:
+      type: string
+      description: "ok | degraded | unavailable"
+    mem0:
+      type: string
+      description: "ok | degraded | unavailable"
+    claude:
+      type: string
+      description: "ok | degraded | unavailable"
+
+CircuitBreakerReport:
+  type: object
+  required:
+    - mem0
+  properties:
+    mem0:
+      $ref: "#/CircuitBreakerStatus"
+
+CircuitBreakerStatus:
+  type: object
+  required:
+    - state
+    - failure_count
+    - retry_queue_size
+    - cache_entries
+  properties:
+    state:
+      type: string
+      description: "closed | open | half_open"
+    failure_count:
+      type: integer
+    last_failure_at:
+      oneOf:
+        - type: string
+        - type: "null"
+      default: null
+    last_success_at:
+      oneOf:
+        - type: string
+        - type: "null"
+      default: null
+    retry_queue_size:
+      type: integer
+    cache_entries:
+      type: integer

--- a/shared/api-contracts/schemas/media.yaml
+++ b/shared/api-contracts/schemas/media.yaml
@@ -1,0 +1,31 @@
+UploadUrlRequest:
+  type: object
+  required:
+    - filename
+    - content_type
+    - type
+  properties:
+    filename:
+      type: string
+      minLength: 1
+      maxLength: 255
+    content_type:
+      type: string
+      minLength: 1
+    type:
+      type: string
+      enum:
+        - photo
+        - audio
+        - tts
+
+UploadUrlResponse:
+  type: object
+  required:
+    - upload_url
+    - file_url
+  properties:
+    upload_url:
+      type: string
+    file_url:
+      type: string

--- a/shared/api-contracts/schemas/memory.yaml
+++ b/shared/api-contracts/schemas/memory.yaml
@@ -1,0 +1,26 @@
+MemoryItem:
+  type: object
+  required:
+    - id
+    - memory
+  properties:
+    id:
+      type: string
+    memory:
+      type: string
+    created_at:
+      oneOf:
+        - type: string
+          format: date-time
+        - type: "null"
+      default: null
+
+MemoryListResponse:
+  type: object
+  required:
+    - memories
+  properties:
+    memories:
+      type: array
+      items:
+        $ref: "#/MemoryItem"

--- a/shared/api-contracts/schemas/onboarding.yaml
+++ b/shared/api-contracts/schemas/onboarding.yaml
@@ -1,0 +1,43 @@
+OnboardingAnswer:
+  type: object
+  required:
+    - question_key
+    - answer
+  properties:
+    question_key:
+      type: string
+      enum:
+        - preferred_name
+        - occupation
+        - daily_rhythm
+        - health_goal
+        - stress_management
+        - sleep_schedule
+        - communication_style
+    answer:
+      type: string
+      minLength: 1
+      maxLength: 500
+
+OnboardingRequest:
+  type: object
+  required:
+    - answers
+  properties:
+    answers:
+      type: array
+      items:
+        $ref: "#/OnboardingAnswer"
+      minItems: 7
+      maxItems: 7
+
+OnboardingResponse:
+  type: object
+  required:
+    - onboarding_completed
+    - memories_seeded
+  properties:
+    onboarding_completed:
+      type: boolean
+    memories_seeded:
+      type: integer

--- a/shared/api-contracts/schemas/profile.yaml
+++ b/shared/api-contracts/schemas/profile.yaml
@@ -1,0 +1,68 @@
+ProfileResponse:
+  type: object
+  required:
+    - id
+    - email
+    - name
+    - timezone
+    - preferred_language
+    - onboarding_completed
+    - subscription_tier
+    - created_at
+  properties:
+    id:
+      type: string
+    email:
+      type: string
+    name:
+      type: string
+    timezone:
+      type: string
+    avatar_url:
+      oneOf:
+        - type: string
+        - type: "null"
+    preferred_language:
+      type: string
+    onboarding_completed:
+      type: boolean
+    subscription_tier:
+      type: string
+    subscription_expires_at:
+      oneOf:
+        - type: string
+          format: date-time
+        - type: "null"
+    created_at:
+      type: string
+      format: date-time
+
+ProfileUpdateRequest:
+  type: object
+  properties:
+    name:
+      oneOf:
+        - type: string
+        - type: "null"
+    timezone:
+      oneOf:
+        - type: string
+        - type: "null"
+    avatar_url:
+      oneOf:
+        - type: string
+        - type: "null"
+    preferred_language:
+      oneOf:
+        - type: string
+        - type: "null"
+
+AccountDeleteRequest:
+  type: object
+  required:
+    - confirmation
+  properties:
+    confirmation:
+      type: string
+      minLength: 1
+      description: Must be exactly "DELETE MY ACCOUNT"

--- a/shared/feature-specs/openapi-specs.md
+++ b/shared/feature-specs/openapi-specs.md
@@ -1,0 +1,612 @@
+# Feature Spec: P1.5-06 -- OpenAPI Specs
+
+**Feature ID**: P1.5-06
+**Phase**: 1.5
+**Layer**: backend
+**GitHub Issue**: #88
+**Date**: 2026-03-13
+**Author**: architect
+
+---
+
+## 1. Overview
+
+### What This Feature Does
+
+This feature creates OpenAPI 3.1 YAML specification files in `shared/api-contracts/` that document every implemented API endpoint. These files become the single source of truth for mobile clients when building their networking layers. Each spec file covers request/response schemas, authentication requirements, error codes, path parameters, query parameters, and SSE streaming behavior.
+
+Additionally, a validation script is added that compares the hand-written YAML specs against the FastAPI auto-generated OpenAPI JSON schema. This ensures the YAML specs never drift from the actual implementation. The validation runs in CI on every backend change.
+
+### Why It Exists
+
+Mobile developers (iOS and Android) currently must read Python route handlers and Pydantic schemas to understand the API contract. This is error-prone and slow. A well-structured OpenAPI spec provides:
+
+1. A language-agnostic, machine-readable contract that mobile developers can reference without reading Python.
+2. An input for future code generation (Retrofit interfaces for Android, URLSession clients for iOS).
+3. A drift-detection mechanism: if a backend developer changes an endpoint without updating the spec, CI fails.
+4. A foundation for API documentation (Swagger UI, Redoc) that can be exposed for debugging.
+
+### Dependencies
+
+- **Requires**: P01-10 (media-upload) -- the last Phase 1 endpoint. All endpoints must be implemented before they can be documented.
+- **Requires**: P1.5-01 (rate-limiting-middleware) -- 429 responses and rate limit headers must be documented.
+
+### What This Feature Does NOT Do
+
+- It does not generate client code from the specs. Code generation is a future concern.
+- It does not replace `docs/04-veri-api.md`. That document remains the human-readable architectural reference in Turkish. The OpenAPI specs are the machine-readable English contract.
+- It does not add new endpoints or change existing endpoint behavior.
+- It does not expose a Swagger UI or Redoc page in production. That is a separate concern (could be enabled in dev mode via FastAPI's built-in docs).
+
+---
+
+## 2. Data Models
+
+### No New Tables
+
+This feature does not create or alter any database tables. It is purely a documentation and validation concern.
+
+### No Mem0 Operations
+
+This feature does not interact with Mem0.
+
+---
+
+## 3. OpenAPI File Organization
+
+### Directory Structure
+
+```
+shared/api-contracts/
+  ember-api.yaml            # Root spec file: info, servers, security, references
+  paths/
+    auth.yaml               # /auth/register, /auth/login, /auth/refresh
+    characters.yaml         # /characters (GET, POST), /characters/{id} (PUT, DELETE)
+    chat.yaml               # /characters/{id}/messages (POST SSE, GET paginated)
+    memories.yaml           # /memories (GET), /characters/{id}/memories (GET, DELETE, DELETE all)
+    media.yaml              # /media/upload-url (POST)
+    onboarding.yaml         # /onboarding/complete (POST)
+    profile.yaml            # /profile (GET, PUT), /profile/account (DELETE)
+    health.yaml             # /health (GET)
+  schemas/
+    auth.yaml               # RegisterRequest, LoginRequest, RefreshRequest, AuthResponse, etc.
+    character.yaml          # CreateCharacterRequest, UpdateCharacterRequest, CharacterDetail, etc.
+    chat.yaml               # SendMessageRequest, MessageItem, MessageListResponse, SSE events
+    memory.yaml             # MemoryItem, MemoryListResponse
+    media.yaml              # UploadUrlRequest, UploadUrlResponse
+    onboarding.yaml         # OnboardingAnswer, OnboardingRequest, OnboardingResponse
+    profile.yaml            # ProfileResponse, ProfileUpdateRequest, AccountDeleteRequest
+    health.yaml             # HealthResponse, DependencyStatus, CircuitBreakerStatus
+    common.yaml             # ErrorResponse (detail), pagination envelope
+```
+
+### Why Split Files
+
+A single monolithic YAML becomes unreadable past 500 lines. Split files let mobile developers open only the path file they care about. The root `ember-api.yaml` uses `$ref` to compose everything.
+
+---
+
+## 4. Root Spec File: `ember-api.yaml`
+
+The root file must contain the following sections.
+
+### Info
+
+```yaml
+openapi: "3.1.0"
+info:
+  title: Ember API
+  version: "1.0.0"
+  description: >
+    REST API for the Ember AI companion app. All endpoints are under /api/v1/.
+    Authentication uses AWS Cognito JWTs (Bearer token).
+  contact:
+    name: Ember Engineering
+servers:
+  - url: https://api.ember.com/api/v1
+    description: Production
+  - url: http://localhost:8000/api/v1
+    description: Local development
+```
+
+### Security Schemes
+
+```yaml
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: AWS Cognito ID token
+```
+
+### Global Security
+
+Most endpoints require auth. The root file sets `security: [bearerAuth: []]` globally. Individual endpoints that do NOT require auth (register, login, refresh, health) override with `security: []`.
+
+### Path References
+
+The root file uses `$ref` to include each path file:
+
+```yaml
+paths:
+  /auth/register:
+    $ref: "paths/auth.yaml#/~1auth~1register"
+  /auth/login:
+    $ref: "paths/auth.yaml#/~1auth~1login"
+  # ... etc.
+```
+
+---
+
+## 5. Endpoint Catalog
+
+This section documents every endpoint that must appear in the OpenAPI specs. The spec YAML files must faithfully represent these contracts.
+
+### 5.1 Health
+
+**GET /health**
+
+- Auth: none (override global security with `security: []`)
+- Query params: `check_dependencies` (boolean, default false)
+- Response 200:
+  ```
+  { status: string, version: string, dependencies?: DependencyStatus, circuit_breaker?: CircuitBreakerReport }
+  ```
+- DependencyStatus: `{ database: string, mem0: string, claude: string }`
+- CircuitBreakerReport: `{ mem0: CircuitBreakerStatus }`
+- CircuitBreakerStatus: `{ state: string, failure_count: integer, last_failure_at: string|null, last_success_at: string|null, retry_queue_size: integer, cache_entries: integer }`
+
+### 5.2 Auth
+
+**POST /auth/register**
+
+- Auth: none
+- Request body: `{ email: string (email format), password: string (minLength 8), name: string (minLength 1, maxLength 100) }`
+- Response 201: `AuthResponse { token: string, refresh_token: string, user: UserResponse }`
+- UserResponse: `{ id: string (uuid), email: string, name: string, onboarding_completed: boolean, subscription_tier: string, preferred_language: string, timezone: string, avatar_url: string|null, created_at: string (date-time) }`
+- Response 409: `{ detail: string }` -- email already exists
+- Response 422: `{ detail: [...] }` -- Pydantic validation errors
+
+**POST /auth/login**
+
+- Auth: none
+- Request body: `{ email: string (email format), password: string (minLength 1) }`
+- Response 200: `AuthResponse`
+- Response 401: `{ detail: string }` -- invalid credentials
+
+**POST /auth/refresh**
+
+- Auth: none
+- Request body: `{ refresh_token: string (minLength 1) }`
+- Response 200: `RefreshResponse { token: string }`
+- Response 401: `{ detail: string }` -- invalid or expired refresh token
+
+### 5.3 Characters
+
+**GET /characters**
+
+- Auth: Bearer JWT required
+- Response 200: `CharacterListResponse { characters: CharacterListItem[] }`
+- CharacterListItem: `{ id: string, name: string, template: string, description: string|null, avatar_style: string, is_default: boolean, last_message_at: string|null (date-time), created_at: string (date-time) }`
+
+**POST /characters**
+
+- Auth: Bearer JWT required
+- Request body: `CreateCharacterRequest { name: string (1-100), template: string (enum: companion, english_teacher, therapist, fitness_coach, career_coach, custom), description: string|null (max 1000, required if template=custom, forbidden otherwise) }`
+- Response 201: `CharacterDetail { id: string, name: string, template: string, description: string|null, system_prompt: string, avatar_style: string, is_default: boolean, created_at: string (date-time) }`
+- Response 422: validation errors
+
+**PUT /characters/{character_id}**
+
+- Auth: Bearer JWT required
+- Path params: `character_id` (string, uuid format)
+- Request body: `UpdateCharacterRequest { name?: string (1-100), system_prompt?: string (1-10000), avatar_style?: string (max 50) }` -- at least one field required
+- Response 200: `CharacterDetail`
+- Response 403: `{ detail: string }` -- not owner
+- Response 404: `{ detail: string }` -- character not found
+
+**DELETE /characters/{character_id}**
+
+- Auth: Bearer JWT required
+- Path params: `character_id` (string, uuid format)
+- Response 204: no content
+- Response 403: `{ detail: string }` -- cannot delete default character, or not owner
+- Response 404: `{ detail: string }` -- character not found
+
+### 5.4 Chat
+
+**POST /characters/{character_id}/messages**
+
+- Auth: Bearer JWT required
+- Path params: `character_id` (string, uuid format)
+- Request body: `SendMessageRequest { content: string (1-4000), media_url?: string (max 2048, must be http/https URL) }`
+- Response 200: `text/event-stream` (NOT JSON)
+- SSE event sequence:
+  ```
+  data: {"type": "chunk", "content": "text fragment"}
+  data: {"type": "chunk", "content": "more text"}
+  data: {"type": "action", "action": "SET_ALARM", "payload": {"time": "07:00", "label": "Wake up"}}
+  data: {"type": "done", "message_id": "uuid-string"}
+  ```
+  On error mid-stream:
+  ```
+  data: {"type": "error", "message": "description"}
+  ```
+- SSE event schemas:
+  - ChunkEvent: `{ type: "chunk", content: string }`
+  - ActionEvent: `{ type: "action", action: string, payload: object }`
+  - DoneEvent: `{ type: "done", message_id: string }`
+  - ErrorEvent: `{ type: "error", message: string }`
+- Response 403: `{ detail: string }` -- not owner
+- Response 404: `{ detail: string }` -- character not found
+- Note: The SSE endpoint returns `Content-Type: text/event-stream` with `Cache-Control: no-cache` and `X-Accel-Buffering: no` headers. OpenAPI cannot fully model SSE, so the response content type is documented as `text/event-stream` with a description of the event format. The SSE event schemas are defined in the schemas section for reference.
+
+**GET /characters/{character_id}/messages**
+
+- Auth: Bearer JWT required
+- Path params: `character_id` (string, uuid format)
+- Query params: `cursor` (string, optional -- base64-encoded composite cursor), `limit` (integer, default 20, min 1, max 100)
+- Response 200: `MessageListResponse { items: MessageItem[], next_cursor: string|null, has_more: boolean }`
+- MessageItem: `{ id: string, role: string (enum: user, assistant), content: string, media_url: string|null, metadata: object|null, created_at: string (date-time) }`
+- Response 400: `{ detail: string }` -- invalid cursor format
+- Response 403: `{ detail: string }` -- not owner
+- Response 404: `{ detail: string }` -- character not found
+
+### 5.5 Memories
+
+**GET /memories**
+
+- Auth: Bearer JWT required
+- Response 200: `MemoryListResponse { memories: MemoryItem[] }`
+- MemoryItem: `{ id: string, memory: string, created_at: string|null (date-time) }`
+
+**GET /characters/{character_id}/memories**
+
+- Auth: Bearer JWT required
+- Path params: `character_id` (string, uuid format)
+- Response 200: `MemoryListResponse`
+- Response 403: `{ detail: string }` -- not owner
+- Response 404: `{ detail: string }` -- character not found
+
+**DELETE /characters/{character_id}/memories/{memory_id}**
+
+- Auth: Bearer JWT required
+- Path params: `character_id` (string, uuid format), `memory_id` (string)
+- Response 204: no content (idempotent)
+- Response 403: not owner
+- Response 404: character not found
+
+**DELETE /characters/{character_id}/memories**
+
+- Auth: Bearer JWT required
+- Path params: `character_id` (string, uuid format)
+- Response 204: no content
+- Response 403: not owner
+- Response 404: character not found
+
+### 5.6 Media
+
+**POST /media/upload-url**
+
+- Auth: Bearer JWT required
+- Request body: `UploadUrlRequest { filename: string (1-255, no path separators, no .., no null bytes), content_type: string (minLength 1), type: string (enum: photo, audio, tts) }`
+- Response 200: `UploadUrlResponse { upload_url: string, file_url: string }`
+- Response 400: `{ detail: string }` -- unsupported content type
+- Response 422: validation errors
+
+### 5.7 Onboarding
+
+**POST /onboarding/complete**
+
+- Auth: Bearer JWT required
+- Request body: `OnboardingRequest { answers: OnboardingAnswer[7] }` -- exactly 7 items, all keys required
+- OnboardingAnswer: `{ question_key: string (enum: preferred_name, occupation, daily_rhythm, health_goal, stress_management, sleep_schedule, communication_style), answer: string (1-500) }`
+- Response 200: `OnboardingResponse { onboarding_completed: boolean, memories_seeded: integer }`
+- Response 409: `{ detail: string }` -- onboarding already completed
+- Response 503: `{ detail: string }` -- Claude or Mem0 unavailable
+
+### 5.8 Profile
+
+**GET /profile**
+
+- Auth: Bearer JWT required
+- Response 200: `ProfileResponse { id: string, email: string, name: string, timezone: string, avatar_url: string|null, preferred_language: string, onboarding_completed: boolean, subscription_tier: string, subscription_expires_at: string|null (date-time), created_at: string (date-time) }`
+
+**PUT /profile**
+
+- Auth: Bearer JWT required
+- Request body: `ProfileUpdateRequest { name?: string (1-100), timezone?: string (IANA), avatar_url?: string (https://, max 2048), preferred_language?: string (enum: en, tr) }`
+- Response 200: `ProfileResponse`
+- Response 422: validation errors
+
+**DELETE /profile/account**
+
+- Auth: Bearer JWT required
+- Request body: `AccountDeleteRequest { confirmation: string }` -- must be exactly "DELETE MY ACCOUNT"
+- Response 204: no content
+- Response 400: `{ detail: string }` -- incorrect confirmation text
+
+### 5.9 Common Schemas
+
+**ErrorResponse**
+
+All error responses use:
+```yaml
+ErrorResponse:
+  type: object
+  required: [detail]
+  properties:
+    detail:
+      oneOf:
+        - type: string
+        - type: array
+          items:
+            type: object
+            properties:
+              loc:
+                type: array
+                items:
+                  oneOf:
+                    - type: string
+                    - type: integer
+              msg:
+                type: string
+              type:
+                type: string
+```
+
+The `detail` field is a string for application-raised errors (HTTPException) and an array of validation error objects for Pydantic 422 responses.
+
+**Rate Limit Headers**
+
+All endpoints may return 429 with:
+- `Retry-After` header (integer, seconds until the rate limit window resets)
+- Response body: `{ detail: string }`
+
+This should be documented as a global response component that applies to all authenticated endpoints.
+
+---
+
+## 6. Backend Logic
+
+### 6.1 Validation Script: `scripts/validate-openapi.py`
+
+The script performs drift detection between the hand-written YAML specs and the FastAPI auto-generated schema.
+
+**How it works:**
+
+1. Import the FastAPI `app` object from `app.main`.
+2. Call `app.openapi()` to get the auto-generated OpenAPI JSON schema.
+3. Load and merge the hand-written YAML specs from `shared/api-contracts/` using a YAML parser with `$ref` resolution.
+4. Compare the two schemas structurally:
+   - Every path in the YAML must exist in the FastAPI schema.
+   - Every path in the FastAPI schema must exist in the YAML (no undocumented endpoints).
+   - For each path+method, compare: request body schema (field names, types, required fields), response status codes, response schema (field names, types), query parameters (names, types, required/optional), path parameters.
+5. Report differences as errors. Exit with code 1 if any differences found, 0 if specs match.
+
+**What it does NOT compare:**
+
+- Description text, summary, examples -- these are documentation-only and may differ.
+- `operationId` values -- FastAPI auto-generates these from function names.
+- Server URLs -- these are environment-specific.
+- The SSE streaming endpoint response body -- FastAPI models this as `StreamingResponse` which does not produce a schema. The YAML documents the SSE event format for human consumption.
+
+**Tolerance rules:**
+
+- The FastAPI schema may use `anyOf` where the YAML uses `type` with `nullable` -- these are semantically equivalent in OpenAPI 3.1 and the validator must treat them as equal.
+- Field ordering differences are ignored.
+- Extra `422` responses in the FastAPI schema (auto-generated for all POST/PUT endpoints) are expected and not flagged if the YAML also includes them.
+
+### 6.2 CI Integration
+
+The validation script runs in the existing `backend-ci.yml` GitHub Actions workflow as a new step after tests pass:
+
+```yaml
+- name: Validate OpenAPI specs
+  run: python scripts/validate-openapi.py
+```
+
+This step only runs when files in `backend/**` or `shared/api-contracts/**` change.
+
+### 6.3 FastAPI OpenAPI Customization
+
+The `create_app()` function in `main.py` should be updated to customize the auto-generated schema title and version to match the YAML specs. This is not a functional change but ensures consistency:
+
+```python
+app = FastAPI(
+    title="Ember API",
+    version=settings.app_version,
+    # ... existing config
+    openapi_tags=[
+        {"name": "health", "description": "Health check and dependency status"},
+        {"name": "auth", "description": "Authentication (register, login, refresh)"},
+        {"name": "characters", "description": "Character CRUD"},
+        {"name": "chat", "description": "Message sending (SSE) and history"},
+        {"name": "memories", "description": "Mem0 memory retrieval and deletion"},
+        {"name": "media", "description": "S3 presigned URL generation"},
+        {"name": "onboarding", "description": "Onboarding flow completion"},
+        {"name": "profile", "description": "User profile management"},
+    ],
+)
+```
+
+---
+
+## 7. Test Plan
+
+### 7.1 Validation Script Tests
+
+**File**: `backend/tests/test_openapi_validation.py`
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Run validation script against current codebase | Exit code 0, no differences reported |
+| 2 | All FastAPI paths are present in the YAML specs | No "undocumented endpoint" warnings |
+| 3 | All YAML paths exist in the FastAPI schema | No "spec references non-existent path" errors |
+| 4 | Request body field names match between YAML and FastAPI | No field name mismatches |
+| 5 | Response status codes match | No missing or extra status codes (except tolerated 422) |
+| 6 | Query parameter names and types match | No parameter mismatches |
+
+### 7.2 YAML Syntax Tests
+
+**File**: `backend/tests/test_openapi_yaml.py`
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | All YAML files parse without syntax errors | Valid YAML |
+| 2 | All `$ref` pointers resolve to existing definitions | No broken references |
+| 3 | The merged spec is valid OpenAPI 3.1 | Passes `openapi-spec-validator` library check |
+| 4 | Every path has at least one response defined | No empty responses |
+| 5 | Every authenticated endpoint has `security: [{bearerAuth: []}]` (or inherits global) | Auth coverage complete |
+| 6 | Every endpoint has a `description` field | No undescribed endpoints |
+
+### 7.3 Content Accuracy Tests
+
+These are manual review items, not automated tests:
+
+- Every Pydantic schema field appears in the corresponding YAML schema
+- Every field constraint (minLength, maxLength, enum values, format) matches the Pydantic validator
+- The SSE event documentation matches the actual event models in `app/schemas/chat.py`
+
+---
+
+## 8. Acceptance Criteria
+
+1. Given the `shared/api-contracts/` directory, when a developer reads `ember-api.yaml`, then they can find a `$ref` entry for every implemented endpoint (18 endpoint+method combinations total).
+
+2. Given the `paths/auth.yaml` file, when a developer reads the POST /auth/register spec, then they see the exact request body schema (email, password, name) with correct types, constraints (minLength, maxLength), and format (email).
+
+3. Given the `paths/chat.yaml` file, when a developer reads the POST /characters/{character_id}/messages spec, then they find documentation of the SSE event types (chunk, action, done, error) with their field definitions.
+
+4. Given the `paths/chat.yaml` file, when a developer reads the GET /characters/{character_id}/messages spec, then they find cursor-based pagination query params (cursor, limit) and the response envelope (items, next_cursor, has_more).
+
+5. Given the `schemas/common.yaml` file, when a developer reads the ErrorResponse schema, then they find both the string variant (HTTPException) and the array variant (Pydantic 422 validation errors).
+
+6. Given a clean backend checkout, when `python scripts/validate-openapi.py` is run, then it exits with code 0 and prints no errors.
+
+7. Given a backend developer changes an endpoint's response schema without updating the YAML spec, when CI runs the validation step, then it fails with a clear error message identifying which endpoint and which field drifted.
+
+8. Given the YAML spec files, when they are loaded by an OpenAPI 3.1 validator library, then they pass validation with zero errors.
+
+9. Given the `ember-api.yaml` root file, when a developer inspects the security section, then all endpoints except health, register, login, and refresh require Bearer JWT auth.
+
+10. Given any path file, when a developer inspects an authenticated endpoint, then they find 401 listed as a possible response code with the error schema.
+
+11. Given any path file, when a developer inspects an authenticated endpoint, then they find 429 listed as a possible response code with the rate-limit error schema and `Retry-After` header.
+
+---
+
+## 9. File Manifest
+
+```
+Backend:
+  MODIFY backend/app/main.py                        (add openapi_tags to FastAPI constructor)
+  CREATE backend/scripts/validate_openapi.py         (drift detection script)
+  CREATE backend/tests/test_openapi_validation.py    (validation script tests)
+  CREATE backend/tests/test_openapi_yaml.py          (YAML syntax and completeness tests)
+
+Shared:
+  CREATE shared/api-contracts/ember-api.yaml         (root OpenAPI spec)
+  CREATE shared/api-contracts/paths/auth.yaml        (auth endpoint paths)
+  CREATE shared/api-contracts/paths/characters.yaml  (character CRUD paths)
+  CREATE shared/api-contracts/paths/chat.yaml        (chat SSE + message history paths)
+  CREATE shared/api-contracts/paths/memories.yaml    (memory paths)
+  CREATE shared/api-contracts/paths/media.yaml       (media upload path)
+  CREATE shared/api-contracts/paths/onboarding.yaml  (onboarding path)
+  CREATE shared/api-contracts/paths/profile.yaml     (profile paths)
+  CREATE shared/api-contracts/paths/health.yaml      (health check path)
+  CREATE shared/api-contracts/schemas/auth.yaml      (auth request/response schemas)
+  CREATE shared/api-contracts/schemas/character.yaml (character schemas)
+  CREATE shared/api-contracts/schemas/chat.yaml      (chat + SSE event schemas)
+  CREATE shared/api-contracts/schemas/memory.yaml    (memory schemas)
+  CREATE shared/api-contracts/schemas/media.yaml     (media schemas)
+  CREATE shared/api-contracts/schemas/onboarding.yaml(onboarding schemas)
+  CREATE shared/api-contracts/schemas/profile.yaml   (profile schemas)
+  CREATE shared/api-contracts/schemas/health.yaml    (health schemas)
+  CREATE shared/api-contracts/schemas/common.yaml    (ErrorResponse, pagination, rate limit)
+  DELETE shared/api-contracts/.gitkeep               (no longer needed)
+
+CI:
+  MODIFY .github/workflows/backend-ci.yml            (add validate-openapi step)
+
+Specs:
+  CREATE shared/feature-specs/openapi-specs.md       (this file)
+  CREATE docs/pipeline/openapi-specs-architect.handoff.md
+```
+
+---
+
+## Appendix A: Complete Endpoint Inventory
+
+This table enumerates every endpoint that must be documented. The backend developer should use this as a checklist.
+
+| # | Method | Path | Auth | Router File | Tags |
+|---|--------|------|------|-------------|------|
+| 1 | GET | /health | No | health.py | health |
+| 2 | POST | /auth/register | No | auth.py | auth |
+| 3 | POST | /auth/login | No | auth.py | auth |
+| 4 | POST | /auth/refresh | No | auth.py | auth |
+| 5 | GET | /characters | Yes | characters.py | characters |
+| 6 | POST | /characters | Yes | characters.py | characters |
+| 7 | PUT | /characters/{character_id} | Yes | characters.py | characters |
+| 8 | DELETE | /characters/{character_id} | Yes | characters.py | characters |
+| 9 | POST | /characters/{character_id}/messages | Yes | chat.py | chat |
+| 10 | GET | /characters/{character_id}/messages | Yes | chat.py | chat |
+| 11 | GET | /memories | Yes | memories.py | memories |
+| 12 | GET | /characters/{character_id}/memories | Yes | memories.py | memories |
+| 13 | DELETE | /characters/{character_id}/memories/{memory_id} | Yes | memories.py | memories |
+| 14 | DELETE | /characters/{character_id}/memories | Yes | memories.py | memories |
+| 15 | POST | /media/upload-url | Yes | media.py | media |
+| 16 | POST | /onboarding/complete | Yes | onboarding.py | onboarding |
+| 17 | GET | /profile | Yes | profile.py | profile |
+| 18 | PUT | /profile | Yes | profile.py | profile |
+| 19 | DELETE | /profile/account | Yes | profile.py | profile |
+
+Total: 19 endpoint+method combinations.
+
+## Appendix B: SSE Documentation Pattern
+
+OpenAPI 3.1 does not natively model Server-Sent Events. The recommended pattern for the POST /characters/{character_id}/messages endpoint is:
+
+```yaml
+responses:
+  "200":
+    description: AI response streamed as Server-Sent Events
+    content:
+      text/event-stream:
+        schema:
+          type: string
+          description: |
+            Stream of SSE events. Each event has `data:` prefix followed by JSON.
+
+            Event types:
+            - chunk: { "type": "chunk", "content": "text fragment" }
+            - action: { "type": "action", "action": "SET_ALARM", "payload": { ... } }
+            - done: { "type": "done", "message_id": "uuid" }
+            - error: { "type": "error", "message": "description" }
+
+            The stream always ends with either a "done" or "error" event.
+    headers:
+      Cache-Control:
+        schema:
+          type: string
+          example: "no-cache"
+      X-Accel-Buffering:
+        schema:
+          type: string
+          example: "no"
+```
+
+The individual SSE event schemas (ChunkEvent, ActionEvent, DoneEvent, ErrorEvent) should also be defined in `schemas/chat.yaml` for reference, even though they are not directly referenced by the response schema. This allows mobile developers to generate data classes from them.
+
+## Appendix C: Validation Script Dependencies
+
+The validation script requires the following Python packages (add to `requirements-dev.txt` or equivalent):
+
+- `pyyaml` -- YAML parsing
+- `openapi-spec-validator` -- OpenAPI 3.1 schema validation
+- `jsonref` -- JSON `$ref` resolution (works with YAML-loaded dicts)
+
+These are dev-only dependencies and must not be added to the production `requirements.txt`.


### PR DESCRIPTION
## openapi-specs

OpenAPI 3.1 YAML specs for all 19 endpoints in shared/api-contracts/. Split file organization with $ref composition. Drift detection validation script + CI integration.

Closes #88

---

## Pipeline Summary

| Stage | Agent | Status |
|-------|-------|--------|
| Architecture | architect | ✅ |
| Backend | backend-dev | ✅ |
| Backend Tests | backend-tester | ✅ |
| Documentation | doc-writer | ✅ |
| Code Review | reviewer | ✅ Approved |

## Test Coverage
- 131 OpenAPI tests, 91% coverage
- All 1883 backend tests passing

🤖 Generated via `/pipeline-run P1.5-06`