### PR TITLE
feat(tts-endpoint): tts-endpoint [P05-02]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [P04-08] Android design polish with shimmer skeletons, card elevation, scale button effects, and micro-interactions
 - [P04-09] Android error handling with EmberError sealed class, error banners, network monitor, offline detection, and retry logic
 - [P05-01] Backend TTS service with ElevenLabs Flash v2.5 primary and AWS Polly fallback, circuit breaker, and S3 audio caching
+- [P05-02] Backend STT endpoint with OpenAI Whisper transcription, S3 audio download, format validation, and confidence scoring
 
 ---
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,7 @@ from app.routes import (
     notifications,
     onboarding,
     profile,
+    stt,
     tts,
 )
 
@@ -96,6 +97,7 @@ def create_app() -> FastAPI:
             {"name": "notifications", "description": "FCM token management and push notifications"},
             {"name": "profile", "description": "User profile management"},
             {"name": "tts", "description": "Text-to-speech audio generation"},
+            {"name": "stt", "description": "Speech-to-text transcription"},
         ],
     )
 
@@ -143,6 +145,7 @@ def create_app() -> FastAPI:
     app.include_router(notifications.router, prefix="/api/v1", tags=["notifications"])
     app.include_router(profile.router, prefix="/api/v1", tags=["profile"])
     app.include_router(tts.router, prefix="/api/v1", tags=["tts"])
+    app.include_router(stt.router, prefix="/api/v1", tags=["stt"])
 
     # Global exception handler
     @app.exception_handler(Exception)

--- a/backend/app/routes/stt.py
+++ b/backend/app/routes/stt.py
@@ -1,0 +1,43 @@
+"""STT route handlers.
+
+Provides a single endpoint for transcribing audio to text using OpenAI
+Whisper API. All endpoints require JWT authentication. Business logic
+is delegated to STTService.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.dependencies import get_current_user
+from app.models.profile import Profile
+from app.schemas.stt import STTRequest, STTResponse
+from app.services.stt_service import STTService
+
+router = APIRouter()
+
+
+@router.post("/stt", response_model=STTResponse)
+async def transcribe_audio(
+    body: STTRequest,
+    current_user: Profile = Depends(get_current_user),
+) -> STTResponse:
+    """Transcribe audio from an S3 URL to text.
+
+    Downloads audio from S3, validates format (M4A, MP3, WAV, OGG) and
+    size (max 25MB), sends to OpenAI Whisper API for transcription, and
+    returns the transcript with detected language and confidence score.
+    """
+    service = STTService()
+    result = await service.transcribe(audio_url=body.audio_url)
+
+    return STTResponse(
+        transcript=str(result["transcript"]),
+        language=str(result["language"]),
+        confidence=float(result["confidence"]),  # type: ignore[arg-type]
+        duration_seconds=(
+            float(result["duration_seconds"])
+            if result.get("duration_seconds") is not None
+            else None
+        ),
+    )

--- a/backend/app/schemas/stt.py
+++ b/backend/app/schemas/stt.py
@@ -1,0 +1,46 @@
+"""Pydantic request/response schemas for STT (speech-to-text) endpoints.
+
+Covers the POST /api/v1/stt endpoint for transcribing audio to text.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+# Supported audio extensions for Whisper transcription
+_SUPPORTED_EXTENSIONS = (".m4a", ".mp3", ".wav", ".ogg")
+
+
+class STTRequest(BaseModel):
+    """Request body for POST /api/v1/stt."""
+
+    audio_url: str = Field(..., min_length=1, max_length=2048)
+
+    @field_validator("audio_url")
+    @classmethod
+    def validate_audio_url(cls, v: str) -> str:
+        """Validate audio URL format and extension."""
+        stripped = v.strip()
+        if not stripped:
+            msg = "audio_url must not be empty after trimming whitespace"
+            raise ValueError(msg)
+
+        lower = stripped.lower()
+        # Remove query parameters for extension check
+        path_part = lower.split("?")[0]
+        if not path_part.endswith(_SUPPORTED_EXTENSIONS):
+            msg = (
+                f"Unsupported audio format. Supported formats: "
+                f"{', '.join(ext.lstrip('.').upper() for ext in _SUPPORTED_EXTENSIONS)}"
+            )
+            raise ValueError(msg)
+        return stripped
+
+
+class STTResponse(BaseModel):
+    """Response for POST /api/v1/stt."""
+
+    transcript: str
+    language: str
+    confidence: float
+    duration_seconds: float | None = None

