### PR TITLE
feat(ios-voice-recording): ios-voice-recording [P05-03]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [P04-09] Android error handling with EmberError sealed class, error banners, network monitor, offline detection, and retry logic
 - [P05-01] Backend TTS service with ElevenLabs Flash v2.5 primary and AWS Polly fallback, circuit breaker, and S3 audio caching
 - [P05-02] Backend STT endpoint with OpenAI Whisper transcription, S3 audio download, format validation, and confidence scoring
+- [P05-03] iOS voice recording with hold-to-record mic button, waveform animation, S3 upload, and Whisper STT transcription
 
 ---
 

--- a/docs/features/ios-voice-recording.md
+++ b/docs/features/ios-voice-recording.md
@@ -1,0 +1,45 @@
+# iOS Voice Recording (P05-03)
+
+## Overview
+
+Adds voice recording capability to the iOS ChatView. Users can hold the mic button to record audio, which is uploaded to S3 and transcribed via the STT endpoint. The transcript appears in the message input for review before sending.
+
+## Features
+
+- **Hold-to-record**: Long press mic button (0.3s) to start recording
+- **M4A format**: AVAudioRecorder with AAC codec, 44100Hz, mono
+- **2-minute max**: Auto-stops recording at 2-minute limit
+- **Swipe to cancel**: Drag up 60pt during recording to cancel
+- **Waveform animation**: Real-time audio level visualization (24 bars)
+- **Transcription flow**: S3 upload → POST /stt → transcript in input field
+- **Permission handling**: NSMicrophoneUsageDescription, settings redirect on denial
+
+## User Flow
+
+1. Text field empty → mic button visible (replaces send button)
+2. Long press mic → recording starts, overlay replaces input bar
+3. Release → recording stops, "Transcribing..." state shown
+4. Audio uploaded to S3, sent to STT endpoint
+5. Transcript appears in text input for user to review/edit
+6. User can then send the message normally
+
+## Architecture
+
+### New Files
+- `VoiceRecorder.swift` — @Observable AVAudioRecorder wrapper with level metering
+- `VoiceRecordingOverlay.swift` — Recording UI with waveform, timer, cancel gesture
+- `WaveformView.swift` — Animated bar visualization from audio levels
+- `STTModels.swift` — STT request/response Codable models
+
+### Modified Files
+- `ChatInputBar.swift` — Mic button with long press gesture
+- `ChatViewModel.swift` — Recording flow and S3→STT processing
+- `ChatService.swift` — Upload URL, S3 upload, and STT API methods
+- `ChatView.swift` — Recording overlay and permission alert
+- `APIEndpoint.swift` — `.transcribeAudio` case
+
+## Known Limitations
+
+- Recording cancels when app goes to background
+- Maximum 2-minute recording duration
+- Transcript placed in input (not auto-sent) — user must tap send

--- a/docs/features/voice-stt-backend.md
+++ b/docs/features/voice-stt-backend.md
@@ -1,65 +1,236 @@
-# Voice STT Backend (P05-02)
+# Voice STT Backend
+
+> Transcribes audio recordings to text by downloading audio from S3, validating the file, and sending it to OpenAI Whisper for multilingual transcription with confidence scoring.
+
+**Status**: Released
+**Added in**: Phase 5 (P05-02)
+**Platforms**: Backend
+
+---
 
 ## Overview
 
-Speech-to-Text backend service that transcribes audio files using OpenAI Whisper API. Accepts S3 audio URLs, validates format and size, and returns transcripts with language detection and confidence scores.
+Ember's speech-to-text endpoint gives mobile clients a way to convert audio recordings into text they can send as chat messages. Rather than streaming audio in real time, the endpoint works asynchronously: the client first uploads an audio file to S3 via the media upload endpoint (P01-10), then calls this endpoint with the resulting S3 URL.
 
-## API Reference
+The backend downloads the audio, validates its format and size, and forwards the bytes to OpenAI Whisper using the `whisper-1` model with `verbose_json` response format. Whisper detects the language automatically — no client-side language hint is required. The response includes the transcript, the detected language code, a confidence score derived from Whisper's per-segment log-probabilities, and the audio duration in seconds.
 
-### POST /api/v1/stt
+This endpoint is intentionally stateless. It reads no database tables and writes nothing to the database or Mem0. The mobile client is responsible for taking the returned transcript and sending it as a chat message via the standard chat endpoint (P01-06). The separation of concerns keeps the STT endpoint simple and independently testable.
 
-Transcribe an audio file to text.
-
-**Auth**: JWT Bearer token required
-
-**Request Body**:
-```json
-{
-  "audio_url": "https://s3.amazonaws.com/bucket/audio/file.m4a"
-}
-```
-
-**Response** (200):
-```json
-{
-  "transcript": "Hello, how are you today?",
-  "language": "en",
-  "confidence": 0.95,
-  "duration_seconds": 3.5
-}
-```
-
-**Errors**:
-- `400` — Unsupported audio format
-- `413` — File exceeds 25MB limit
-- `422` — Invalid request (missing/malformed audio_url)
-- `503` — Whisper API unavailable
-
-### Supported Formats
-- M4A, MP3, WAV, OGG
-
-### Size Limit
-- Maximum 25MB per audio file
-
-## Configuration
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `OPENAI_API_KEY` | OpenAI API key for Whisper | Required |
-| `AWS_S3_BUCKET` | S3 bucket for audio files | Required |
+---
 
 ## Architecture
 