--- a/backend/app/services/stt_service.py
+++ b/backend/app/services/stt_service.py
@@ -1,0 +1,277 @@
+"""STT service — speech-to-text using OpenAI Whisper API.
+
+Downloads audio from S3, validates format and size, sends to Whisper for
+transcription, and returns transcript with detected language and confidence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from urllib.parse import urlparse
+
+import boto3
+from botocore.exceptions import ClientError
+from fastapi import HTTPException, status
+from openai import OpenAI
+
+from app.config import settings
+from app.utils.timing import log_external_call
+
+logger = logging.getLogger("ember")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Maximum audio file size: 25MB (Whisper API limit)
+_MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024
+
+# Supported audio extensions
+_SUPPORTED_EXTENSIONS = {".m4a", ".mp3", ".wav", ".ogg"}
+
+# Extension to MIME type mapping for Whisper
+_EXTENSION_MIME_MAP: dict[str, str] = {
+    ".m4a": "audio/mp4",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".ogg": "audio/ogg",
+}
+
+# Module-level AWS S3 client (reused across requests)
+_s3_client = boto3.client("s3", region_name=settings.aws_region)
+
+
+# ---------------------------------------------------------------------------
+# STT Service
+# ---------------------------------------------------------------------------
+
+
+class STTService:
+    """Speech-to-Text service using OpenAI Whisper."""
+
+    async def transcribe(self, audio_url: str) -> dict[str, object]:
+        """Transcribe audio from an S3 URL using OpenAI Whisper.
+
+        Flow:
+        1. Parse the S3 URL to extract bucket and key.
+        2. Download audio from S3.
+        3. Validate file size (max 25MB).
+        4. Send to Whisper API for transcription.
+        5. Return transcript, language, confidence, and duration.
+
+        Args:
+            audio_url: S3 URL of the audio file.
+
+        Returns:
+            Dict with transcript, language, confidence, and duration_seconds.
+
+        Raises:
+            HTTPException(400): Unsupported audio format.
+            HTTPException(413): File exceeds 25MB.
+            HTTPException(503): S3 or Whisper API unavailable.
+        """
+        # Parse S3 URL
+        bucket, key = self._parse_s3_url(audio_url)
+
+        # Validate extension
+        extension = self._get_extension(key)
+        if extension not in _SUPPORTED_EXTENSIONS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Unsupported audio format. "
+                    "Supported formats: M4A, MP3, WAV, OGG"
+                ),
+            )
+
+        # Download from S3
+        audio_data = await self._download_from_s3(bucket, key)
+
+        # Validate size
+        if len(audio_data) > _MAX_FILE_SIZE_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail="Audio file exceeds maximum size of 25MB",
+            )
+
+        # Transcribe with Whisper
+        result = await self._call_whisper(audio_data, key, extension)
+
+        return result
+
+    @staticmethod
+    def _parse_s3_url(url: str) -> tuple[str, str]:
+        """Parse an S3 URL into (bucket, key).
+
+        Supports both virtual-hosted and path-style S3 URLs:
+        - https://bucket.s3.region.amazonaws.com/key
+        - https://s3.region.amazonaws.com/bucket/key
+        """
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+
+        if host.endswith(".amazonaws.com"):
+            # Virtual-hosted style: bucket.s3.region.amazonaws.com/key
+            parts = host.split(".")
+            if parts[0] != "s3":
+                bucket = parts[0]
+                key = parsed.path.lstrip("/")
+            else:
+                # Path-style: s3.region.amazonaws.com/bucket/key
+                path_parts = parsed.path.lstrip("/").split("/", 1)
+                if len(path_parts) < 2:  # noqa: PLR2004
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Invalid S3 URL format",
+                    )
+                bucket = path_parts[0]
+                key = path_parts[1]
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid S3 URL: must be an amazonaws.com URL",
+            )
+
+        if not bucket or not key:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid S3 URL format",
+            )
+
+        return bucket, key
+
+    @staticmethod
+    def _get_extension(key: str) -> str:
+        """Extract the file extension from an S3 key, ignoring query params."""
+        # Remove query string if present
+        clean = key.split("?")[0]
+        dot_idx = clean.rfind(".")
+        if dot_idx == -1:
+            return ""
+        return clean[dot_idx:].lower()
+
+    async def _download_from_s3(self, bucket: str, key: str) -> bytes:
+        """Download audio file from S3."""
+        try:
+            async with log_external_call("s3", "get_object"):
+                response = await asyncio.to_thread(
+                    _s3_client.get_object,
+                    Bucket=bucket,
+                    Key=key,
+                )
+            body = response["Body"]
+            audio_data: bytes = await asyncio.to_thread(body.read)
+            return audio_data
+        except ClientError as exc:
+            error_code = exc.response.get("Error", {}).get("Code", "")
+            if error_code in ("NoSuchKey", "404"):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Audio file not found at the provided URL",
+                ) from None
+            logger.exception("S3 download failed for bucket=%s key=%s", bucket, key)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Storage service unavailable",
+            ) from None
+
+    async def _call_whisper(
+        self,
+        audio_data: bytes,
+        key: str,
+        extension: str,
+    ) -> dict[str, object]:
+        """Send audio to OpenAI Whisper API for transcription."""
+        if not settings.openai_api_key:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="STT service not configured",
+            )
+
+        # Determine filename and content type
+        filename = key.split("/")[-1]
+        content_type = _EXTENSION_MIME_MAP.get(extension, "audio/mpeg")
+
+        try:
+            async with log_external_call("openai", "whisper_transcribe"):
+                result = await asyncio.to_thread(
+                    self._whisper_transcribe,
+                    audio_data,
+                    filename,
+                    content_type,
+                )
+            return result
+        except HTTPException:
+            raise
+        except Exception:
+            logger.exception("Whisper transcription failed")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="STT service unavailable",
+            ) from None
+
+    @staticmethod
+    def _whisper_transcribe(
+        audio_data: bytes,
+        filename: str,
+        content_type: str,
+    ) -> dict[str, object]:
+        """Synchronous Whisper API call (run via asyncio.to_thread)."""
+        client = OpenAI(api_key=settings.openai_api_key)
+
+        audio_file = io.BytesIO(audio_data)
+        audio_file.name = filename
+
+        transcription = client.audio.transcriptions.create(
+            model="whisper-1",
+            file=audio_file,
+            response_format="verbose_json",
+        )
+
+        # Extract fields from the Whisper response
+        transcript = getattr(transcription, "text", "") or ""
+        language = getattr(transcription, "language", "unknown") or "unknown"
+        duration = getattr(transcription, "duration", None)
+
+        # Whisper verbose_json does not return a top-level confidence score.
+        # We compute an average confidence from segment-level data if available.
+        confidence = _compute_average_confidence(transcription)
+
+        return {
+            "transcript": transcript,
+            "language": language,
+            "confidence": confidence,
+            "duration_seconds": float(duration) if duration is not None else None,
+        }
+
+
+def _compute_average_confidence(transcription: object) -> float:
+    """Compute average confidence from Whisper segment-level data.
+
+    Whisper verbose_json returns segments with avg_logprob. We convert
+    logprob to a 0-1 confidence approximation. Returns 0.0 if no
+    segment data is available.
+    """
+    segments = getattr(transcription, "segments", None)
+    if not segments:
+        return 0.0
+
+    import math
+
+    total = 0.0
+    count = 0
+    for segment in segments:
+        avg_logprob = getattr(segment, "avg_logprob", None)
+        if avg_logprob is None and isinstance(segment, dict):
+            avg_logprob = segment.get("avg_logprob")
+        if avg_logprob is not None:
+            # Convert log probability to a 0-1 scale
+            total += math.exp(avg_logprob)
+            count += 1
+
+    if count == 0:
+        return 0.0
+
+    return round(min(max(total / count, 0.0), 1.0), 4)

--- a/backend/tests/routes/test_stt.py
+++ b/backend/tests/routes/test_stt.py
@@ -1,0 +1,303 @@
+"""Route-level integration tests for STT endpoints.
+
+Uses the FastAPI test client with mocked auth dependency and external services.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import uuid  # noqa: E402
+from collections.abc import AsyncGenerator  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from app.dependencies import get_current_user, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_USER_ID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+FAKE_AUDIO_DATA = b"\xff\xfb\x90\x00" * 100
+VALID_AUDIO_URL = "https://test-bucket.s3.us-east-1.amazonaws.com/audio/user123/recording.mp3"
+
+
+def _make_fake_profile(
+    user_id: uuid.UUID = FAKE_USER_ID,
+) -> MagicMock:
+    """Create a fake Profile for auth dependency override."""
+    profile = MagicMock()
+    profile.id = user_id
+    profile.email = "test@ember.ai"
+    profile.name = "Alex"
+    profile.mem0_user_id = f"user_{user_id}"
+    profile.timezone = "UTC"
+    profile.preferred_language = "en"
+    profile.created_at = datetime.now(tz=UTC)
+    profile.updated_at = datetime.now(tz=UTC)
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client with mocked DB and auth."""
+    fake_profile = _make_fake_profile()
+
+    async def override_user() -> MagicMock:
+        return fake_profile
+
+    async def override_db() -> AsyncGenerator[AsyncMock, None]:
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def unauthed_client() -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client without auth override."""
+
+    async def override_db() -> AsyncGenerator[AsyncMock, None]:
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/stt tests
+# ---------------------------------------------------------------------------
+
+
+class TestSTTEndpoint:
+    """Tests for POST /api/v1/stt."""
+
+    @pytest.mark.asyncio
+    async def test_valid_request_returns_200(self, client: AsyncClient) -> None:
+        """Valid STT request returns 200 with transcript."""
+        body_mock = MagicMock()
+        body_mock.read.return_value = FAKE_AUDIO_DATA
+        s3_response = {"Body": body_mock}
+
+        whisper_response = MagicMock()
+        whisper_response.text = "Hello world"
+        whisper_response.language = "en"
+        whisper_response.duration = 3.5
+        segment = MagicMock()
+        segment.avg_logprob = -0.1
+        whisper_response.segments = [segment]
+
+        with (
+            patch("app.services.stt_service._s3_client") as mock_s3,
+            patch("app.services.stt_service.OpenAI") as mock_openai_cls,
+            patch("app.services.stt_service.settings") as mock_settings,
+        ):
+            mock_settings.openai_api_key = "test-key"
+            mock_s3.get_object.return_value = s3_response
+
+            mock_client = MagicMock()
+            mock_client.audio.transcriptions.create.return_value = whisper_response
+            mock_openai_cls.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/stt",
+                json={"audio_url": VALID_AUDIO_URL},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["transcript"] == "Hello world"
+        assert data["language"] == "en"
+        assert data["confidence"] > 0
+        assert data["duration_seconds"] == 3.5
+
+    @pytest.mark.asyncio
+    async def test_without_auth_returns_401_or_403(self, unauthed_client: AsyncClient) -> None:
+        """Request without auth header returns 401 or 403."""
+        resp = await unauthed_client.post(
+            "/api/v1/stt",
+            json={"audio_url": VALID_AUDIO_URL},
+        )
+        assert resp.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_missing_audio_url_returns_422(self, client: AsyncClient) -> None:
+        """Missing audio_url returns 422."""
+        resp = await client.post("/api/v1/stt", json={})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_empty_audio_url_returns_422(self, client: AsyncClient) -> None:
+        """Empty audio_url returns 422."""
+        resp = await client.post("/api/v1/stt", json={"audio_url": ""})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_unsupported_format_returns_422(self, client: AsyncClient) -> None:
+        """Unsupported audio format returns 422 (caught by schema validator)."""
+        resp = await client.post(
+            "/api/v1/stt",
+            json={
+                "audio_url": "https://bucket.s3.us-east-1.amazonaws.com/audio/file.txt",
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_file_too_large_returns_413(self, client: AsyncClient) -> None:
+        """File exceeding 25MB returns 413."""
+        large_data = b"\x00" * (26 * 1024 * 1024)
+        body_mock = MagicMock()
+        body_mock.read.return_value = large_data
+        s3_response = {"Body": body_mock}
+
+        with patch("app.services.stt_service._s3_client") as mock_s3:
+            mock_s3.get_object.return_value = s3_response
+
+            resp = await client.post(
+                "/api/v1/stt",
+                json={"audio_url": VALID_AUDIO_URL},
+            )
+
+        assert resp.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_s3_not_found_returns_400(self, client: AsyncClient) -> None:
+        """S3 file not found returns 400."""
+        with patch("app.services.stt_service._s3_client") as mock_s3:
+            mock_s3.get_object.side_effect = ClientError(
+                {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+                "GetObject",
+            )
+
+            resp = await client.post(
+                "/api/v1/stt",
+                json={"audio_url": VALID_AUDIO_URL},
+            )
+
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_whisper_failure_returns_503(self, client: AsyncClient) -> None:
+        """Whisper API failure returns 503."""
+        body_mock = MagicMock()
+        body_mock.read.return_value = FAKE_AUDIO_DATA
+        s3_response = {"Body": body_mock}
+
+        with (
+            patch("app.services.stt_service._s3_client") as mock_s3,
+            patch("app.services.stt_service.OpenAI") as mock_openai_cls,
+            patch("app.services.stt_service.settings") as mock_settings,
+        ):
+            mock_settings.openai_api_key = "test-key"
+            mock_s3.get_object.return_value = s3_response
+
+            mock_client = MagicMock()
+            mock_client.audio.transcriptions.create.side_effect = Exception("Whisper error")
+            mock_openai_cls.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/stt",
+                json={"audio_url": VALID_AUDIO_URL},
+            )
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_response_shape(self, client: AsyncClient) -> None:
+        """Response has correct shape: transcript, language, confidence, duration_seconds."""
+        body_mock = MagicMock()
+        body_mock.read.return_value = FAKE_AUDIO_DATA
+        s3_response = {"Body": body_mock}
+
+        whisper_response = MagicMock()
+        whisper_response.text = "Test"
+        whisper_response.language = "en"
+        whisper_response.duration = 1.0
+        whisper_response.segments = []
+
+        with (
+            patch("app.services.stt_service._s3_client") as mock_s3,
+            patch("app.services.stt_service.OpenAI") as mock_openai_cls,
+            patch("app.services.stt_service.settings") as mock_settings,
+        ):
+            mock_settings.openai_api_key = "test-key"
+            mock_s3.get_object.return_value = s3_response
+
+            mock_client = MagicMock()
+            mock_client.audio.transcriptions.create.return_value = whisper_response
+            mock_openai_cls.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/stt",
+                json={"audio_url": VALID_AUDIO_URL},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "transcript" in data
+        assert "language" in data
+        assert "confidence" in data
+        assert "duration_seconds" in data
+
+    @pytest.mark.asyncio
+    async def test_m4a_url_accepted(self, client: AsyncClient) -> None:
+        """M4A URL is accepted."""
+        body_mock = MagicMock()
+        body_mock.read.return_value = FAKE_AUDIO_DATA
+        s3_response = {"Body": body_mock}
+
+        whisper_response = MagicMock()
+        whisper_response.text = "Hello"
+        whisper_response.language = "en"
+        whisper_response.duration = 1.0
+        whisper_response.segments = []
+
+        with (
+            patch("app.services.stt_service._s3_client") as mock_s3,
+            patch("app.services.stt_service.OpenAI") as mock_openai_cls,
+            patch("app.services.stt_service.settings") as mock_settings,
+        ):
+            mock_settings.openai_api_key = "test-key"
+            mock_s3.get_object.return_value = s3_response
+
+            mock_client = MagicMock()
+            mock_client.audio.transcriptions.create.return_value = whisper_response
+            mock_openai_cls.return_value = mock_client
+
+            m4a_url = "https://test-bucket.s3.us-east-1.amazonaws.com/audio/recording.m4a"
+            resp = await client.post(
+                "/api/v1/stt",
+                json={"audio_url": m4a_url},
+            )
+
+        assert resp.status_code == 200

--- a/backend/tests/schemas/test_stt.py
+++ b/backend/tests/schemas/test_stt.py
@@ -1,0 +1,154 @@
+"""Schema validation tests for STT Pydantic models."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from app.schemas.stt import STTRequest, STTResponse  # noqa: E402
+
+
+class TestSTTRequest:
+    """Tests for STTRequest schema validation."""
+
+    def test_valid_m4a_url(self) -> None:
+        """Valid M4A URL is accepted."""
+        req = STTRequest(
+            audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/recording.m4a",
+        )
+        assert req.audio_url.endswith(".m4a")
+
+    def test_valid_mp3_url(self) -> None:
+        """Valid MP3 URL is accepted."""
+        req = STTRequest(
+            audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/recording.mp3",
+        )
+        assert req.audio_url.endswith(".mp3")
+
+    def test_valid_wav_url(self) -> None:
+        """Valid WAV URL is accepted."""
+        req = STTRequest(
+            audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/recording.wav",
+        )
+        assert req.audio_url.endswith(".wav")
+
+    def test_valid_ogg_url(self) -> None:
+        """Valid OGG URL is accepted."""
+        req = STTRequest(
+            audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/recording.ogg",
+        )
+        assert req.audio_url.endswith(".ogg")
+
+    def test_url_with_query_params_accepted(self) -> None:
+        """URL with query parameters is accepted if extension is valid."""
+        req = STTRequest(
+            audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/recording.mp3?X-Amz-Signature=abc",
+        )
+        assert "recording.mp3" in req.audio_url
+
+    def test_strips_whitespace(self) -> None:
+        """Leading/trailing whitespace is stripped."""
+        req = STTRequest(
+            audio_url="  https://bucket.s3.us-east-1.amazonaws.com/audio/recording.mp3  ",
+        )
+        assert not req.audio_url.startswith(" ")
+        assert not req.audio_url.endswith(" ")
+
+    def test_empty_url_raises_error(self) -> None:
+        """Empty audio_url raises ValidationError."""
+        with pytest.raises(ValidationError):
+            STTRequest(audio_url="")
+
+    def test_whitespace_only_raises_error(self) -> None:
+        """Whitespace-only audio_url raises ValidationError."""
+        with pytest.raises(ValidationError):
+            STTRequest(audio_url="   ")
+
+    def test_missing_audio_url_raises_error(self) -> None:
+        """Missing audio_url raises ValidationError."""
+        with pytest.raises(ValidationError):
+            STTRequest()  # type: ignore[call-arg]
+
+    def test_unsupported_format_raises_error(self) -> None:
+        """Unsupported format (e.g., .txt) raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            STTRequest(
+                audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/file.txt",
+            )
+        assert "unsupported" in str(exc_info.value).lower()
+
+    def test_pdf_format_raises_error(self) -> None:
+        """PDF format raises ValidationError."""
+        with pytest.raises(ValidationError):
+            STTRequest(
+                audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/file.pdf",
+            )
+
+    def test_no_extension_raises_error(self) -> None:
+        """URL without extension raises ValidationError."""
+        with pytest.raises(ValidationError):
+            STTRequest(
+                audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/noextension",
+            )
+
+    def test_url_max_length(self) -> None:
+        """URL exceeding 2048 chars raises ValidationError."""
+        long_url = "https://bucket.s3.us-east-1.amazonaws.com/" + "a" * 2010 + ".mp3"
+        with pytest.raises(ValidationError):
+            STTRequest(audio_url=long_url)
+
+    def test_case_insensitive_extension(self) -> None:
+        """Extension matching is case-insensitive."""
+        req = STTRequest(
+            audio_url="https://bucket.s3.us-east-1.amazonaws.com/audio/recording.MP3",
+        )
+        assert "recording.MP3" in req.audio_url
+
+
+class TestSTTResponse:
+    """Tests for STTResponse schema."""
+
+    def test_valid_response(self) -> None:
+        """Valid response with all fields."""
+        resp = STTResponse(
+            transcript="Hello world",
+            language="en",
+            confidence=0.95,
+            duration_seconds=3.5,
+        )
+        assert resp.transcript == "Hello world"
+        assert resp.language == "en"
+        assert resp.confidence == 0.95
+        assert resp.duration_seconds == 3.5
+
+    def test_response_without_duration(self) -> None:
+        """Response without duration is valid (optional field)."""
+        resp = STTResponse(
+            transcript="Hello",
+            language="en",
+            confidence=0.9,
+        )
+        assert resp.duration_seconds is None
+
+    def test_missing_transcript_raises_error(self) -> None:
+        """Missing transcript raises ValidationError."""
+        with pytest.raises(ValidationError):
+            STTResponse(language="en", confidence=0.9)  # type: ignore[call-arg]
+
+    def test_missing_language_raises_error(self) -> None:
+        """Missing language raises ValidationError."""
+        with pytest.raises(ValidationError):
+            STTResponse(transcript="Hello", confidence=0.9)  # type: ignore[call-arg]
+
+    def test_missing_confidence_raises_error(self) -> None:
+        """Missing confidence raises ValidationError."""
+        with pytest.raises(ValidationError):
+            STTResponse(transcript="Hello", language="en")  # type: ignore[call-arg]

--- a/backend/tests/services/test_stt.py
+++ b/backend/tests/services/test_stt.py
@@ -1,0 +1,355 @@
+"""Service-level unit tests for STTService.
+
+Tests S3 download, format validation, size validation, Whisper API calls,
+and error handling. All external services are mocked.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DEBUG", "true")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://ember:ember@localhost:5432/ember_test",
+)
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+from app.services.stt_service import (  # noqa: E402
+    STTService,
+    _compute_average_confidence,
+)
+
+FAKE_AUDIO_DATA = b"\xff\xfb\x90\x00" * 100  # Fake audio bytes
+SMALL_AUDIO_URL = "https://test-bucket.s3.us-east-1.amazonaws.com/audio/user123/recording.mp3"
+M4A_AUDIO_URL = "https://test-bucket.s3.us-east-1.amazonaws.com/audio/user123/recording.m4a"
+WAV_AUDIO_URL = "https://test-bucket.s3.us-east-1.amazonaws.com/audio/user123/recording.wav"
+OGG_AUDIO_URL = "https://test-bucket.s3.us-east-1.amazonaws.com/audio/user123/recording.ogg"
+
+
+# ---------------------------------------------------------------------------
+# S3 URL Parsing Tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseS3URL:
+    """Tests for _parse_s3_url."""
+
+    def test_virtual_hosted_style(self) -> None:
+        """Parse virtual-hosted style S3 URL."""
+        service = STTService()
+        bucket, key = service._parse_s3_url(
+            "https://my-bucket.s3.us-east-1.amazonaws.com/audio/file.mp3",
+        )
+        assert bucket == "my-bucket"
+        assert key == "audio/file.mp3"
+
+    def test_path_style(self) -> None:
+        """Parse path-style S3 URL."""
+        service = STTService()
+        bucket, key = service._parse_s3_url(
+            "https://s3.us-east-1.amazonaws.com/my-bucket/audio/file.mp3",
+        )
+        assert bucket == "my-bucket"
+        assert key == "audio/file.mp3"
+
+    def test_invalid_non_s3_url_raises_400(self) -> None:
+        """Non-S3 URL raises 400."""
+        service = STTService()
+        with pytest.raises(HTTPException) as exc_info:
+            service._parse_s3_url("https://example.com/audio/file.mp3")
+        assert exc_info.value.status_code == 400
+
+    def test_path_style_missing_key_raises_400(self) -> None:
+        """Path-style URL without key raises 400."""
+        service = STTService()
+        with pytest.raises(HTTPException) as exc_info:
+            service._parse_s3_url("https://s3.us-east-1.amazonaws.com/bucket-only")
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Extension Validation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetExtension:
+    """Tests for _get_extension."""
+
+    def test_mp3(self) -> None:
+        """Extract .mp3 extension."""
+        assert STTService._get_extension("audio/file.mp3") == ".mp3"
+
+    def test_m4a(self) -> None:
+        """Extract .m4a extension."""
+        assert STTService._get_extension("audio/file.m4a") == ".m4a"
+
+    def test_wav(self) -> None:
+        """Extract .wav extension."""
+        assert STTService._get_extension("audio/file.wav") == ".wav"
+
+    def test_ogg(self) -> None:
+        """Extract .ogg extension."""
+        assert STTService._get_extension("audio/file.ogg") == ".ogg"
+
+    def test_uppercase_normalized(self) -> None:
+        """Extension is lowercased."""
+        assert STTService._get_extension("audio/file.MP3") == ".mp3"
+
+    def test_no_extension(self) -> None:
+        """Returns empty string for no extension."""
+        assert STTService._get_extension("audio/noext") == ""
+
+    def test_query_params_stripped(self) -> None:
+        """Query parameters are ignored."""
+        assert STTService._get_extension("audio/file.mp3?token=abc") == ".mp3"
+
+
+# ---------------------------------------------------------------------------
+# Confidence Computation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAverageConfidence:
+    """Tests for _compute_average_confidence."""
+
+    def test_no_segments_returns_zero(self) -> None:
+        """Returns 0.0 when no segments."""
+        mock_transcription = MagicMock()
+        mock_transcription.segments = None
+        assert _compute_average_confidence(mock_transcription) == 0.0
+
+    def test_empty_segments_returns_zero(self) -> None:
+        """Returns 0.0 for empty segment list."""
+        mock_transcription = MagicMock()
+        mock_transcription.segments = []
+        assert _compute_average_confidence(mock_transcription) == 0.0
+
+    def test_single_segment(self) -> None:
+        """Computes confidence from a single segment."""
+        import math
+
+        segment = MagicMock()
+        segment.avg_logprob = -0.1  # exp(-0.1) ~ 0.9048
+        mock_transcription = MagicMock()
+        mock_transcription.segments = [segment]
+
+        confidence = _compute_average_confidence(mock_transcription)
+        expected = round(math.exp(-0.1), 4)
+        assert confidence == expected
+
+    def test_multiple_segments_averaged(self) -> None:
+        """Averages confidence across multiple segments."""
+        import math
+
+        seg1 = MagicMock()
+        seg1.avg_logprob = -0.1
+        seg2 = MagicMock()
+        seg2.avg_logprob = -0.2
+        mock_transcription = MagicMock()
+        mock_transcription.segments = [seg1, seg2]
+
+        confidence = _compute_average_confidence(mock_transcription)
+        expected = round((math.exp(-0.1) + math.exp(-0.2)) / 2, 4)
+        assert confidence == expected
+
+    def test_confidence_clamped_to_1(self) -> None:
+        """Confidence is clamped to max 1.0."""
+        segment = MagicMock()
+        segment.avg_logprob = 1.0  # exp(1) > 1, should be clamped
+        mock_transcription = MagicMock()
+        mock_transcription.segments = [segment]
+
+        confidence = _compute_average_confidence(mock_transcription)
+        assert confidence <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# STTService.transcribe Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSTTServiceTranscribe:
+    """Tests for STTService.transcribe."""
+
+    @pytest.mark.asyncio
+    async def test_successful_transcription(self) -> None:
+        """Successful transcription returns transcript, language, confidence."""
+        service = STTService()
+
+        # Mock S3 download
+        body_mock = MagicMock()
+        body_mock.read.return_value = FAKE_AUDIO_DATA
+        s3_response = {"Body": body_mock}
+
+        # Mock Whisper response
+        whisper_response = MagicMock()
+        whisper_response.text = "Hello world"
+        whisper_response.language = "en"
+        whisper_response.duration = 3.5
+        segment = MagicMock()
+        segment.avg_logprob = -0.1
+        whisper_response.segments = [segment]
+
+        with (
+            patch("app.services.stt_service._s3_client") as mock_s3,
+            patch("app.services.stt_service.OpenAI") as mock_openai_cls,
+            patch("app.services.stt_service.settings") as mock_settings,
+        ):
+            mock_settings.openai_api_key = "test-key"
+            mock_s3.get_object.return_value = s3_response
+
+            mock_client = MagicMock()
+            mock_client.audio.transcriptions.create.return_value = whisper_response
+            mock_openai_cls.return_value = mock_client
+
+            result = await service.transcribe(SMALL_AUDIO_URL)
+
+        assert result["transcript"] == "Hello world"
+        assert result["language"] == "en"
+        assert result["duration_seconds"] == 3.5
+        assert isinstance(result["confidence"], float)
+
+    @pytest.mark.asyncio
+    async def test_unsupported_format_raises_400(self) -> None:
+        """Unsupported audio format raises 400."""
+        service = STTService()
+        url = "https://test-bucket.s3.us-east-1.amazonaws.com/audio/file.txt"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.transcribe(url)
+        assert exc_info.value.status_code == 400
+        assert "Unsupported" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_file_too_large_raises_413(self) -> None:
+        """File exceeding 25MB raises 413."""
+        service = STTService()
+
+        # Create data > 25MB
+        large_data = b"\x00" * (26 * 1024 * 1024)
+        body_mock = MagicMock()
+        body_mock.read.return_value = large_data
+        s3_response = {"Body": body_mock}
+
+        with patch("app.services.stt_service._s3_client") as mock_s3:
+            mock_s3.get_object.return_value = s3_response
+
+            with pytest.raises(HTTPException) as exc_info:
+                await service.transcribe(SMALL_AUDIO_URL)
+            assert exc_info.value.status_code == 413
+            assert "25MB" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_s3_not_found_raises_400(self) -> None:
+        """S3 file not found raises 400."""
+        service = STTService()
+
+        with patch("app.services.stt_service._s3_client") as mock_s3:
+            mock_s3.get_object.side_effect = ClientError(
+                {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+                "GetObject",
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await service.transcribe(SMALL_AUDIO_URL)
+            assert exc_info.value.status_code == 400
+            assert "not found" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_s3_server_error_raises_503(self) -> None:
+        """S3 internal error raises 503."""
+        service = STTService()
+
+        with patch("app.services.stt_service._s3_client") as mock_s3:
+            mock_s3.get_object.side_effect = ClientError(
+                {"Error": {"Code": "InternalError", "Message": "S3 down"}},
+                "GetObject",
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await service.transcribe(SMALL_AUDIO_URL)
+            assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_whisper_api_failure_raises_503(self) -> None:
+        """Whisper API failure raises 503."""
+        service = STTService()
+
+        body_mock = MagicMock()
+        body_mock.read.return_value = FAKE_AUDIO_DATA
+        s3_response = {"Body": body_mock}
+
+        with (
+            patch("app.services.stt_service._s3_client") as mock_s3,
+            patch("app.services.stt_service.OpenAI") as mock_openai_cls,
+            patch("app.services.stt_service.settings") as mock_settings,
+        ):
+            mock_settings.openai_api_key = "test-key"
+            mock_s3.get_object.return_value = s3_response
+
+            mock_client = MagicMock()
+            mock_client.audio.transcriptions.create.side_effect = Exception("Whisper down")
+            mock_openai_cls.return_value = mock_client
+
+            with pytest.raises(HTTPException) as exc_info:
+                await service.transcribe(SMALL_AUDIO_URL)
+            assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_no_openai_key_raises_503(self) -> None:
+        """Missing OpenAI API key raises 503."""
+        service = STTService()
+
+        body_mock = MagicMock()
+        body_mock.read.return_value = FAKE_AUDIO_DATA
+        s3_response = {"Body": body_mock}
+
+        with (
+            patch("app.services.stt_service._s3_client") as mock_s3,
+            patch("app.services.stt_service.settings") as mock_settings,
+        ):
+            mock_settings.openai_api_key = ""
+            mock_s3.get_object.return_value = s3_response
+
+            with pytest.raises(HTTPException) as exc_info:
+                await service.transcribe(SMALL_AUDIO_URL)
+            assert exc_info.value.status_code == 503
+            assert "not configured" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_m4a_format_accepted(self) -> None:
+        """M4A format is accepted and transcribed."""
+        service = STTService()
+
+        body_mock = MagicMock()
+        body_mock.read.return_value = FAKE_AUDIO_DATA
+        s3_response = {"Body": body_mock}
+
+        whisper_response = MagicMock()
+        whisper_response.text = "Merhaba"
+        whisper_response.language = "tr"
+        whisper_response.duration = 2.0
+        whisper_response.segments = []
+
+        with (
+            patch("app.services.stt_service._s3_client") as mock_s3,
+            patch("app.services.stt_service.OpenAI") as mock_openai_cls,
+            patch("app.services.stt_service.settings") as mock_settings,
+        ):
+            mock_settings.openai_api_key = "test-key"
+            mock_s3.get_object.return_value = s3_response
+
+            mock_client = MagicMock()
+            mock_client.audio.transcriptions.create.return_value = whisper_response
+            mock_openai_cls.return_value = mock_client
+
+            result = await service.transcribe(M4A_AUDIO_URL)
+
+        assert result["transcript"] == "Merhaba"
+        assert result["language"] == "tr"

--- a/backend/tests/test_openapi_validation.py
+++ b/backend/tests/test_openapi_validation.py
@@ -862,13 +862,13 @@ class TestLoadYamlSpecs:
     def test_valid_contracts_dir_loads_paths(self) -> None:
         """load_yaml_specs loads all path keys from the real contracts directory.
 
-        Note: 17 path keys cover endpoint+method combinations
+        Note: 18 path keys cover endpoint+method combinations
         (some paths like /characters have both GET and POST operations).
         """
         contracts_dir = backend_dir.parent / "shared" / "api-contracts"
         yaml_paths = load_yaml_specs(contracts_dir)
-        assert len(yaml_paths) == 17, (
-            f"Expected 17 path keys from YAML specs, got {len(yaml_paths)}"
+        assert len(yaml_paths) == 18, (
+            f"Expected 18 path keys from YAML specs, got {len(yaml_paths)}"
         )
 
     def test_unresolvable_pointer_prints_warning_and_skips(

--- a/backend/tests/test_openapi_yaml.py
+++ b/backend/tests/test_openapi_yaml.py
@@ -195,7 +195,7 @@ class TestContentCompleteness:
         )
 
     def test_endpoint_count(self) -> None:
-        """The spec must document all 20 endpoint+method combinations."""
+        """The spec must document all endpoint+method combinations."""
         root = _load_root_spec()
         paths = _load_all_paths(root)
 
@@ -205,7 +205,7 @@ class TestContentCompleteness:
                 if isinstance(op, dict):
                     count += 1
 
-        assert count == 23, f"Expected 23 endpoints, found {count}"
+        assert count == 24, f"Expected 24 endpoints, found {count}"
 
 
 # ---------------------------------------------------------------------------
@@ -305,7 +305,7 @@ class TestRootSpec:
         tag_names = {t["name"] for t in root.get("tags", [])}
         expected = {
             "health", "auth", "characters", "chat",
-            "memories", "media", "notifications", "onboarding", "profile", "tts",
+            "memories", "media", "notifications", "onboarding", "profile", "tts", "stt",
         }
         assert tag_names == expected, f"Missing tags: {expected - tag_names}"
 

--- a/docs/features/voice-stt-backend.md
+++ b/docs/features/voice-stt-backend.md
@@ -1,0 +1,65 @@
+# Voice STT Backend (P05-02)
+
+## Overview
+
+Speech-to-Text backend service that transcribes audio files using OpenAI Whisper API. Accepts S3 audio URLs, validates format and size, and returns transcripts with language detection and confidence scores.
+
+## API Reference
+
+### POST /api/v1/stt
+
+Transcribe an audio file to text.
+
+**Auth**: JWT Bearer token required
+
+**Request Body**:
+```json
+{
+  "audio_url": "https://s3.amazonaws.com/bucket/audio/file.m4a"
+}
+```
+
+**Response** (200):
+```json
+{
+  "transcript": "Hello, how are you today?",
+  "language": "en",
+  "confidence": 0.95,
+  "duration_seconds": 3.5
+}
+```
+
+**Errors**:
+- `400` — Unsupported audio format
+- `413` — File exceeds 25MB limit
+- `422` — Invalid request (missing/malformed audio_url)
+- `503` — Whisper API unavailable
+
+### Supported Formats
+- M4A, MP3, WAV, OGG
+
+### Size Limit
+- Maximum 25MB per audio file
+
+## Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OPENAI_API_KEY` | OpenAI API key for Whisper | Required |
+| `AWS_S3_BUCKET` | S3 bucket for audio files | Required |
+
+## Architecture
+
+1. Client sends `audio_url` (S3 presigned URL from P01-10)
+2. Service downloads audio from S3
+3. Validates format (extension check) and size (Content-Length header)
+4. Sends to OpenAI Whisper API via `asyncio.to_thread`
+5. Computes confidence from segment log probabilities
+6. Returns transcript, detected language, confidence, and duration
+
+## Known Limitations
+
+- Batch transcription only (not real-time streaming)
+- Maximum 25MB file size (Whisper API limit)
+- Confidence score is derived from average segment logprobs
+- No caching of transcription results (each request re-transcribes)

--- a/docs/pipeline/voice-stt-backend-architect.handoff.md
+++ b/docs/pipeline/voice-stt-backend-architect.handoff.md
@@ -1,0 +1,35 @@
+# Architect Handoff: Voice STT Backend (P05-02)
+
+**Date**: 2026-03-13
+**Agent**: architect
+**Status**: COMPLETE
+
+## Summary
+
+Designed the POST /api/v1/stt endpoint for speech-to-text transcription using
+OpenAI Whisper API. The endpoint downloads audio from S3, validates format and
+size, transcribes via Whisper, and returns transcript with language detection.
+
+## Spec Location
+
+`shared/feature-specs/voice-stt-backend.md`
+
+## Key Decisions
+
+- Stateless endpoint: no new database tables needed
+- Audio downloaded from S3 (not direct upload to endpoint) to stay consistent
+  with the existing media upload flow (P01-10)
+- Supported formats: M4A, MP3, WAV, OGG (Whisper supports all four)
+- 25MB max file size (Whisper API hard limit)
+- OpenAI Whisper SDK calls wrapped in asyncio.to_thread (sync SDK)
+- Follows existing TTS route/service patterns for consistency
+
+## Files for Backend Dev
+
+- `backend/app/routes/stt.py` — route handler
+- `backend/app/services/stt_service.py` — business logic
+- `backend/app/schemas/stt.py` — Pydantic schemas
+- `backend/app/main.py` — register router
+- `shared/api-contracts/paths/stt.yaml` — OpenAPI path
+- `shared/api-contracts/schemas/stt.yaml` — OpenAPI schemas
+- `shared/api-contracts/ember-api.yaml` — add STT path reference

--- a/docs/pipeline/voice-stt-backend-backend-dev.handoff.md
+++ b/docs/pipeline/voice-stt-backend-backend-dev.handoff.md
@@ -1,0 +1,35 @@
+# Backend Dev Handoff: Voice STT (P05-02)
+
+**Date**: 2026-03-13
+**Agent**: backend-dev
+**Status**: COMPLETE
+
+## Implemented Files
+- `backend/app/routes/stt.py` — 1 endpoint (POST /api/v1/stt)
+- `backend/app/services/stt_service.py` — STTService class with 6 methods
+- `backend/app/schemas/stt.py` — 2 schemas (STTRequest, STTResponse)
+- `backend/app/main.py` — registered STT router
+- `shared/api-contracts/paths/stt.yaml` — OpenAPI path spec
+- `shared/api-contracts/schemas/stt.yaml` — OpenAPI schema spec
+- `shared/api-contracts/ember-api.yaml` — added STT path reference and tag
+- `docs/standards/backend.md` — added STT route, service, schema to project structure
+
+## Endpoints Implemented
+- `POST /api/v1/stt` — transcribe audio from S3 URL using OpenAI Whisper
+
+## Test Results
+- pytest: 2185 passed, 0 failed (excluding pre-existing infra failures)
+- ruff: clean
+- New STT tests: 53 passed (19 schema + 24 service + 10 route)
+
+## Known Issues / Deviations from Spec
+- None
+
+## Notes for Backend Tester
+- Mock `app.services.stt_service._s3_client` for all S3 tests
+- Mock `app.services.stt_service.OpenAI` for all Whisper tests
+- Mock `app.services.stt_service.settings` when testing API key presence
+- The `_compute_average_confidence` function converts Whisper logprob to 0-1 scale
+- Schema validation catches unsupported formats at the Pydantic level (422)
+- Service validation catches them again at the service level (400) as defense in depth
+- Pre-existing infra test failures (missing .env.example, Dockerfile, pyproject path) are unrelated

--- a/docs/pipeline/voice-stt-backend-doc.handoff.md
+++ b/docs/pipeline/voice-stt-backend-doc.handoff.md
@@ -1,0 +1,5 @@
+# Doc-Writer Handoff — voice-stt-backend
+
+- **status**: COMPLETE
+- **feature**: P05-02 — voice-stt-backend
+- **files_created**: docs/features/voice-stt-backend.md, CHANGELOG.md updated

--- a/docs/pipeline/voice-stt-backend-review.handoff.md
+++ b/docs/pipeline/voice-stt-backend-review.handoff.md
@@ -1,0 +1,70 @@
+# Reviewer Handoff: Voice STT Backend (P05-02)
+
+**Date**: 2026-03-13
+**Agent**: reviewer
+**Status**: APPROVED
+
+## Review Summary
+
+| Category | Passed | Warnings | Issues |
+|----------|--------|----------|--------|
+| Architecture | 5 | 0 | 0 |
+| Backend | 7 | 1 | 0 |
+| Testing | 5 | 0 | 0 |
+| Security | 4 | 0 | 0 |
+| **Total** | **21** | **1** | **0** |
+
+## Files Reviewed
+
+**Backend**:
+- `backend/app/routes/stt.py` — PASS
+- `backend/app/services/stt_service.py` — PASS
+- `backend/app/schemas/stt.py` — PASS
+- `backend/app/main.py` (STT router registration) — PASS
+- `shared/api-contracts/paths/stt.yaml` — PASS (exists)
+- `shared/api-contracts/schemas/stt.yaml` — PASS (exists)
+
+**Tests**:
+- `backend/tests/schemas/test_stt.py` (19 tests) — PASS
+- `backend/tests/services/test_stt.py` (24 tests) — PASS
+- `backend/tests/routes/test_stt.py` (10 tests) — PASS
+
+**Total: 53 tests, all passing.**
+
+## Checklist Detail
+
+### Architecture Compliance
+- [x] Endpoint matches spec: `POST /api/v1/stt` — PASS
+- [x] Request/response schemas match spec (audio_url, transcript, language, confidence, duration_seconds) — PASS
+- [x] No hardcoded secrets — PASS (grep clean)
+- [x] No `/conversations` path segment — PASS (N/A, stateless endpoint)
+- [x] No OFFSET pagination — PASS (N/A, stateless endpoint)
+
+### Backend Code Quality
+- [x] Route handler is `async def` — PASS
+- [x] Blocking calls wrapped in `asyncio.to_thread` — PASS (S3 get_object, body.read, Whisper transcribe)
+- [x] JWT extraction via `get_current_user` dependency — PASS
+- [x] No `user_id` from request body — PASS
+- [x] Business logic in service layer, not route handler — PASS
+- [x] Proper error responses with correct HTTP status codes (400, 413, 422, 503) — PASS
+- [x] Input validation via Pydantic (STTRequest with Field constraints and field_validator) — PASS
+
+### Testing
+- [x] 53 tests, all passing — PASS
+- [x] Edge cases covered: empty URL, missing URL, unsupported format, oversized file, S3 not found, Whisper failure, missing API key — PASS
+- [x] External services mocked: S3 client and OpenAI both mocked — PASS
+- [x] Auth tested: unauthenticated request returns 401/403 — PASS
+- [x] Defense in depth: format validated at schema level (422) and service level (400) — PASS
+
+### Security
+- [x] No hardcoded API keys, tokens, or passwords — PASS
+- [x] No `user_id` accepted from client — PASS
+- [x] No SQL injection risk (stateless endpoint, no DB queries) — PASS
+- [x] Error messages do not expose internal IDs or stack traces — PASS
+
+## Issues Resolved During Review
+- None (first-pass clean)
+
+## Warnings (Not Blocking)
+- `current_user` parameter in route handler is used only for auth gating (not referenced in service call). This is correct per the spec (stateless transcription), but worth noting for future maintainers.
+- `# type: ignore[arg-type]` on line 37 of `routes/stt.py` is minor; could be resolved by having the service return a typed dataclass/schema instead of `dict[str, object]`, but acceptable for now.

--- a/docs/standards/backend.md
+++ b/docs/standards/backend.md
@@ -60,6 +60,7 @@ backend/
       onboarding.py
       profile.py
       tts.py                 # TTS (text-to-speech) endpoint
+      stt.py                 # STT (speech-to-text) endpoint
     services/
       __init__.py
       activity_service.py     # Background user activity upserts
@@ -77,6 +78,7 @@ backend/
       onboarding_service.py
       profile_service.py
       tts_service.py          # TTS with ElevenLabs + Polly fallback
+      stt_service.py          # STT with OpenAI Whisper
       llm/                   # Multi-provider LLM package
         __init__.py
         provider.py          # LLMProvider ABC
@@ -105,6 +107,7 @@ backend/
       health.py              # Health check response schemas
       profile.py             # Profile CRUD schemas
       tts.py                 # TTS request/response schemas
+      stt.py                 # STT request/response schemas
     utils/
       __init__.py
       cursor.py              # Cursor encode/decode helpers

--- a/shared/api-contracts/ember-api.yaml
+++ b/shared/api-contracts/ember-api.yaml
@@ -35,6 +35,8 @@ tags:
     description: User profile management
   - name: tts
     description: Text-to-speech audio generation
+  - name: stt
+    description: Speech-to-text transcription
 
 security:
   - bearerAuth: []
@@ -91,3 +93,6 @@ paths:
 
   /tts:
     $ref: "paths/tts.yaml#/~1tts"
+
+  /stt:
+    $ref: "paths/stt.yaml#/~1stt"

--- a/shared/api-contracts/paths/stt.yaml
+++ b/shared/api-contracts/paths/stt.yaml
@@ -1,0 +1,64 @@
+/stt:
+  post:
+    operationId: transcribe_audio
+    summary: Transcribe audio to text
+    description: >
+      Download audio from an S3 URL and transcribe it using OpenAI Whisper API.
+      Supported formats: M4A, MP3, WAV, OGG. Maximum file size: 25MB.
+      Returns the transcript with detected language and confidence score.
+    tags:
+      - stt
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/stt.yaml#/STTRequest"
+    responses:
+      "200":
+        description: Audio transcribed successfully
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/stt.yaml#/STTResponse"
+      "400":
+        description: Unsupported audio format or invalid S3 URL
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "401":
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "413":
+        description: Audio file exceeds 25MB
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "422":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+      "429":
+        description: Rate limit exceeded
+        headers:
+          Retry-After:
+            schema:
+              type: integer
+            description: Seconds until the rate limit window resets
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/RateLimitError"
+      "503":
+        description: STT service unavailable
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"

--- a/shared/api-contracts/schemas/stt.yaml
+++ b/shared/api-contracts/schemas/stt.yaml
@@ -1,0 +1,35 @@
+STTRequest:
+  type: object
+  required:
+    - audio_url
+  properties:
+    audio_url:
+      type: string
+      minLength: 1
+      maxLength: 2048
+      description: >
+        S3 URL of the audio file to transcribe.
+        Supported formats: M4A, MP3, WAV, OGG. Max 25MB.
+
+STTResponse:
+  type: object
+  required:
+    - transcript
+    - language
+    - confidence
+  properties:
+    transcript:
+      type: string
+      description: The transcribed text from the audio
+    language:
+      type: string
+      description: Detected language code (e.g., "en", "tr")
+    confidence:
+      type: number
+      format: float
+      description: Average confidence score (0.0 to 1.0)
+    duration_seconds:
+      type: number
+      format: float
+      nullable: true
+      description: Duration of the audio in seconds (may be null)

--- a/shared/feature-specs/voice-stt-backend.md
+++ b/shared/feature-specs/voice-stt-backend.md
@@ -1,0 +1,72 @@
+# Feature Spec: Voice STT Backend (P05-02)
+
+**Feature ID**: P05-02
+**Layer**: backend
+**Status**: SPEC COMPLETE
+**Date**: 2026-03-13
+
+## Overview
+
+Speech-to-text endpoint that accepts an S3 audio URL, downloads the audio,
+sends it to OpenAI Whisper API for transcription, and returns the transcript
+with detected language and confidence score.
+
+## Endpoint
+
+### POST /api/v1/stt
+
+**Auth**: Bearer JWT (required)
+
+**Request Body**:
+```json
+{
+  "audio_url": "https://s3.amazonaws.com/ember-media/audio/user_id/recording.m4a"
+}
+```
+
+**Response (200)**:
+```json
+{
+  "transcript": "I want to practice speaking today",
+  "language": "en",
+  "confidence": 0.97,
+  "duration_seconds": 4.2
+}
+```
+
+**Error Responses**:
+- `400` — Unsupported audio format (not M4A/MP3/WAV/OGG)
+- `401` — Missing or invalid JWT
+- `413` — Audio file exceeds 25MB
+- `422` — Validation error (missing/invalid audio_url)
+- `429` — Rate limit exceeded
+- `503` — Whisper API unavailable
+
+## Constraints
+
+- **Supported formats**: M4A, MP3, WAV, OGG
+- **Max file size**: 25MB (Whisper API limit)
+- **Audio source**: Must be an S3 URL from the configured bucket
+- **Blocking calls**: OpenAI Whisper SDK is synchronous; wrap in `asyncio.to_thread`
+- **No new DB tables**: This is a stateless transcription endpoint
+
+## Flow
+
+1. Validate JWT, extract user from token
+2. Validate `audio_url` format and extension
+3. Download audio from S3 using boto3 (via `asyncio.to_thread`)
+4. Validate file size (reject if > 25MB)
+5. Send audio bytes to OpenAI Whisper API (`asyncio.to_thread`)
+6. Return transcript, detected language, confidence, and duration
+
+## Acceptance Criteria
+
+- [ ] POST /api/v1/stt returns 200 with transcript for valid audio
+- [ ] Returns 400 for unsupported audio formats
+- [ ] Returns 413 for files exceeding 25MB
+- [ ] Returns 422 for missing/invalid audio_url
+- [ ] Returns 401 without valid JWT
+- [ ] Returns 503 when Whisper API is unavailable
+- [ ] All external calls (S3 download, Whisper) use asyncio.to_thread
+- [ ] No hardcoded API keys
+- [ ] Tests pass with mocked S3 and Whisper


### PR DESCRIPTION
## tts-endpoint (STT Backend)

Backend STT endpoint with OpenAI Whisper transcription, S3 audio download, format validation (M4A/MP3/WAV/OGG), size validation (25MB), and confidence scoring.

Closes #38

---

## Pipeline Summary

| Stage | Agent | Status |
|-------|-------|--------|
| Architecture | architect | ✅ |
| Backend | backend-dev | ✅ |
| Backend Tests | backend-tester | ✅ |
| Documentation | doc-writer | ✅ |
| Code Review | reviewer | ✅ Approved |

## Spec
`shared/feature-specs/voice-stt-backend.md`

## Test Coverage
53 tests passing (schemas: 19, services: 24, routes: 10)

🤖 Generated via `/pipeline-run P05-02`