-1. Client sends `audio_url` (S3 presigned URL from P01-10)
-2. Service downloads audio from S3
-3. Validates format (extension check) and size (Content-Length header)
-4. Sends to OpenAI Whisper API via `asyncio.to_thread`
-5. Computes confidence from segment log probabilities
-6. Returns transcript, detected language, confidence, and duration
+### How It Works (Data Flow)
+
+1. The mobile client records audio and uploads it to S3 via `POST /api/v1/media/upload-url` (P01-10), receiving a permanent `file_url`.
+2. The client calls `POST /api/v1/stt` with `Authorization: Bearer <jwt>` and the S3 `file_url` as `audio_url` in the JSON body.
+3. The route handler resolves the authenticated user via the `get_current_user` dependency. The user identity is used only for authentication — no user-specific logic is applied to the transcription itself.
+4. The route instantiates `STTService` and calls `transcribe(audio_url=body.audio_url)`.
+5. `STTService._parse_s3_url()` parses the URL and extracts the S3 bucket name and object key. Both virtual-hosted style (`bucket.s3.region.amazonaws.com/key`) and path-style (`s3.region.amazonaws.com/bucket/key`) URLs are supported.
+6. `STTService._get_extension()` extracts the file extension from the S3 key (ignoring any query parameters). If the extension is not one of `.m4a`, `.mp3`, `.wav`, `.ogg`, a 400 error is raised.
+7. Note: unsupported formats are also caught earlier at the Pydantic schema layer (returning 422), so the service-level check is a defense-in-depth safeguard.
+8. `STTService._download_from_s3()` calls `boto3.client.get_object()` via `asyncio.to_thread()` to keep the async event loop unblocked. If the key does not exist (`NoSuchKey`), a 400 error is returned; other S3 errors return 503.
+9. The downloaded byte length is checked against the 25 MB limit (26,214,400 bytes). Files that exceed this raise 413.
+10. `STTService._call_whisper()` checks that `settings.openai_api_key` is non-empty (503 if missing), then calls `STTService._whisper_transcribe()` via `asyncio.to_thread()` because the OpenAI Python SDK is synchronous.
+11. `_whisper_transcribe()` creates an `OpenAI` client, wraps the audio bytes in a `BytesIO` object with the filename set (so Whisper infers MIME type from the name), and calls `client.audio.transcriptions.create()` with `response_format="verbose_json"`.
+12. `_compute_average_confidence()` derives a 0–1 confidence score by averaging `math.exp(segment.avg_logprob)` across all returned segments and clamping to `[0.0, 1.0]`. If no segment data is present, confidence is `0.0`.
+13. The route handler maps the result dict to an `STTResponse` Pydantic model and returns HTTP 200.
+
+### Confidence Score Derivation
+
+Whisper's `verbose_json` format does not include a single top-level confidence value. Each segment carries `avg_logprob`, the average log-probability over tokens in that segment. The service converts this to a linear scale with `exp(avg_logprob)` and averages across all segments. Because `avg_logprob` is typically a negative value close to zero for high-quality transcriptions (e.g., `-0.1` yields `~0.905`), the result is a natural 0–1 float. The value is clamped to `[0.0, 1.0]` and rounded to 4 decimal places. When Whisper returns no segment data, the confidence is reported as `0.0` rather than omitted.
+
+### S3 URL Parsing
+
+The service handles both S3 URL styles in production:
+
+| Style | Format | Example |
+|-------|--------|---------|
+| Virtual-hosted | `https://{bucket}.s3.{region}.amazonaws.com/{key}` | `https://ember-media.s3.us-east-1.amazonaws.com/audio/usr123/rec.m4a` |
+| Path-style | `https://s3.{region}.amazonaws.com/{bucket}/{key}` | `https://s3.us-east-1.amazonaws.com/ember-media/audio/usr123/rec.m4a` |
+
+The URL must be an `amazonaws.com` URL; any other domain returns 400. This prevents callers from directing the backend to download audio from arbitrary external URLs.
+
+### Threading Model
+
+Both external calls — S3 download and Whisper transcription — use `asyncio.to_thread()`. The boto3 S3 client and the OpenAI Python SDK are both synchronous. Running them directly in the async route handler would block the FastAPI event loop. `asyncio.to_thread()` moves each call to the default thread pool, keeping the server responsive during the download and transcription wait.
+
+The module-level `_s3_client` is created once at import time and reused across requests. boto3 clients manage their own connection pool and credential cache; per-request instantiation would be wasteful.
+
+### Database Tables Involved
+
+This feature does not read from or write to any database table. The `get_current_user` dependency validates the JWT and provides the `Profile` object, but no database query is issued by the STT endpoint itself.
+
+| Table | Operation | Notes |
+|-------|-----------|-------|
+| (none) | — | Stateless endpoint; all data comes from S3 and Whisper |
+
+### No Mem0 Operations
+
+This feature does not interact with Mem0. Memory storage is the responsibility of the chat endpoint (P01-06) when the client sends the transcript as a message.
+
+---
+
+## API Reference
+
+### `POST /api/v1/stt`
+
+Transcribes audio from an S3 URL to text using OpenAI Whisper.
+
+**Auth**: Bearer JWT required
+**Content-Type**: `application/json`
+
+**Request Body**:
+
+```json
+{
+  "audio_url": "https://ember-media.s3.us-east-1.amazonaws.com/audio/user_id/recording.m4a"
+}
+```
+
+**Request Fields**:
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `audio_url` | string | yes | 1–2048 chars; must end with `.m4a`, `.mp3`, `.wav`, or `.ogg` (case-insensitive, query params ignored); must be an `amazonaws.com` URL |
+
+**Response 200 OK**:
+
+```json
+{
+  "transcript": "I want to practice speaking today",
+  "language": "en",
+  "confidence": 0.9048,
+  "duration_seconds": 4.2
+}
+```
+
+**Response Fields**:
+
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| `transcript` | string | no | Full transcribed text from Whisper |
+| `language` | string | no | ISO 639-1 language code detected by Whisper (e.g., `"en"`, `"tr"`). Returns `"unknown"` when Whisper cannot detect. |
+| `confidence` | float | no | Average confidence derived from segment log-probabilities, clamped to `[0.0, 1.0]`. Returns `0.0` when Whisper provides no segment data. |
+| `duration_seconds` | float | yes | Audio duration in seconds as reported by Whisper. `null` when Whisper does not return duration. |
+
+**Error Responses**:
+
+| Status | When |
+|--------|------|
+| 400 | `audio_url` is not an `amazonaws.com` URL |
+| 400 | Unsupported audio format at the service layer (defense-in-depth, normally caught at 422) |
+| 400 | S3 object does not exist (`NoSuchKey`) |
+| 401 | Missing or invalid JWT |
+| 413 | Audio file exceeds 25 MB after download |
+| 422 | Missing `audio_url`, empty string, or extension not in `.m4a/.mp3/.wav/.ogg` (Pydantic validation) |
+| 429 | Rate limit exceeded (per-user rate limiting from P1.5-01) |
+| 503 | S3 is unreachable or returns an unexpected error |
+| 503 | `openai_api_key` is not configured |
+| 503 | OpenAI Whisper API call failed |
+
+---
+
+## Configuration
+
+No new configuration sections were introduced. The only new setting consumed is `openai_api_key`.
+
+| Setting | Source | Description |
+|---------|--------|-------------|
+| `openai_api_key` | `app/config.py` (`settings.openai_api_key`) | OpenAI API key. Required for Whisper. If empty, the endpoint returns 503 immediately without attempting S3 download. |
+| `aws_region` | `app/config.py` (`settings.aws_region`) | AWS region used when constructing the module-level boto3 S3 client. |
+
+The `openai` Python package must be present in `backend/requirements.txt`. No new infrastructure dependencies are required beyond the existing S3 permissions already granted by the ECS task role for the media upload feature (P01-10).
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `backend/app/routes/stt.py` | Route handler. Single async endpoint `POST /stt` registered under the `/api/v1` prefix. Delegates all logic to `STTService`. |
+| `backend/app/services/stt_service.py` | `STTService` class with `transcribe()`, `_parse_s3_url()`, `_get_extension()`, `_download_from_s3()`, `_call_whisper()`, and `_whisper_transcribe()` methods. Module-level `_s3_client` and `_compute_average_confidence()` helper function. |
+| `backend/app/schemas/stt.py` | `STTRequest` and `STTResponse` Pydantic models. `STTRequest.audio_url` has a `field_validator` that checks for the supported extensions before the service is reached. |
+| `backend/app/main.py` | Imports `stt` router and registers it at `prefix="/api/v1"`, `tags=["stt"]`. |
+| `shared/api-contracts/paths/stt.yaml` | OpenAPI path specification for `POST /api/v1/stt`. |
+| `shared/api-contracts/schemas/stt.yaml` | OpenAPI schema definitions for `STTRequest` and `STTResponse`. |
+| `shared/api-contracts/ember-api.yaml` | Top-level OpenAPI document; includes the STT path reference and `stt` tag. |
+
+### Router Registration
+
+```python
+# In main.py:
+from app.routes import ..., stt
+
+app.include_router(stt.router, prefix="/api/v1", tags=["stt"])
+```
+
+---
+
+## Testing
+
+### Coverage Summary
+
+| File | Tests | Notes |
+|------|-------|-------|
+| `backend/tests/schemas/test_stt.py` | 19 schema tests | Pydantic validation, field constraints, extension whitelist |
+| `backend/tests/services/test_stt.py` | 24 service tests | S3 URL parsing, extension extraction, confidence math, transcribe flow, all error paths |
+| `backend/tests/routes/test_stt.py` | 10 route tests | Full HTTP integration with mocked S3 and Whisper |
+| **Total** | **53 passed, 0 failed** | |
+
+Full backend suite at time of implementation: 2185 passed, 0 failed.
+
+### Key Test Scenarios
+
+**Schema tests** validate the `field_validator` on `audio_url`: whitespace trimming, case-insensitive extension matching (`.MP3` accepted), query-parameter stripping before extension check, all four accepted formats, rejection of unsupported extensions (`.txt`, `.flac`, `.mp4`), empty string rejection, max length (2048 chars), and response model serialization including nullable `duration_seconds`.
+
+**Service tests** cover `_parse_s3_url` for both virtual-hosted and path-style URLs, non-S3 URL rejection (400), path-style URL missing key (400), `_get_extension` for all four formats plus uppercase normalization and query-param stripping, `_compute_average_confidence` for no segments (0.0), empty segments (0.0), single segment, multi-segment averaging, and logprob clamping to 1.0. The `STTService.transcribe` tests cover: successful full flow, unsupported format at service layer (400), file exceeding 25 MB (413), S3 `NoSuchKey` (400), S3 internal error (503), Whisper API failure (503), missing OpenAI API key (503), and M4A format acceptance.
+
+**Route tests** cover: valid request returns 200 with all response fields, missing auth returns 401/403, missing `audio_url` returns 422, empty `audio_url` returns 422, unsupported format returns 422, file too large returns 413, S3 not found returns 400, Whisper failure returns 503, response shape validation, and M4A URL acceptance.
+
+### Running Tests
+
+STT tests only:
+
+```bash
+cd backend && python -m pytest tests/schemas/test_stt.py tests/services/test_stt.py tests/routes/test_stt.py -v
+```
+
+Full backend suite:
+
+```bash
+cd backend && python -m pytest tests/ -v
+```
+
+---
 
 ## Known Limitations
 
-- Batch transcription only (not real-time streaming)
-- Maximum 25MB file size (Whisper API limit)
-- Confidence score is derived from average segment logprobs
-- No caching of transcription results (each request re-transcribes)
+- **No real-time streaming**: Whisper transcription is batch-only. The entire audio file is downloaded before transcription begins. For short voice messages (under 30 seconds), this is acceptable latency. Long recordings will have proportionally longer wait times.
+- **Confidence is `0.0` for short utterances**: When Whisper returns no segment-level data (e.g., for very short or silent clips), the `confidence` field is `0.0`, which is indistinguishable from a low-confidence transcription. Callers should not treat a `0.0` confidence score as an error.
+- **No direct upload**: The endpoint only accepts S3 URLs. It does not accept direct audio byte uploads. Callers must use the media upload endpoint (P01-10) first.
+- **S3 URL must be `amazonaws.com`**: Presigned URLs with custom domains (e.g., CloudFront) are not accepted by the URL parser. If CloudFront is placed in front of S3 in future, the URL validation logic in `_parse_s3_url` will need to be updated.
+- **No language hint**: The Whisper call does not pass a `language` parameter; Whisper auto-detects. This is intentional for multilingual users but may reduce accuracy for short phrases in minority languages.
+- **Rate limiting applies**: The STT endpoint is subject to the standard write-group rate limit (P1.5-01). Rapid successive calls from the same user will be rejected with 429.
+
+---
+
+## Extending This Feature
+
+**Adding a new audio format**: Add the extension to the `_SUPPORTED_EXTENSIONS` set in `stt_service.py` and to the `_SUPPORTED_EXTENSIONS` tuple in `stt.py` (schemas). Also add an extension-to-MIME mapping entry to `_EXTENSION_MIME_MAP` in `stt_service.py`. Whisper supports a wider range of formats than the four currently allowed; check the Whisper API docs before adding new entries.
+
+**Passing a language hint**: If the mobile UI has a known locale (e.g., the user's `preferred_language` from their profile), it can be added to the request body as an optional `language` field. Pass it through to `client.audio.transcriptions.create(language=language)` in `_whisper_transcribe()`. This can improve accuracy for short phrases in specific languages.
+
+**Storing transcription results**: If you need audit logging or usage analytics, add an optional database write after a successful transcription. A lightweight `stt_logs` table with `user_id`, `duration_seconds`, `language`, and `created_at` would suffice. Insert it via a background task to avoid adding latency to the response.
+
+**Supporting direct byte upload**: To allow clients to POST audio bytes directly (avoiding the two-step upload-then-transcribe flow), add a new endpoint that accepts `multipart/form-data`. The service's `_call_whisper()` method already accepts raw bytes, so only the route handler and the S3 download step would differ.
+
+---
+
+## Related Documentation
+
+- [Voice and Audio Architecture](../12-ses-voice.md) — TTS/STT design decisions, ElevenLabs and Whisper overview
+- [Database Schema and API Endpoints](../04-veri-api.md) — full API contract reference
+- [Media Upload](./media-upload.md) — P01-10, the two-step upload flow that produces the S3 URL consumed by this endpoint
+- [Chat Streaming](./chat-streaming.md) — P01-06, where the client sends the transcript as a chat message after transcription
+- [Security and Performance](../08-guvenlik-performans.md) — S3 isolation, IAM permissions

--- a/docs/pipeline/ios-voice-recording-architect.handoff.md
+++ b/docs/pipeline/ios-voice-recording-architect.handoff.md
@@ -1,0 +1,30 @@
+# Architect Handoff: iOS Voice Recording (P05-03)
+
+**Date**: 2026-03-13
+**Agent**: architect
+**Status**: COMPLETE
+
+## Summary
+
+Designed the voice recording feature for the iOS ChatView. Users hold a mic button to record audio (M4A, 44100Hz, 2min max), upload to S3 via presigned URL, transcribe via POST /stt, and display the transcript in the message input field.
+
+## Spec Location
+
+- `shared/feature-specs/ios-voice-recording.md`
+
+## Key Decisions
+
+1. **Hold-to-record UX**: Long press (0.3s min) starts recording, release stops. More natural than tap-to-toggle.
+2. **M4A format**: AAC encoding in M4A container -- good quality/size ratio, native iOS support.
+3. **Waveform visualization**: 24 bars updated at ~15Hz from AVAudioRecorder metering data.
+4. **Swipe up to cancel**: Drag gesture with 60pt threshold, matches common messaging app patterns.
+5. **Transcript-to-input**: Transcript goes to the text input (not auto-sent), allowing user to review/edit.
+6. **2-minute limit**: Auto-stop timer prevents excessively large uploads.
+
+## Handoff to iOS Dev
+
+- Feature spec is complete at `shared/feature-specs/ios-voice-recording.md`
+- All API endpoints are already implemented on the backend
+- Existing `UploadURLRequest`/`UploadURLResponse` models in `ProfileModels.swift` can be reused
+- New `STTRequest`/`STTResponse` models needed in `Core/Models/STTModels.swift`
+- New `.transcribeAudio` case needed in `APIEndpoint.swift`

--- a/docs/pipeline/ios-voice-recording-doc.handoff.md
+++ b/docs/pipeline/ios-voice-recording-doc.handoff.md
@@ -1,0 +1,5 @@
+# Doc-Writer Handoff — ios-voice-recording
+
+- **status**: COMPLETE
+- **feature**: P05-03 — ios-voice-recording
+- **files_created**: docs/features/ios-voice-recording.md, CHANGELOG.md updated

--- a/docs/pipeline/ios-voice-recording-ios-dev.handoff.md
+++ b/docs/pipeline/ios-voice-recording-ios-dev.handoff.md
@@ -1,0 +1,40 @@
+# iOS Dev Handoff: iOS Voice Recording (P05-03)
+
+**Date**: 2026-03-13
+**Agent**: ios-dev
+**Status**: COMPLETE
+
+## Implemented Files
+
+### New Files
+- `ios/Ember/Features/Chat/VoiceRecorder.swift` -- @Observable class wrapping AVAudioRecorder with metering
+- `ios/Ember/Features/Chat/VoiceRecordingOverlay.swift` -- Recording overlay UI with waveform, timer, cancel gesture
+- `ios/Ember/Features/Chat/WaveformView.swift` -- Animated waveform bar visualization
+- `ios/Ember/Core/Models/STTModels.swift` -- STTRequest and STTResponse Codable models
+
+### Modified Files
+- `ios/Ember/Features/Chat/ChatInputBar.swift` -- Added mic button (shown when text field empty), long-press gesture to start/stop recording
+- `ios/Ember/Features/Chat/ChatViewModel.swift` -- Added VoiceRecorder instance, startRecording/stopRecording/cancelRecording methods, processVoiceRecording (upload + STT) flow
+- `ios/Ember/Features/Chat/ChatService.swift` -- Added getUploadURL, uploadFile, transcribeAudio methods to protocol and implementation
+- `ios/Ember/Features/Chat/ChatView.swift` -- Added VoiceRecordingOverlay, mic permission alert, background-cancel observer
+- `ios/Ember/Core/Network/APIEndpoint.swift` -- Added `.transcribeAudio` case for POST /api/v1/stt
+- `ios/Ember/Core/Extensions/EmberSymbol.swift` -- Added microphoneSlash, waveform, stopCircle symbols
+- `ios/Ember.xcodeproj/project.pbxproj` -- Added NSMicrophoneUsageDescription in both Debug and Release build configs
+
+## Screens Implemented
+- **ChatInputBar**: Mic button appears when text input is empty. Long press starts recording, release stops.
+- **VoiceRecordingOverlay**: Replaces input bar during recording. Shows pulsing red dot, waveform, timer, "Slide up to cancel" hint.
+- **Mic Permission Alert**: Shown when microphone access is denied, with "Open Settings" button.
+
+## Deviations from Spec
+- None
+
+## Notes for iOS Tester
+- `ChatServiceProtocol` now has three new methods: `getUploadURL`, `uploadFile`, `transcribeAudio` -- create mocks for all three
+- `VoiceRecorder` uses AVAudioRecorder which requires a real device -- mock the recorder for unit tests
+- Test the 2-minute auto-stop by setting `maxDuration` to a smaller value in tests
+- Test the cancel gesture by simulating a drag offset beyond 60pt
+- Test app backgrounding during recording -- should cancel and clean up
+- Test permission denied flow -- should show alert with Settings button
+- `VoiceRecordingError` has three cases: `invalidUploadURL`, `emptyTranscript`, `recordingFailed`
+- The processVoiceRecording flow has three network calls in sequence -- test each failure point

--- a/docs/pipeline/ios-voice-recording-review.handoff.md
+++ b/docs/pipeline/ios-voice-recording-review.handoff.md
@@ -1,0 +1,17 @@
+# Review Handoff — ios-voice-recording
+
+- **status**: APPROVED
+- **feature**: P05-03 — ios-voice-recording
+
+- ✅ @Observable for VoiceRecorder (no ObservableObject)
+- ✅ No force unwrap (!) in any new/modified files
+- ✅ accessibilityLabel on mic button
+- ✅ SF Symbols via EmberSymbol constants
+- ✅ Presigned URL for S3 upload (no client-side AWS credentials)
+- ✅ Audio file cleanup in defer blocks
+- ✅ 2-min max recording with auto-stop
+- ✅ Swipe-up cancel gesture (60pt threshold)
+- ✅ Microphone permission handling with settings redirect
+- ✅ MockChatService updated with voice method stubs
+- ✅ URLSession injected into ChatService for testability
+- ✅ No hardcoded secrets

--- a/docs/pipeline/voice-stt-backend-doc.handoff.md
+++ b/docs/pipeline/voice-stt-backend-doc.handoff.md
@@ -1,5 +1,17 @@
-# Doc-Writer Handoff — voice-stt-backend
+# Doc Writer Handoff: Voice STT Backend (P05-02)
 
-- **status**: COMPLETE
-- **feature**: P05-02 — voice-stt-backend
-- **files_created**: docs/features/voice-stt-backend.md, CHANGELOG.md updated
+**Date**: 2026-03-13
+**Agent**: doc-writer
+**Status**: COMPLETE
+
+## Documents Written
+- `docs/features/voice-stt-backend.md` — main feature documentation
+- `CHANGELOG.md` — added entry under [Unreleased]
+
+## Summary
+Documented the `POST /api/v1/stt` speech-to-text endpoint. The feature is a stateless backend service that accepts S3 audio URLs, downloads the audio via boto3, validates format (M4A/MP3/WAV/OGG) and size (25 MB max), and transcribes using OpenAI Whisper with `verbose_json` format. Confidence scoring is derived from per-segment `avg_logprob` values using `exp(logprob)` averaging. All external calls use `asyncio.to_thread` to keep the async event loop unblocked.
+
+## Notes
+- The CHANGELOG P05-02 entry was already present in the file when reviewed (written by a prior agent run); no duplicate was added.
+- The spec listed a `429` rate-limit error response, which was documented even though it is not explicitly handled in the STT route itself — it is enforced by the upstream `RateLimitMiddleware` registered in `main.py` (P1.5-01).
+- No deviations from spec were found in the implementation (confirmed by backend-dev handoff: "Known Issues / Deviations from Spec: None").

--- a/ios/Ember.xcodeproj/project.pbxproj
+++ b/ios/Ember.xcodeproj/project.pbxproj
@@ -888,6 +888,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_KEY_CFBundleDisplayName = Ember;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Ember needs access to your microphone to record voice messages for transcription.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -981,6 +982,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_KEY_CFBundleDisplayName = Ember;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Ember needs access to your microphone to record voice messages for transcription.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/Ember.xcodeproj/project.pbxproj
+++ b/ios/Ember.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		7816B27230E7871E8A688BF0 /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57E73744849DD063E8C2BE9 /* AppRouter.swift */; };
 		78D942D72364946849FD96FF /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625EFB811F6DFCFF2551B343 /* AppContainer.swift */; };
 		7CA9643B5AEBC5D280C26FEA /* MemoryModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5815E5BF025CF78A656C15E3 /* MemoryModels.swift */; };
+		82794CCE497BF52B9167A243 /* WaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D10A03DBB8206265A6742A /* WaveformView.swift */; };
 		885270C7195D746767F5B5C2 /* MockAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0E68DD7F905A848184196D /* MockAuthService.swift */; };
 		890FDD5E7608F21CF9D405C9 /* ShimmerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF01901F82F3FC3E20F1371 /* ShimmerViewTests.swift */; };
 		8912175DABE2E1DD942F4E1C /* CharacterModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738EFCA07CE8287CDB6E9F6E /* CharacterModels.swift */; };
@@ -79,6 +80,8 @@
 		9AAB3726C67409E8EA3BF342 /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB654AF5D4A257459F78DA04 /* ColorTests.swift */; };
 		A04BA81FBA32142ADAB62A8C /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB2A1DCD60BEE6ECDF317BE /* HapticManager.swift */; };
 		A1F454CD4D646D532FBAC11B /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE93367A9580AB1FA8922E47 /* NetworkMonitor.swift */; };
+		A366694EA1E70F9280CFE75D /* VoiceRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1F403A213BB05011C54A9C /* VoiceRecorder.swift */; };
+		A3A69F5A070EA4D714D35F3C /* VoiceRecordingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91EFEC94F532D83F6C5A03F /* VoiceRecordingOverlay.swift */; };
 		A968C087F957EB463C4312D2 /* AuthViewModelExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB219CD2A3724F6E6A6D1C84 /* AuthViewModelExtendedTests.swift */; };
 		ACC0A3867AE871060A59E1FB /* APIEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12E6C3943FFBAEA963EEED7 /* APIEndpointTests.swift */; };
 		AFF55A3A6DF9D10944C89226 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947D6EE45A9FE4DCBDA9C980 /* ChatViewModel.swift */; };
@@ -105,6 +108,7 @@
 		DF4003B964FE24596BE39B64 /* onboarding-welcome.json in Resources */ = {isa = PBXBuildFile; fileRef = 9055117FF4D41BBF78F80480 /* onboarding-welcome.json */; };
 		E159FB4FEB63ECA64B033DBA /* DailySummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FEFEF3CFE2336771E36F34 /* DailySummaryCard.swift */; };
 		E4AEA1452ED9285F8AC1CE33 /* EmberError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E26E2CAD05E8161BE99E8F5 /* EmberError.swift */; };
+		E7C07872E2CBB4B69B27D240 /* STTModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7E0D16F622C90B4D72359A /* STTModels.swift */; };
 		E7E038AE9A82DA7D8E2BB110 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9201A3D0D142F13E3A45D070 /* HomeViewModelTests.swift */; };
 		E953F35F57B30DF11BA6B43A /* QuestionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463113285D1665317349466D /* QuestionsView.swift */; };
 		EA50789D7ED226E7216F90A4 /* OnboardingModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB87C828A7AB86CE5AEF3A38 /* OnboardingModelsTests.swift */; };
@@ -130,14 +134,17 @@
 		042F9AE1FED0CE6055D1C6F9 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		043381FB0511D95E4E489A23 /* HomeViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelExtendedTests.swift; sourceTree = "<group>"; };
 		071D1111C3645B1A1ADCF2CE /* ProfileViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModelExtendedTests.swift; sourceTree = "<group>"; };
+		09D10A03DBB8206265A6742A /* WaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformView.swift; sourceTree = "<group>"; };
 		0A48F65DCAC32D101F0F3959 /* ErrorBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBannerView.swift; sourceTree = "<group>"; };
 		0AB2A1DCD60BEE6ECDF317BE /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		0C36E5D731703C92F96B5E5F /* EmberSymbolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmberSymbolTests.swift; sourceTree = "<group>"; };
 		0CBAD21BD849A88E704C9516 /* OnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowView.swift; sourceTree = "<group>"; };
+		0F7E0D16F622C90B4D72359A /* STTModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STTModels.swift; sourceTree = "<group>"; };
 		1136DA5D1E4E538F920EA57B /* ViewEmberShadowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewEmberShadowTests.swift; sourceTree = "<group>"; };
 		1340B9513AD310D371FB1AEF /* KeychainTokenStoreExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTokenStoreExtendedTests.swift; sourceTree = "<group>"; };
 		1476737E0C64957D45052CDF /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
 		1A051E0347F1CE7A611797DF /* TypingIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingIndicatorView.swift; sourceTree = "<group>"; };
+		1B1F403A213BB05011C54A9C /* VoiceRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecorder.swift; sourceTree = "<group>"; };
 		1E03B69C920D79E1C864A0FB /* OnboardingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModels.swift; sourceTree = "<group>"; };
 		1F7916B71ED00545E5F13F08 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		21070CEF6687451F4EBB49EF /* APIErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIErrorTests.swift; sourceTree = "<group>"; };
@@ -192,6 +199,7 @@
 		A459DCBA87D0471A3D56F25E /* CharacterCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterCardView.swift; sourceTree = "<group>"; };
 		A59B6BB004695246F1101A25 /* View+EmberShadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+EmberShadow.swift"; sourceTree = "<group>"; };
 		A75A86FD9A08EAB8C4E2356A /* MemoriesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoriesViewModel.swift; sourceTree = "<group>"; };
+		A91EFEC94F532D83F6C5A03F /* VoiceRecordingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingOverlay.swift; sourceTree = "<group>"; };
 		AC977483F47AFB311AE56138 /* onboarding-memory.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "onboarding-memory.json"; sourceTree = "<group>"; };
 		B650251BA97DB32026B0DE24 /* EmberErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmberErrorTests.swift; sourceTree = "<group>"; };
 		B6D2C2C6F32C3B249FF0B1BB /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
@@ -428,6 +436,7 @@
 				79A30B3D9C17325C7F85CD9E /* MessageModels.swift */,
 				1E03B69C920D79E1C864A0FB /* OnboardingModels.swift */,
 				97C5B52E1670BB8FF78F6F12 /* ProfileModels.swift */,
+				0F7E0D16F622C90B4D72359A /* STTModels.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -452,6 +461,9 @@
 				C1275A81A38F898BB37459D4 /* DateSeparatorView.swift */,
 				8A0500EE3E6A5A93F9FD82F8 /* MessageBubbleView.swift */,
 				1A051E0347F1CE7A611797DF /* TypingIndicatorView.swift */,
+				1B1F403A213BB05011C54A9C /* VoiceRecorder.swift */,
+				A91EFEC94F532D83F6C5A03F /* VoiceRecordingOverlay.swift */,
+				09D10A03DBB8206265A6742A /* WaveformView.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -797,11 +809,15 @@
 				E953F35F57B30DF11BA6B43A /* QuestionsView.swift in Sources */,
 				62B55FA4899F1F32B93020EF /* RetryHelper.swift in Sources */,
 				BFC056BCDD142A5B949CD2B4 /* SSEClient.swift in Sources */,
+				E7C07872E2CBB4B69B27D240 /* STTModels.swift in Sources */,
 				033BD497159381F22F0FD01E /* ShimmerView.swift in Sources */,
 				91D2191B9132F40BD0AFDDBC /* SignUpView.swift in Sources */,
 				ED746473BA8EECD780787216 /* TimezonePickerSheet.swift in Sources */,
 				EC2EBAB671B388F51AAC3981 /* TypingIndicatorView.swift in Sources */,
 				0B32B3917AE8142DB91D0DC9 /* View+EmberShadow.swift in Sources */,
+				A366694EA1E70F9280CFE75D /* VoiceRecorder.swift in Sources */,
+				A3A69F5A070EA4D714D35F3C /* VoiceRecordingOverlay.swift in Sources */,
+				82794CCE497BF52B9167A243 /* WaveformView.swift in Sources */,
 				8E86E697D023439B735E0F46 /* WelcomeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -888,7 +904,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_KEY_CFBundleDisplayName = Ember;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Ember needs access to your microphone to record voice messages for transcription.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -982,7 +997,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_KEY_CFBundleDisplayName = Ember;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Ember needs access to your microphone to record voice messages for transcription.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/Ember/Core/Extensions/EmberSymbol.swift
+++ b/ios/Ember/Core/Extensions/EmberSymbol.swift
@@ -26,4 +26,9 @@ enum EmberSymbol {
     // Chat-specific icons
     static let camera = "camera"
     static let copy = "doc.on.doc"
+
+    // Voice recording
+    static let microphoneSlash = "mic.slash.fill"
+    static let waveform = "waveform"
+    static let stopCircle = "stop.circle.fill"
 }

--- a/ios/Ember/Core/Models/STTModels.swift
+++ b/ios/Ember/Core/Models/STTModels.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Request body for `POST /api/v1/stt`.
+struct STTRequest: Encodable {
+    let audioUrl: String
+}
+
+/// Response from `POST /api/v1/stt`.
+struct STTResponse: Codable {
+    let transcript: String
+    let language: String
+    let confidence: Double
+}

--- a/ios/Ember/Core/Network/APIEndpoint.swift
+++ b/ios/Ember/Core/Network/APIEndpoint.swift
@@ -39,6 +39,9 @@ enum APIEndpoint {
     // Media
     case uploadURL
 
+    // Speech-to-Text
+    case transcribeAudio
+
     // Profile
     case getProfile
     case updateProfile
@@ -92,6 +95,10 @@ enum APIEndpoint {
         case .uploadURL:
             return "/api/v1/media/upload-url"
 
+        // Speech-to-Text
+        case .transcribeAudio:
+            return "/api/v1/stt"
+
         // Profile
         case .getProfile, .updateProfile:
             return "/api/v1/profile"
@@ -117,6 +124,7 @@ enum APIEndpoint {
              .createCharacter,
              .sendMessage, .streamMessage,
              .uploadURL,
+             .transcribeAudio,
              .completeOnboarding,
              .updateFCMToken:
             return .post

--- a/ios/Ember/Features/Chat/ChatInputBar.swift
+++ b/ios/Ember/Features/Chat/ChatInputBar.swift
@@ -1,11 +1,16 @@
 import SwiftUI
 
 /// Text input bar at the bottom of the chat screen.
-/// Contains a multiline text field and a send button.
+/// Contains a multiline text field, a send button, and a mic button for voice recording.
+/// The mic button appears when the text field is empty; the send button appears when text is present.
 struct ChatInputBar: View {
     @Binding var text: String
     let isSending: Bool
+    let isRecording: Bool
+    let isProcessingVoice: Bool
     let onSend: () -> Void
+    let onStartRecording: () -> Void
+    let onStopRecording: () -> Void
 
     @FocusState private var isFocused: Bool
 
@@ -28,21 +33,14 @@ struct ChatInputBar: View {
                             onSend()
                         }
                     }
+                    .disabled(isRecording || isProcessingVoice)
 
-                // Send button
-                Button(action: {
-                    guard canSend else { return }
-                    HapticManager.impact(.light)
-                    onSend()
-                }) {
-                    Image(systemName: EmberSymbol.send)
-                        .font(.system(size: 28))
-                        .foregroundStyle(canSend ? Color.emberPrimary : Color.emberTextDisabled)
-                        .frame(width: 36, height: 36)
+                // Send or Mic button
+                if showMicButton {
+                    micButton
+                } else {
+                    sendButton
                 }
-                .disabled(!canSend)
-                .buttonStyle(.ember)
-                .accessibilityLabel("Send message")
             }
             .padding(.horizontal, .emberSpacing12)
             .padding(.vertical, .emberSpacing8)
@@ -51,9 +49,71 @@ struct ChatInputBar: View {
         }
     }
 
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var sendButton: some View {
+        Button(action: {
+            guard canSend else { return }
+            HapticManager.impact(.light)
+            onSend()
+        }) {
+            Image(systemName: EmberSymbol.send)
+                .font(.system(size: 28))
+                .foregroundStyle(canSend ? Color.emberPrimary : Color.emberTextDisabled)
+                .frame(width: 36, height: 36)
+        }
+        .disabled(!canSend)
+        .buttonStyle(.ember)
+        .accessibilityLabel("Send message")
+    }
+
+    @ViewBuilder
+    private var micButton: some View {
+        Button(action: {}) {
+            Image(systemName: EmberSymbol.microphone)
+                .font(.system(size: 22))
+                .foregroundStyle(micButtonColor)
+                .frame(width: 36, height: 36)
+        }
+        .disabled(isSending || isProcessingVoice)
+        .buttonStyle(.ember)
+        .accessibilityLabel(isRecording ? "Stop recording" : "Record voice message")
+        .accessibilityHint(isRecording ? "Release to stop recording" : "Press and hold to record a voice message")
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.3)
+                .onEnded { _ in
+                    if !isRecording && !isSending && !isProcessingVoice {
+                        onStartRecording()
+                    }
+                }
+        )
+        .onLongPressGesture(minimumDuration: .infinity, pressing: { isPressing in
+            // When the user releases after a long press has started
+            if !isPressing && isRecording {
+                onStopRecording()
+            }
+        }, perform: {})
+    }
+
     // MARK: - Private
 
     private var canSend: Bool {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending
+    }
+
+    /// Show mic button when text is empty and not currently sending.
+    private var showMicButton: Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var micButtonColor: Color {
+        if isRecording {
+            return Color.emberError
+        } else if isSending || isProcessingVoice {
+            return Color.emberTextDisabled
+        } else {
+            return Color.emberPrimary
+        }
     }
 }

--- a/ios/Ember/Features/Chat/ChatService.swift
+++ b/ios/Ember/Features/Chat/ChatService.swift
@@ -34,9 +34,11 @@ protocol ChatServiceProtocol: Sendable {
 /// Production implementation backed by `APIClientProtocol`.
 final class ChatService: ChatServiceProtocol {
     private let apiClient: APIClientProtocol
+    private let urlSession: URLSession
 
-    init(apiClient: APIClientProtocol = APIClient.shared) {
+    init(apiClient: APIClientProtocol = APIClient.shared, urlSession: URLSession = .shared) {
         self.apiClient = apiClient
+        self.urlSession = urlSession
     }
 
     func loadMessages(
@@ -74,7 +76,7 @@ final class ChatService: ChatServiceProtocol {
         request.httpBody = data
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
 
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (_, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {

--- a/ios/Ember/Features/Chat/ChatService.swift
+++ b/ios/Ember/Features/Chat/ChatService.swift
@@ -18,6 +18,15 @@ protocol ChatServiceProtocol: Sendable {
         characterId: String,
         content: String
     ) -> AsyncThrowingStream<SSEEvent, Error>
+
+    /// Requests a presigned upload URL from the backend.
+    func getUploadURL(request: UploadURLRequest) async throws -> UploadURLResponse
+
+    /// Uploads raw file data to a presigned S3 URL.
+    func uploadFile(to url: URL, data: Data, contentType: String) async throws
+
+    /// Sends an audio URL to the STT endpoint for transcription.
+    func transcribeAudio(request: STTRequest) async throws -> STTResponse
 }
 
 // MARK: - Chat Service
@@ -48,6 +57,37 @@ final class ChatService: ChatServiceProtocol {
         apiClient.streamSSE(
             endpoint: .streamMessage(characterId: characterId),
             body: SendMessageBody(content: content)
+        )
+    }
+
+    func getUploadURL(request: UploadURLRequest) async throws -> UploadURLResponse {
+        try await apiClient.request(
+            endpoint: .uploadURL,
+            body: request,
+            responseType: UploadURLResponse.self
+        )
+    }
+
+    func uploadFile(to url: URL, data: Data, contentType: String) async throws {
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.httpBody = data
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw APIError.serverError(statusCode: statusCode, detail: "File upload failed")
+        }
+    }
+
+    func transcribeAudio(request: STTRequest) async throws -> STTResponse {
+        try await apiClient.request(
+            endpoint: .transcribeAudio,
+            body: request,
+            responseType: STTResponse.self
         )
     }
 }

--- a/ios/Ember/Features/Chat/ChatView.swift
+++ b/ios/Ember/Features/Chat/ChatView.swift
@@ -16,14 +16,37 @@ struct ChatView: View {
     var body: some View {
         VStack(spacing: 0) {
             messagesList
-            ChatInputBar(
-                text: $viewModel.inputText,
-                isSending: viewModel.isStreaming,
-                onSend: {
-                    Task { await viewModel.sendMessage() }
-                }
-            )
+
+            // Voice recording overlay replaces input bar when recording or processing
+            if viewModel.voiceRecorder.isRecording || viewModel.isProcessingVoice {
+                VoiceRecordingOverlay(
+                    audioLevels: viewModel.voiceRecorder.audioLevels,
+                    duration: viewModel.voiceRecorder.recordingDuration,
+                    isProcessing: viewModel.isProcessingVoice,
+                    onCancel: { viewModel.cancelRecording() }
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            } else {
+                ChatInputBar(
+                    text: $viewModel.inputText,
+                    isSending: viewModel.isStreaming,
+                    isRecording: viewModel.voiceRecorder.isRecording,
+                    isProcessingVoice: viewModel.isProcessingVoice,
+                    onSend: {
+                        Task { await viewModel.sendMessage() }
+                    },
+                    onStartRecording: {
+                        Task { await viewModel.startRecording() }
+                    },
+                    onStopRecording: {
+                        viewModel.stopRecording()
+                    }
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
+        .animation(.easeInOut(duration: 0.25), value: viewModel.voiceRecorder.isRecording)
+        .animation(.easeInOut(duration: 0.25), value: viewModel.isProcessingVoice)
         .background(Color.emberBackground.ignoresSafeArea())
         .navigationTitle(viewModel.characterName)
         .navigationBarTitleDisplayMode(.inline)
@@ -46,6 +69,23 @@ struct ChatView: View {
             }
             .animation(.easeInOut(duration: 0.3), value: viewModel.currentError)
             .animation(.easeInOut(duration: 0.3), value: networkMonitor.isConnected)
+        }
+        .alert(
+            "Microphone Access Required",
+            isPresented: $viewModel.showMicPermissionAlert
+        ) {
+            Button("Open Settings") {
+                viewModel.openSettings()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Ember needs microphone access to record voice messages. Please enable it in Settings.")
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
+            // Stop recording if user backgrounds the app
+            if viewModel.voiceRecorder.isRecording {
+                viewModel.cancelRecording()
+            }
         }
     }
 

--- a/ios/Ember/Features/Chat/ChatViewModel.swift
+++ b/ios/Ember/Features/Chat/ChatViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import UIKit
 
 /// Represents a single chat message displayed in the UI.
 /// Distinct from `MessagePreview` (which is for home screen previews).
@@ -71,6 +72,17 @@ final class ChatViewModel {
     var errorMessage: String? = nil
     var currentError: EmberError? = nil
     var characterName: String
+
+    // MARK: - Voice Recording State
+
+    /// The voice recorder instance managing AVAudioRecorder.
+    let voiceRecorder = VoiceRecorder()
+
+    /// Whether a voice recording is being uploaded and transcribed.
+    var isProcessingVoice: Bool = false
+
+    /// Whether to show the permission-denied alert directing the user to Settings.
+    var showMicPermissionAlert: Bool = false
 
     // MARK: - Pagination State
 
@@ -252,6 +264,109 @@ final class ChatViewModel {
         currentError = nil
     }
 
+    // MARK: - Voice Recording
+
+    /// Starts a voice recording session. Requests microphone permission on first use.
+    func startRecording() async {
+        // Check / request permission
+        voiceRecorder.checkPermissionStatus()
+
+        if voiceRecorder.permissionDenied {
+            showMicPermissionAlert = true
+            return
+        }
+
+        if !voiceRecorder.permissionGranted {
+            await voiceRecorder.requestPermission()
+
+            if voiceRecorder.permissionDenied {
+                showMicPermissionAlert = true
+                return
+            }
+
+            guard voiceRecorder.permissionGranted else { return }
+        }
+
+        // Start recording
+        let started = voiceRecorder.startRecording()
+        if started {
+            HapticManager.impact(.rigid)
+        }
+    }
+
+    /// Stops the current recording and processes it (upload + STT).
+    func stopRecording() {
+        guard let audioURL = voiceRecorder.stopRecording() else { return }
+
+        HapticManager.notification(.success)
+
+        Task {
+            await processVoiceRecording(audioURL: audioURL)
+        }
+    }
+
+    /// Cancels the current recording.
+    func cancelRecording() {
+        voiceRecorder.cancelRecording()
+        HapticManager.notification(.warning)
+    }
+
+    /// Opens the system Settings app so the user can grant microphone permission.
+    func openSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(settingsURL)
+    }
+
+    /// Processes a voice recording: uploads to S3 via presigned URL, then transcribes via STT.
+    func processVoiceRecording(audioURL: URL) async {
+        isProcessingVoice = true
+        errorMessage = nil
+
+        defer {
+            isProcessingVoice = false
+            voiceRecorder.cleanupRecordingFile(at: audioURL)
+        }
+
+        do {
+            // Step 1: Get presigned upload URL
+            let uploadRequest = UploadURLRequest(
+                filename: audioURL.lastPathComponent,
+                contentType: "audio/mp4",
+                type: "audio"
+            )
+            let uploadResponse = try await service.getUploadURL(request: uploadRequest)
+
+            // Step 2: Upload audio file to S3
+            guard let presignedURL = URL(string: uploadResponse.uploadUrl) else {
+                throw VoiceRecordingError.invalidUploadURL
+            }
+            let audioData = try Data(contentsOf: audioURL)
+            try await service.uploadFile(to: presignedURL, data: audioData, contentType: "audio/mp4")
+
+            // Step 3: Transcribe via STT
+            let sttRequest = STTRequest(audioUrl: uploadResponse.fileUrl)
+            let sttResponse = try await service.transcribeAudio(request: sttRequest)
+
+            let transcript = sttResponse.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !transcript.isEmpty else {
+                throw VoiceRecordingError.emptyTranscript
+            }
+
+            // Set transcript as input text
+            inputText = transcript
+        } catch let error as VoiceRecordingError {
+            let emberError = EmberError.unknown(error.errorDescription ?? "Voice recording failed")
+            currentError = emberError
+            errorMessage = emberError.errorDescription
+            HapticManager.notification(.error)
+        } catch {
+            let emberError = EmberError.from(error)
+            currentError = emberError
+            errorMessage = emberError.errorDescription
+            HapticManager.notification(.error)
+        }
+    }
+
     // MARK: - Private Helpers
 
     /// Maps an API response page into `ChatMessage` values.
@@ -282,5 +397,25 @@ final class ChatViewModel {
             return
         }
         messages.removeLast()
+    }
+}
+
+// MARK: - Voice Recording Errors
+
+/// Domain errors specific to the voice recording flow.
+enum VoiceRecordingError: LocalizedError {
+    case invalidUploadURL
+    case emptyTranscript
+    case recordingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidUploadURL:
+            return "Failed to upload voice recording. Please try again."
+        case .emptyTranscript:
+            return "Could not transcribe audio. Please try again."
+        case .recordingFailed:
+            return "Voice recording failed. Please try again."
+        }
     }
 }

--- a/ios/Ember/Features/Chat/VoiceRecorder.swift
+++ b/ios/Ember/Features/Chat/VoiceRecorder.swift
@@ -1,0 +1,252 @@
+import AVFoundation
+import Observation
+import UIKit
+
+/// Wraps AVAudioRecorder to provide voice recording with audio level metering.
+///
+/// Uses `@Observable` (iOS 17+) for state management.
+/// Records in M4A (AAC) format at 44100 Hz mono, with a 2-minute maximum duration.
+@Observable
+final class VoiceRecorder: NSObject {
+    // MARK: - Public State
+
+    /// Whether a recording is currently in progress.
+    private(set) var isRecording: Bool = false
+
+    /// Elapsed recording duration in seconds.
+    private(set) var recordingDuration: TimeInterval = 0
+
+    /// Normalized audio levels (0.0 to 1.0) for waveform visualization.
+    /// Updated at ~15 Hz while recording.
+    private(set) var audioLevels: [CGFloat] = Array(repeating: 0, count: 24)
+
+    /// Whether the user has granted microphone permission.
+    private(set) var permissionGranted: Bool = false
+
+    /// Whether the user has explicitly denied microphone permission.
+    private(set) var permissionDenied: Bool = false
+
+    /// Whether the recorder is currently processing (uploading + transcribing).
+    private(set) var isProcessing: Bool = false
+
+    // MARK: - Private
+
+    private var audioRecorder: AVAudioRecorder?
+    private var meteringTimer: Timer?
+    private var durationTimer: Timer?
+    private var recordingURL: URL?
+
+    /// Maximum recording duration in seconds.
+    private let maxDuration: TimeInterval = 120
+
+    /// Number of waveform bars to maintain.
+    private let levelCount: Int = 24
+
+    // MARK: - Permission
+
+    /// Requests microphone permission. Must be called before `startRecording()`.
+    /// Updates `permissionGranted` and `permissionDenied` state.
+    func requestPermission() async {
+        if #available(iOS 17, *) {
+            let granted = await AVAudioApplication.requestRecordPermission()
+            await MainActor.run {
+                self.permissionGranted = granted
+                self.permissionDenied = !granted
+            }
+        } else {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                    Task { @MainActor in
+                        self.permissionGranted = granted
+                        self.permissionDenied = !granted
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Checks the current microphone authorization status without prompting.
+    func checkPermissionStatus() {
+        let status = AVAudioSession.sharedInstance().recordPermission
+        switch status {
+        case .granted:
+            permissionGranted = true
+            permissionDenied = false
+        case .denied:
+            permissionGranted = false
+            permissionDenied = true
+        case .undetermined:
+            permissionGranted = false
+            permissionDenied = false
+        @unknown default:
+            permissionGranted = false
+            permissionDenied = false
+        }
+    }
+
+    // MARK: - Recording
+
+    /// Starts recording audio. Returns `false` if setup fails.
+    @discardableResult
+    func startRecording() -> Bool {
+        guard permissionGranted else { return false }
+        guard !isRecording else { return false }
+
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.record, mode: .default, options: [])
+            try session.setActive(true)
+        } catch {
+            return false
+        }
+
+        let url = makeRecordingURL()
+        recordingURL = url
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44100.0,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+
+        do {
+            let recorder = try AVAudioRecorder(url: url, settings: settings)
+            recorder.delegate = self
+            recorder.isMeteringEnabled = true
+
+            guard recorder.prepareToRecord(), recorder.record() else {
+                return false
+            }
+
+            audioRecorder = recorder
+            isRecording = true
+            recordingDuration = 0
+            audioLevels = Array(repeating: 0, count: levelCount)
+
+            startMeteringTimer()
+            startDurationTimer()
+
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Stops the current recording and returns the URL of the recorded file.
+    /// Returns `nil` if no recording was in progress.
+    func stopRecording() -> URL? {
+        guard isRecording, let recorder = audioRecorder else { return nil }
+
+        recorder.stop()
+        stopTimers()
+        isRecording = false
+
+        deactivateAudioSession()
+
+        return recordingURL
+    }
+
+    /// Cancels the current recording and deletes the file.
+    func cancelRecording() {
+        guard isRecording, let recorder = audioRecorder else { return }
+
+        recorder.stop()
+        recorder.deleteRecording()
+        stopTimers()
+        isRecording = false
+        recordingURL = nil
+        audioLevels = Array(repeating: 0, count: levelCount)
+
+        deactivateAudioSession()
+    }
+
+    /// Cleans up a temporary recording file after it has been processed.
+    func cleanupRecordingFile(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - Private Helpers
+
+    private func makeRecordingURL() -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+        let filename = "voice_\(UUID().uuidString).m4a"
+        return tempDir.appendingPathComponent(filename)
+    }
+
+    private func startMeteringTimer() {
+        meteringTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 15.0, repeats: true) { [weak self] _ in
+            self?.updateMetering()
+        }
+    }
+
+    private func startDurationTimer() {
+        durationTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            self.recordingDuration += 0.1
+
+            // Auto-stop at max duration
+            if self.recordingDuration >= self.maxDuration {
+                _ = self.stopRecording()
+            }
+        }
+    }
+
+    private func stopTimers() {
+        meteringTimer?.invalidate()
+        meteringTimer = nil
+        durationTimer?.invalidate()
+        durationTimer = nil
+    }
+
+    private func updateMetering() {
+        guard let recorder = audioRecorder, recorder.isRecording else { return }
+
+        recorder.updateMeters()
+
+        // AVAudioRecorder returns dB values: -160 (silence) to 0 (max).
+        // Normalize to 0.0 - 1.0 range.
+        let dB = recorder.averagePower(forChannel: 0)
+        let normalizedLevel = normalizeDecibels(dB)
+
+        // Shift levels left, append new level
+        var newLevels = audioLevels
+        newLevels.removeFirst()
+        newLevels.append(normalizedLevel)
+        audioLevels = newLevels
+    }
+
+    /// Converts a decibel value (-160 to 0) to a normalized level (0.0 to 1.0).
+    private func normalizeDecibels(_ dB: Float) -> CGFloat {
+        let minDB: Float = -60
+        let maxDB: Float = 0
+
+        let clamped = max(minDB, min(maxDB, dB))
+        let normalized = (clamped - minDB) / (maxDB - minDB)
+        return CGFloat(normalized)
+    }
+
+    private func deactivateAudioSession() {
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}
+
+// MARK: - AVAudioRecorderDelegate
+
+extension VoiceRecorder: AVAudioRecorderDelegate {
+    func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        if !flag {
+            // Recording failed (e.g., disk full, interrupted)
+            isRecording = false
+            stopTimers()
+            recordingURL = nil
+        }
+    }
+
+    func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        isRecording = false
+        stopTimers()
+        recordingURL = nil
+    }
+}

--- a/ios/Ember/Features/Chat/VoiceRecordingOverlay.swift
+++ b/ios/Ember/Features/Chat/VoiceRecordingOverlay.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// Recording state overlay displayed over the ChatInputBar when voice recording is active.
+/// Shows a pulsing record indicator, waveform visualization, duration timer,
+/// and a "Slide up to cancel" hint.
+struct VoiceRecordingOverlay: View {
+    let audioLevels: [CGFloat]
+    let duration: TimeInterval
+    let isProcessing: Bool
+    let onCancel: () -> Void
+
+    /// Tracks the vertical drag offset for the cancel gesture.
+    @State private var dragOffset: CGFloat = 0
+
+    /// Pulsing animation state for the record dot.
+    @State private var isPulsing: Bool = false
+
+    /// Threshold (in points) for the upward swipe to cancel.
+    private let cancelThreshold: CGFloat = 60
+
+    var body: some View {
+        VStack(spacing: .emberSpacing8) {
+            // Cancel hint at the top
+            if !isProcessing {
+                cancelHint
+                    .opacity(cancelProgress)
+            }
+
+            // Main recording bar
+            HStack(spacing: .emberSpacing12) {
+                // Recording dot
+                recordingDot
+
+                if isProcessing {
+                    processingView
+                } else {
+                    // Waveform
+                    WaveformView(levels: audioLevels)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 28)
+
+                    // Duration timer
+                    Text(formattedDuration)
+                        .font(.emberCaption)
+                        .foregroundStyle(Color.emberTextPrimary)
+                        .monospacedDigit()
+                }
+            }
+            .padding(.horizontal, .emberSpacing16)
+            .padding(.vertical, .emberSpacing12)
+            .background(Color.emberSurface)
+            .shadow(color: Color.black.opacity(0.3), radius: 4, y: -2)
+        }
+        .offset(y: min(0, dragOffset))
+        .opacity(isCancelling ? 0.5 : 1.0)
+        .gesture(
+            DragGesture(minimumDistance: 10)
+                .onChanged { value in
+                    // Only track upward drags (negative y translation)
+                    dragOffset = min(0, value.translation.height)
+                }
+                .onEnded { value in
+                    if value.translation.height < -cancelThreshold {
+                        HapticManager.notification(.warning)
+                        onCancel()
+                    }
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                        dragOffset = 0
+                    }
+                }
+        )
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var recordingDot: some View {
+        Circle()
+            .fill(Color.emberError)
+            .frame(width: 10, height: 10)
+            .scaleEffect(isPulsing ? 1.2 : 0.8)
+            .opacity(isPulsing ? 1.0 : 0.6)
+            .animation(
+                .easeInOut(duration: 0.6)
+                .repeatForever(autoreverses: true),
+                value: isPulsing
+            )
+            .onAppear { isPulsing = true }
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var cancelHint: some View {
+        VStack(spacing: .emberSpacing4) {
+            Image(systemName: "chevron.up")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(Color.emberTextSecondary)
+
+            Text("Slide up to cancel")
+                .font(.emberMicro)
+                .foregroundStyle(Color.emberTextSecondary)
+        }
+        .padding(.top, .emberSpacing4)
+    }
+
+    @ViewBuilder
+    private var processingView: some View {
+        HStack(spacing: .emberSpacing8) {
+            ProgressView()
+                .tint(Color.emberPrimary)
+                .scaleEffect(0.8)
+
+            Text("Transcribing...")
+                .font(.emberSecondary)
+                .foregroundStyle(Color.emberTextSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Computed Properties
+
+    private var formattedDuration: String {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    private var isCancelling: Bool {
+        dragOffset < -cancelThreshold
+    }
+
+    /// Progress value (0.0 to 1.0) for how close the drag is to triggering cancel.
+    private var cancelProgress: Double {
+        guard dragOffset < 0 else { return 0 }
+        return min(1.0, Double(abs(dragOffset)) / Double(cancelThreshold))
+    }
+}

--- a/ios/Ember/Features/Chat/WaveformView.swift
+++ b/ios/Ember/Features/Chat/WaveformView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Animated waveform visualization driven by audio power levels.
+/// Displays a row of vertical bars whose heights reflect the current audio input.
+struct WaveformView: View {
+    /// Normalized audio levels (0.0 to 1.0). The view displays one bar per element.
+    let levels: [CGFloat]
+
+    /// Total height available for the tallest bar.
+    var maxBarHeight: CGFloat = 28
+
+    /// Width of each individual bar.
+    var barWidth: CGFloat = 3
+
+    /// Spacing between bars.
+    var barSpacing: CGFloat = 2
+
+    var body: some View {
+        HStack(alignment: .center, spacing: barSpacing) {
+            ForEach(Array(levels.enumerated()), id: \.offset) { _, level in
+                RoundedRectangle(cornerRadius: barWidth / 2)
+                    .fill(Color.emberPrimary)
+                    .frame(width: barWidth, height: barHeight(for: level))
+                    .animation(
+                        .spring(response: 0.15, dampingFraction: 0.6),
+                        value: level
+                    )
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    /// Maps a normalized level (0.0-1.0) to a bar height with a minimum floor.
+    private func barHeight(for level: CGFloat) -> CGFloat {
+        let minHeight: CGFloat = 4
+        return minHeight + (maxBarHeight - minHeight) * level
+    }
+}

--- a/ios/EmberTests/Mocks/MockChatService.swift
+++ b/ios/EmberTests/Mocks/MockChatService.swift
@@ -68,4 +68,34 @@ final class MockChatService: ChatServiceProtocol, @unchecked Sendable {
             }
         }
     }
+
+    // MARK: - Voice Recording Stubs
+
+    var stubbedUploadURLResponse: UploadURLResponse = UploadURLResponse(uploadUrl: "https://s3.example.com/upload", fileUrl: "https://s3.example.com/file.m4a")
+    var stubbedSTTResponse: STTResponse = STTResponse(transcript: "Hello world", language: "en", confidence: 0.95, durationSeconds: 2.5)
+
+    var getUploadURLCallCount: Int = 0
+    var uploadFileCallCount: Int = 0
+    var transcribeAudioCallCount: Int = 0
+    var lastUploadURL: URL? = nil
+    var lastTranscribeRequest: STTRequest? = nil
+
+    func getUploadURL(request: UploadURLRequest) async throws -> UploadURLResponse {
+        getUploadURLCallCount += 1
+        if let error = shouldThrow { throw error }
+        return stubbedUploadURLResponse
+    }
+
+    func uploadFile(to url: URL, data: Data, contentType: String) async throws {
+        uploadFileCallCount += 1
+        lastUploadURL = url
+        if let error = shouldThrow { throw error }
+    }
+
+    func transcribeAudio(request: STTRequest) async throws -> STTResponse {
+        transcribeAudioCallCount += 1
+        lastTranscribeRequest = request
+        if let error = shouldThrow { throw error }
+        return stubbedSTTResponse
+    }
 }

--- a/shared/feature-specs/ios-voice-recording.md
+++ b/shared/feature-specs/ios-voice-recording.md
@@ -1,0 +1,137 @@
+# Feature Spec: iOS Voice Recording (P05-03)
+
+## Overview
+
+Add voice recording capability to the iOS ChatView. Users hold a mic button to record audio, which is uploaded to S3 and transcribed via STT, with the transcript inserted into the message input field.
+
+## Layer
+
+`ios`
+
+## Dependencies
+
+- P03-07 (ios-chat-view) -- already implemented
+- P01-10 (media-upload backend) -- already implemented
+- Voice STT backend endpoint (`POST /api/v1/stt`) -- already implemented
+
+## User Stories
+
+1. **As a user**, I want to hold a mic button to record a voice message so I can compose messages hands-free.
+2. **As a user**, I want to see a visual recording indicator (waveform + timer) so I know recording is active.
+3. **As a user**, I want to swipe up to cancel a recording so I can abort without sending.
+4. **As a user**, I want my voice to be transcribed and placed in the text input so I can review/edit before sending.
+
+## Technical Design
+
+### Architecture
+
+```
+ChatInputBar (modified)
+  └── mic button (long press gesture)
+        ├── VoiceRecorder (@Observable, AVAudioRecorder wrapper)
+        │     ├── startRecording() -> requests mic permission if needed
+        │     ├── stopRecording() -> URL?
+        │     └── cancelRecording()
+        └── VoiceRecordingOverlay (SwiftUI view)
+              ├── WaveformView (animated bars from audio levels)
+              ├── Duration timer
+              └── "Slide up to cancel" hint
+
+ChatViewModel (modified)
+  └── processVoiceRecording(audioURL: URL) async
+        ├── Step 1: POST /api/v1/media/upload-url (get presigned URL)
+        ├── Step 2: PUT to presigned URL (upload M4A file)
+        └── Step 3: POST /api/v1/stt (get transcript)
+              └── Sets inputText = transcript
+```
+
+### Audio Recording Configuration
+
+- **Format**: M4A (AAC)
+- **Sample rate**: 44100 Hz
+- **Channels**: 1 (mono)
+- **Max duration**: 2 minutes (auto-stop with timer)
+- **Audio session category**: `.record`
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `ios/Ember/Features/Chat/VoiceRecorder.swift` | @Observable class wrapping AVAudioRecorder |
+| `ios/Ember/Features/Chat/VoiceRecordingOverlay.swift` | Recording overlay UI with waveform + timer |
+| `ios/Ember/Features/Chat/WaveformView.swift` | Animated waveform bars |
+| `ios/Ember/Core/Models/STTModels.swift` | STT request/response Codable models |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `ios/Ember/Features/Chat/ChatInputBar.swift` | Add mic button (shown when text is empty), long-press gesture |
+| `ios/Ember/Features/Chat/ChatViewModel.swift` | Add VoiceRecorder, processVoiceRecording() method |
+| `ios/Ember/Core/Network/APIEndpoint.swift` | Add `.transcribeAudio` case |
+| `ios/Ember/Core/Extensions/EmberSymbol.swift` | Add voice recording symbols |
+
+### API Endpoints Used
+
+1. `POST /api/v1/media/upload-url` (existing `.uploadURL` endpoint)
+   - Request: `{ "filename": "voice_xxx.m4a", "content_type": "audio/mp4", "type": "audio" }`
+   - Response: `{ "upload_url": "...", "file_url": "..." }`
+
+2. `PUT {presigned_url}` (direct S3 upload, no auth header)
+   - Body: raw audio data
+   - Content-Type: `audio/mp4`
+
+3. `POST /api/v1/stt` (new endpoint case)
+   - Request: `{ "audio_url": "..." }`
+   - Response: `{ "transcript": "...", "language": "en", "confidence": 0.97 }`
+
+### Microphone Permission
+
+- `NSMicrophoneUsageDescription` must be added to Xcode project Info settings
+- Permission requested on first recording attempt via `AVAudioSession.requestRecordPermission`
+- Denied state: show alert directing user to Settings
+
+### Gesture Design
+
+- **Start recording**: Long press on mic button (min 0.3s)
+- **Stop recording**: Release finger
+- **Cancel recording**: Drag up > 60pt while holding
+- Haptic feedback: `.rigid` on start, `.notification(.success)` on stop, `.notification(.warning)` on cancel
+
+### Recording Overlay UI
+
+- Full-width bar replacing the input bar during recording
+- Left: red recording dot (pulsing animation)
+- Center: WaveformView (animated bars) + duration timer (MM:SS)
+- Bottom hint: "Slide up to cancel" with upward chevron
+- Background: `Color.emberSurface` with slight opacity
+
+### WaveformView
+
+- 20-30 vertical bars
+- Height driven by normalized audio power levels (0.0-1.0)
+- Bars animate with spring physics
+- Color: `Color.emberPrimary`
+
+## Edge Cases
+
+- Microphone permission denied: show alert with "Open Settings" button
+- Recording exceeds 2 min: auto-stop and process
+- Network failure during upload: show error via existing error banner
+- STT returns empty transcript: show "Could not transcribe audio" error
+- App backgrounded during recording: stop and discard recording
+- Simultaneous streaming: disable mic button while AI is streaming
+
+## Acceptance Criteria
+
+1. Mic button appears when text input is empty
+2. Long press starts recording with haptic feedback and visual overlay
+3. Waveform animates based on audio levels
+4. Duration timer counts up in MM:SS format
+5. Releasing finger stops recording and initiates upload + STT flow
+6. Swiping up > 60pt cancels recording with haptic feedback
+7. Transcript appears in text input field after STT completes
+8. 2-minute max recording enforced with auto-stop
+9. Microphone permission requested on first use
+10. All icon buttons have accessibilityLabel
+11. Recording state properly cleaned up on cancel/error/background


### PR DESCRIPTION
## ios-voice-recording

iOS voice recording with hold-to-record mic button, waveform animation, S3 upload, and Whisper STT transcription in ChatView.

Closes #39

---

## Pipeline Summary

| Stage | Agent | Status |
|-------|-------|--------|
| Architecture | architect | ✅ |
| iOS | ios-dev | ✅ |
| Documentation | doc-writer | ✅ |
| Code Review | reviewer | ✅ Approved |

## Spec
`shared/feature-specs/ios-voice-recording.md`

## Key Changes
- VoiceRecorder (@Observable) with AVAudioRecorder, M4A, 44100Hz, 2min max
- VoiceRecordingOverlay with waveform animation and swipe-to-cancel
- ChatInputBar mic button with long press gesture
- 3-step flow: presigned URL → S3 upload → STT transcription
- MockChatService updated for testability

🤖 Generated via `/pipeline-run P05-03`